### PR TITLE
fix: include paymaster RPC URLs

### DIFF
--- a/packages/nextjs/supportedChains.ts
+++ b/packages/nextjs/supportedChains.ts
@@ -23,6 +23,11 @@ const mainnetFork = {
       http: [`${rpcUrlDevnet}/rpc`],
     },
   },
+  paymasterRpcUrls: {
+    avnu: {
+      http: [rpcUrlDevnet],
+    },
+  },
 } as snchains.Chain;
 
 const devnet = {


### PR DESCRIPTION
## Summary
- add `paymasterRpcUrls` to the `mainnetFork` chain definition so it conforms to the `Chain` interface

## Testing
- `node_modules/.bin/next build` *(fails: Module not found: Can't resolve '@starknet-react/core')*

------
https://chatgpt.com/codex/tasks/task_e_68b0e70542788320bb8b034446bd4b81