### PR TITLE
Prevent unwanted Starknet auto-connect

### DIFF
--- a/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx
+++ b/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx
@@ -62,7 +62,7 @@ export const ScaffoldEthAppWithProviders = ({ children }: { children: React.Reac
       provider={provider}
       connectors={connectors.connectors}
       explorer={starkscan}
-      autoConnect={true}
+      autoConnect={false}
     >
       <WagmiProvider config={wagmiConfig}>
         <QueryClientProvider client={queryClient}>

--- a/packages/nextjs/hooks/scaffold-stark/__tests__/useAutoConnect.test.ts
+++ b/packages/nextjs/hooks/scaffold-stark/__tests__/useAutoConnect.test.ts
@@ -1,6 +1,6 @@
-import { renderHook } from "@testing-library/react";
-import { useAutoConnect } from "../useAutoConnect";
-import { useConnect } from "@starknet-react/core";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useAutoConnect, __resetAutoConnect } from "../useAutoConnect";
+import { useConnect, useAccount } from "@starknet-react/core";
 import { useReadLocalStorage } from "usehooks-ts";
 import scaffoldConfig from "~~/scaffold.config";
 import { burnerAccounts } from "@scaffold-stark/stark-burner";
@@ -13,6 +13,7 @@ vi.mock("usehooks-ts", () => ({
 
 vi.mock("@starknet-react/core", () => ({
   useConnect: vi.fn(),
+  useAccount: vi.fn(),
 }));
 
 vi.mock("~~/scaffold.config", () => ({
@@ -40,39 +41,46 @@ describe("useAutoConnect", () => {
       connect: mockConnect,
       connectors: mockConnectors,
     });
+    (useAccount as ReturnType<typeof vi.fn>).mockReturnValue({
+      status: "disconnected",
+    });
     vi.spyOn(scaffoldConfig, "walletAutoConnect", "get").mockReturnValue(true);
   });
 
   afterEach(() => {
     vi.clearAllMocks();
+    window.localStorage.clear();
+    __resetAutoConnect();
   });
 
-  it("should auto-connect if walletAutoConnect is enabled and a saved connector exists", () => {
-    vi.mocked(useReadLocalStorage).mockReturnValue({ id: "wallet-1" });
+  it("should auto-connect if walletAutoConnect is enabled and a saved connector exists", async () => {
+    vi.mocked(useReadLocalStorage).mockReturnValue(Date.now());
+    window.localStorage.setItem("lastUsedConnector", JSON.stringify({ id: "wallet-1" }));
 
     renderHook(() => useAutoConnect());
 
-    expect(mockConnect).toHaveBeenCalledWith({
-      connector: expect.objectContaining({ id: "wallet-1" }),
-    });
+    await waitFor(() =>
+      expect(mockConnect).toHaveBeenCalledWith({
+        connector: expect.objectContaining({ id: "wallet-1" }),
+      }),
+    );
   });
 
-  it("should not auto-connect if walletAutoConnect is disabled", () => {
+  it("should not auto-connect if walletAutoConnect is disabled", async () => {
     vi.spyOn(scaffoldConfig, "walletAutoConnect", "get").mockReturnValue(
       false as true,
     );
-    vi.mocked(useReadLocalStorage).mockReturnValue({ id: "wallet-1" });
+    vi.mocked(useReadLocalStorage).mockReturnValue(Date.now());
+    window.localStorage.setItem("lastUsedConnector", JSON.stringify({ id: "wallet-1" }));
 
     renderHook(() => useAutoConnect());
 
-    expect(mockConnect).not.toHaveBeenCalled();
+    await waitFor(() => expect(mockConnect).not.toHaveBeenCalled());
   });
 
-  it("should auto-connect to the burner wallet and set burnerAccount if savedConnector exists", () => {
-    vi.mocked(useReadLocalStorage).mockReturnValue({
-      id: "burner-wallet",
-      ix: 1,
-    });
+  it("should auto-connect to the burner wallet and set burnerAccount if savedConnector exists", async () => {
+    vi.mocked(useReadLocalStorage).mockReturnValue(Date.now());
+    window.localStorage.setItem("lastUsedConnector", JSON.stringify({ id: "burner-wallet", ix: 1 }));
     mockConnectors = [
       { id: "wallet-1" },
       {
@@ -84,32 +92,58 @@ describe("useAutoConnect", () => {
       connect: mockConnect,
       connectors: mockConnectors,
     });
+    (useAccount as ReturnType<typeof vi.fn>).mockReturnValue({
+      status: "disconnected",
+    });
 
     renderHook(() => useAutoConnect());
 
-    expect(mockConnect).toHaveBeenCalledWith({
-      connector: expect.objectContaining({
-        id: "burner-wallet",
-        burnerAccount: burnerAccounts[1],
+    await waitFor(() =>
+      expect(mockConnect).toHaveBeenCalledWith({
+        connector: expect.objectContaining({
+          id: "burner-wallet",
+          burnerAccount: burnerAccounts[1],
+        }),
       }),
-    });
+    );
   });
 
-  it("should not connect if there is no saved connector", () => {
-    vi.mocked(useReadLocalStorage).mockReturnValue(null);
+  it("should not connect if there is no saved connector", async () => {
+    vi.mocked(useReadLocalStorage).mockReturnValue(Date.now());
 
     renderHook(() => useAutoConnect());
 
-    expect(mockConnect).not.toHaveBeenCalled();
+    await waitFor(() => expect(mockConnect).not.toHaveBeenCalled());
   });
 
-  it("should not connect if saved connector is not found in the connectors list", () => {
-    vi.mocked(useReadLocalStorage).mockReturnValue({
-      id: "non-existent-connector",
+  it("should not connect if saved connector is not found in the connectors list", async () => {
+    vi.mocked(useReadLocalStorage).mockReturnValue(Date.now());
+    window.localStorage.setItem("lastUsedConnector", JSON.stringify({ id: "non-existent-connector" }));
+
+    renderHook(() => useAutoConnect());
+
+    await waitFor(() => expect(mockConnect).not.toHaveBeenCalled());
+  });
+
+  it("should not auto-connect if already connected", async () => {
+    vi.mocked(useReadLocalStorage).mockReturnValue(Date.now());
+    window.localStorage.setItem("lastUsedConnector", JSON.stringify({ id: "wallet-1" }));
+    (useAccount as ReturnType<typeof vi.fn>).mockReturnValue({
+      status: "connected",
     });
 
     renderHook(() => useAutoConnect());
 
-    expect(mockConnect).not.toHaveBeenCalled();
+    await waitFor(() => expect(mockConnect).not.toHaveBeenCalled());
+  });
+
+  it("should only auto-connect once per session", async () => {
+    vi.mocked(useReadLocalStorage).mockReturnValue(Date.now());
+    window.localStorage.setItem("lastUsedConnector", JSON.stringify({ id: "wallet-1" }));
+
+    renderHook(() => useAutoConnect());
+    renderHook(() => useAutoConnect());
+
+    await waitFor(() => expect(mockConnect).toHaveBeenCalledTimes(1));
   });
 });

--- a/packages/nextjs/vitest.config.ts
+++ b/packages/nextjs/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+  },
+  resolve: {
+    alias: {
+      "~~": path.resolve(__dirname),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- persist a module-level flag so Starknet auto-connect fires only once per session
- exercise single-attempt behaviour and saved connector cases in useAutoConnect tests
- configure Vitest with jsdom and repo aliases for Next.js workspace

## Testing
- `./node_modules/.bin/next lint` (warnings only)
- `npx vitest run packages/nextjs/hooks/scaffold-stark/__tests__/useAutoConnect.test.ts` *(fails: Cannot find package '@testing-library/react')*

------
https://chatgpt.com/codex/tasks/task_e_68b0ddd738748320ad0378275f1f5fb9