### PR TITLE
docs: outline frontend refactor and share network color

### DIFF
--- a/docs/frontend-refactor-plan.md
+++ b/docs/frontend-refactor-plan.md
@@ -1,0 +1,35 @@
+# Frontend Refactoring Plan
+
+This document outlines a staged approach for refactoring the Next.js front end to reduce duplication, simplify component structure and centralize shared logic.
+
+## 1. Decompose Position Components
+- Extract common presentation pieces (header, stats, action row) from `BorrowPosition` and `SupplyPosition`.
+- Introduce a generic `PositionCard` that accepts a type (`"borrow" | "supply"`) and renders network‑specific behaviours via props.
+- Keep protocol‑specific or network‑specific UI in small subcomponents placed under `components/specific/*`.
+
+## 2. Unify Modals
+- Replace duplicate EVM/Starknet modal implementations with a single modal layer.
+- Network differences handled via props or small wrappers inside `components/modals/network/*`.
+- Ensure shared modal state management through `useModal`.
+
+## 3. Consolidate Network Hooks
+- Move duplicated hooks to `hooks/common` and have network packages provide wrappers.
+- Start with `useNetworkColor` and gradually merge others (`useNetwork`, `useDeployedContractInfo`, etc.).
+- Network specific configuration remains inside `hooks/scaffold-eth` and `hooks/scaffold-stark`.
+
+## 4. Centralise Utilities and Formatting
+- Create `utils/format` for currency and percentage helpers.
+- Store protocol logos and token metadata under `data/` and expose retrieval helpers.
+- Remove inline helpers from components in favour of shared utilities.
+
+## 5. Standardise Data Fetching
+- Wrap contract reads and API calls with React Query for caching and error handling.
+- Replace `mockData` with real endpoints; keep a dev‑only mock service when needed.
+
+## 6. Iterative Execution
+1. **Foundational hooks** – move shared hooks to `hooks/common` (done for `useNetworkColor`).
+2. **Refactor BorrowPosition/SupplyPosition** to use shared card and utilities.
+3. **Unify modals** once card structure is stable.
+4. **Clean remaining duplicate hooks/utilities** and add tests.
+
+Each step should be accompanied by linting and incremental tests to maintain stability.

--- a/packages/nextjs/hooks/common/index.ts
+++ b/packages/nextjs/hooks/common/index.ts
@@ -1,0 +1,1 @@
+export * from "./useNetworkColor";

--- a/packages/nextjs/hooks/common/useNetworkColor.ts
+++ b/packages/nextjs/hooks/common/useNetworkColor.ts
@@ -1,0 +1,22 @@
+import { useTheme } from "next-themes";
+
+export type NetworkWithColor = {
+  color?: string | [string, string];
+};
+
+export const DEFAULT_NETWORK_COLOR: [string, string] = ["#666666", "#bbbbbb"];
+
+export const getNetworkColor = (network: NetworkWithColor, isDarkMode: boolean) => {
+  const colorConfig = network.color ?? DEFAULT_NETWORK_COLOR;
+  return Array.isArray(colorConfig)
+    ? isDarkMode
+      ? colorConfig[1]
+      : colorConfig[0]
+    : colorConfig;
+};
+
+export const useNetworkColor = (network: NetworkWithColor) => {
+  const { resolvedTheme } = useTheme();
+  const isDarkMode = resolvedTheme === "dark";
+  return getNetworkColor(network, isDarkMode);
+};

--- a/packages/nextjs/hooks/scaffold-eth/useNetworkColor.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useNetworkColor.ts
@@ -1,23 +1,11 @@
-import { useTargetNetwork } from "./useTargetNetwork";
-import { useTheme } from "next-themes";
 import { useSelectedNetwork } from "~~/hooks/scaffold-eth";
-import { AllowedChainIds, ChainWithAttributes } from "~~/utils/scaffold-eth";
-
-export const DEFAULT_NETWORK_COLOR: [string, string] = ["#666666", "#bbbbbb"];
-
-export function getNetworkColor(network: ChainWithAttributes, isDarkMode: boolean) {
-  const colorConfig = network.color ?? DEFAULT_NETWORK_COLOR;
-  return Array.isArray(colorConfig) ? (isDarkMode ? colorConfig[1] : colorConfig[0]) : colorConfig;
-}
+import { AllowedChainIds } from "~~/utils/scaffold-eth";
+import { useNetworkColor as useSharedNetworkColor } from "../common/useNetworkColor";
 
 /**
- * Gets the color of the target network
+ * Gets the color of the selected EVM network
  */
 export const useNetworkColor = (chainId?: AllowedChainIds) => {
-  const { resolvedTheme } = useTheme();
-
   const chain = useSelectedNetwork(chainId);
-  const isDarkMode = resolvedTheme === "dark";
-
-  return getNetworkColor(chain, isDarkMode);
+  return useSharedNetworkColor(chain);
 };

--- a/packages/nextjs/hooks/scaffold-stark/useNetworkColor.ts
+++ b/packages/nextjs/hooks/scaffold-stark/useNetworkColor.ts
@@ -1,29 +1,10 @@
 import { useTargetNetwork } from "./useTargetNetwork";
-import { useTheme } from "next-themes";
-import { ChainWithAttributes } from "~~/utils/scaffold-stark";
-
-export const DEFAULT_NETWORK_COLOR: [string, string] = ["#666666", "#bbbbbb"];
-
-export function getNetworkColor(
-  network: ChainWithAttributes,
-  isDarkMode: boolean,
-) {
-  const colorConfig = network.color ?? DEFAULT_NETWORK_COLOR;
-  return Array.isArray(colorConfig)
-    ? isDarkMode
-      ? colorConfig[1]
-      : colorConfig[0]
-    : colorConfig;
-}
+import { useNetworkColor as useSharedNetworkColor } from "../common/useNetworkColor";
 
 /**
- * Gets the color of the target network
+ * Gets the color of the target Starknet network
  */
 export const useNetworkColor = () => {
-  const { resolvedTheme } = useTheme();
   const { targetNetwork } = useTargetNetwork();
-
-  const isDarkMode = resolvedTheme === "dark";
-
-  return getNetworkColor(targetNetwork, isDarkMode);
+  return useSharedNetworkColor(targetNetwork);
 };


### PR DESCRIPTION
## Summary
- document front-end refactoring plan and staged approach
- introduce shared `useNetworkColor` hook and wrappers for EVM and Starknet

## Testing
- `npx next lint`
- `yarn hardhat:lint` *(fails: Prettier errors in Hardhat package)*
- `yarn test` *(fails: hardhat command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0e8567b088320b79f37f06bb68e9c