### PR TITLE
Add Ekubo swap instruction to RouterGateway

### DIFF
--- a/packages/snfoundry/contracts/Scarb.lock
+++ b/packages/snfoundry/contracts/Scarb.lock
@@ -8,10 +8,16 @@ source = "registry+https://scarbs.xyz/"
 checksum = "sha256:0ad256055661ed5b29ccef7bddbb44136995641cf537a6b259b94b6b6df14133"
 
 [[package]]
+name = "ekubo"
+version = "0.1.0"
+source = "git+https://github.com/EkuboProtocol/abis#f4a16b95967c5596d5a3cd4e0422bb9a2e3eb017"
+
+[[package]]
 name = "kapan"
 version = "0.0.1"
 dependencies = [
  "alexandria_math",
+ "ekubo",
  "openzeppelin",
  "openzeppelin_utils",
  "snforge_std",

--- a/packages/snfoundry/contracts/Scarb.toml
+++ b/packages/snfoundry/contracts/Scarb.toml
@@ -11,6 +11,7 @@ starknet = "2.9.4"
 # Change to just "openzeppelin" to use full features
 openzeppelin = "1.0.0"
 alexandria_math = "0.4.0"
+ekubo = { git = "https://github.com/EkuboProtocol/abis" }
 
 [dev-dependencies]
 openzeppelin_utils = "1.0.0"

--- a/packages/snfoundry/contracts/src/gateways/RouterGateway.cairo
+++ b/packages/snfoundry/contracts/src/gateways/RouterGateway.cairo
@@ -1,21 +1,15 @@
 use core::array::{Array, Span};
 use core::bool;
-use core::traits::Into;
 use core::integer::BoundedInt;
-use starknet::{ContractAddress};
-use crate::interfaces::IGateway::{
-    LendingInstruction,
-    Deposit, 
-    Withdraw, 
-    Borrow, 
-    Repay, 
-    Reborrow,
-    Redeposit,
-    BasicInstruction,
-    ILendingInstructionProcessorDispatcher,
-    ILendingInstructionProcessorDispatcherTrait
-};
+use core::traits::Into;
+use ekubo::interfaces::router::{IRouterDispatcher, IRouterDispatcherTrait};
 use openzeppelin::token::erc20::interface::{IERC20Dispatcher, IERC20DispatcherTrait};
+use starknet::ContractAddress;
+use crate::interfaces::IGateway::{
+    BasicInstruction, Borrow, Deposit, EkuboSwap, ILendingInstructionProcessorDispatcher,
+    ILendingInstructionProcessorDispatcherTrait, LendingInstruction, Reborrow, Redeposit, Repay,
+    Withdraw,
+};
 
 #[derive(Drop, Serde, Copy)]
 pub struct ProtocolInstructions {
@@ -26,8 +20,12 @@ pub struct ProtocolInstructions {
 #[starknet::interface]
 pub trait RouterGatewayTrait<TContractState> {
     fn add_gateway(ref self: TContractState, protocol_name: felt252, gateway: ContractAddress);
-    fn process_protocol_instructions(ref self: TContractState, instructions: Span<ProtocolInstructions>);
-    fn get_authorizations_for_instructions(ref self: TContractState, instructions: Span<ProtocolInstructions>, rawSelectors: bool) -> Span<(ContractAddress, felt252, Array<felt252>)>;
+    fn process_protocol_instructions(
+        ref self: TContractState, instructions: Span<ProtocolInstructions>,
+    );
+    fn get_authorizations_for_instructions(
+        ref self: TContractState, instructions: Span<ProtocolInstructions>, rawSelectors: bool,
+    ) -> Span<(ContractAddress, felt252, Array<felt252>)>;
     fn move_debt(ref self: TContractState, instructions: Span<ProtocolInstructions>);
 }
 
@@ -35,12 +33,14 @@ pub trait RouterGatewayTrait<TContractState> {
 mod RouterGateway {
     use core::num::traits::Zero;
     use starknet::storage::{
-        Map, StorageMapReadAccess, StorageMapWriteAccess,
-        StoragePointerReadAccess, StoragePointerWriteAccess,
+        Map, StorageMapReadAccess, StorageMapWriteAccess, StoragePointerReadAccess,
+        StoragePointerWriteAccess,
+    };
+    use starknet::{contract_address_const, get_caller_address, get_contract_address};
+    use crate::interfaces::vesu::{
+        IFlashloanProviderDispatcher, IFlashloanProviderDispatcherTrait, IFlashloanReceiver,
     };
     use super::*;
-    use starknet::{contract_address_const, get_caller_address, get_contract_address};
-    use crate::interfaces::vesu::{IFlashloanReceiver, IFlashloanProviderDispatcher, IFlashloanProviderDispatcherTrait};
 
     #[event]
     #[derive(Drop, starknet::Event)]
@@ -48,7 +48,6 @@ mod RouterGateway {
         GatewayAdded: GatewayAdded,
     }
 
-    
 
     #[derive(Drop, starknet::Event)]
     struct GatewayAdded {
@@ -64,51 +63,73 @@ mod RouterGateway {
     }
 
     #[constructor]
-    fn constructor(ref self: ContractState, _owner: ContractAddress, flashloan_provider: ContractAddress) {
+    fn constructor(
+        ref self: ContractState, _owner: ContractAddress, flashloan_provider: ContractAddress,
+    ) {
         self.owner.write(_owner);
         self.flashloan_provider.write(flashloan_provider);
     }
 
     #[generate_trait]
     impl InternalFunctions of InternalFunctionsTrait {
-
-        // @dev - Internal function that translates redeposit and reborrow to normal borrow and deposit instructions as
-        // those instructions only have a meaning here in the router during the flash loan process.
-        fn remap_instructions(ref self: ContractState, instructions: Span<LendingInstruction>, balanceDiffs: Span<u256>) -> Span<LendingInstruction> {
+        // @dev - Internal function that translates redeposit and reborrow to normal borrow and
+        // deposit instructions as those instructions only have a meaning here in the router during
+        // the flash loan process.
+        fn remap_instructions(
+            ref self: ContractState,
+            instructions: Span<LendingInstruction>,
+            balanceDiffs: Span<u256>,
+        ) -> Span<LendingInstruction> {
             let mut remappedInstructions = array![];
             for instruction in instructions {
                 match instruction {
                     LendingInstruction::Reborrow(reborrow) => {
-                        remappedInstructions.append(LendingInstruction::Borrow(Borrow {
-                            basic: BasicInstruction {
-                                token: *reborrow.token,
-                                amount: *balanceDiffs.at(*reborrow.target_instruction_index),
-                                user: *reborrow.user,
-                            },
-                            context: *reborrow.context,
-                        }));
+                        remappedInstructions
+                            .append(
+                                LendingInstruction::Borrow(
+                                    Borrow {
+                                        basic: BasicInstruction {
+                                            token: *reborrow.token,
+                                            amount: *balanceDiffs
+                                                .at(*reborrow.target_instruction_index),
+                                            user: *reborrow.user,
+                                        },
+                                        context: *reborrow.context,
+                                    },
+                                ),
+                            );
                     },
                     LendingInstruction::Redeposit(redeposit) => {
-                        remappedInstructions.append(LendingInstruction::Deposit(Deposit {
-                            basic: BasicInstruction {
-                                token: *redeposit.token,
-                                amount: *balanceDiffs.at(*redeposit.target_instruction_index),
-                                user: *redeposit.user,
-                            },
-                            context: *redeposit.context,
-                        }));
+                        remappedInstructions
+                            .append(
+                                LendingInstruction::Deposit(
+                                    Deposit {
+                                        basic: BasicInstruction {
+                                            token: *redeposit.token,
+                                            amount: *balanceDiffs
+                                                .at(*redeposit.target_instruction_index),
+                                            user: *redeposit.user,
+                                        },
+                                        context: *redeposit.context,
+                                    },
+                                ),
+                            );
                     },
-                    _ => {
-                        remappedInstructions.append(*instruction);
-                    }
+                    _ => { remappedInstructions.append(*instruction); },
                 }
             }
             remappedInstructions.span()
         }
 
-        // @dev - befor sending instructions to the protocol's gateway we need to grant necessary approvals.
+        // @dev - befor sending instructions to the protocol's gateway we need to grant necessary
+        // approvals.
         // furthermore we keep track of the balances beforehand in order to calculate diffs.
-        fn before_send_instructions(ref self: ContractState, gateway: ContractAddress, instructions: Span<LendingInstruction>, should_transfer: bool) -> Span<u256> {
+        fn before_send_instructions(
+            ref self: ContractState,
+            gateway: ContractAddress,
+            instructions: Span<LendingInstruction>,
+            should_transfer: bool,
+        ) -> Span<u256> {
             let mut i: usize = 0;
             let mut balancesBefore = array![];
 
@@ -136,7 +157,7 @@ mod RouterGateway {
                         let balance = erc20.balance_of(get_contract_address());
                         balancesBefore.append(balance);
                     },
-                    _ => {}
+                    _ => {},
                 }
                 i += 1;
             }
@@ -149,7 +170,13 @@ mod RouterGateway {
                         let basic = *deposit.basic;
                         let erc20 = IERC20Dispatcher { contract_address: basic.token };
                         if should_transfer {
-                            assert(erc20.transfer_from(get_caller_address(), get_contract_address(), basic.amount), 'transfer failed');
+                            assert(
+                                erc20
+                                    .transfer_from(
+                                        get_caller_address(), get_contract_address(), basic.amount,
+                                    ),
+                                'transfer failed',
+                            );
                         }
                         assert(erc20.approve(gateway, basic.amount), 'approve failed');
                     },
@@ -157,7 +184,13 @@ mod RouterGateway {
                         let basic = *repay.basic;
                         let erc20 = IERC20Dispatcher { contract_address: basic.token };
                         if should_transfer {
-                            assert(erc20.transfer_from(get_caller_address(), get_contract_address(), basic.amount), 'transfer failed');
+                            assert(
+                                erc20
+                                    .transfer_from(
+                                        get_caller_address(), get_contract_address(), basic.amount,
+                                    ),
+                                'transfer failed',
+                            );
                         }
                         let mut amount = basic.amount;
                         if *repay.repay_all {
@@ -165,7 +198,7 @@ mod RouterGateway {
                         }
                         assert(erc20.approve(gateway, amount), 'approve failed');
                     },
-                    _ => {}
+                    _ => {},
                 }
                 i += 1;
             }
@@ -173,15 +206,16 @@ mod RouterGateway {
             balancesBefore.span()
         }
 
-        // @dev - after the instructions are executed we need to send back to the user the balance differences.
-        // It is however possible to skip the transfer in cases of debt refinancing where the balances are used in place
-        // to fund the follow up redeposit. 
+        // @dev - after the instructions are executed we need to send back to the user the balance
+        // differences.
+        // It is however possible to skip the transfer in cases of debt refinancing where the
+        // balances are used in place to fund the follow up redeposit.
         fn after_send_instructions(
             ref self: ContractState,
             gateway: ContractAddress,
             instructions: Span<LendingInstruction>,
             balancesBefore: Span<u256>,
-            should_transfer: bool
+            should_transfer: bool,
         ) -> Span<u256> {
             // First pass: count balances after execution
             let mut i: usize = 0;
@@ -219,10 +253,8 @@ mod RouterGateway {
                             erc20.approve(gateway, 0);
                         }
                     },
-                    LendingInstruction::Deposit(deposit) => {
-                        balancesAfter.append(0);
-                    },
-                    _ => {}
+                    LendingInstruction::Deposit(deposit) => { balancesAfter.append(0); },
+                    _ => {},
                 }
                 i += 1;
             }
@@ -235,7 +267,11 @@ mod RouterGateway {
                         LendingInstruction::Borrow(borrow) => {
                             let basic = *borrow.basic;
                             let erc20 = IERC20Dispatcher { contract_address: basic.token };
-                            assert(erc20.transfer(basic.user, erc20.balance_of(get_contract_address())), 'transfer failed');
+                            assert(
+                                erc20
+                                    .transfer(basic.user, erc20.balance_of(get_contract_address())),
+                                'transfer failed',
+                            );
                         },
                         LendingInstruction::Withdraw(withdraw) => {
                             let basic = *withdraw.basic;
@@ -251,7 +287,7 @@ mod RouterGateway {
                                 assert(erc20.transfer(basic.user, *diff), 'transfer failed');
                             }
                         },
-                        _ => {}
+                        _ => {},
                     }
                     i += 1;
                 }
@@ -260,9 +296,44 @@ mod RouterGateway {
             balancesAfter.span()
         }
 
-        // @dev - the core logic loop of the router. It goes protocol by protocol, giving approvals and transfering from caller
-        // before forwarding to the concrete protocol's gateway. Then it looks at balance diffs and transfers back to the user.
-        fn process_protocol_instructions_internal(ref self: ContractState, instructions: Span<ProtocolInstructions>, should_transfer: bool) {
+        fn process_ekubo_instructions(
+            ref self: ContractState,
+            router: ContractAddress,
+            instructions: Span<LendingInstruction>,
+        ) -> Span<u256> {
+            let mut balances_after = array![];
+            for instr in instructions {
+                match instr {
+                    LendingInstruction::EkuboSwap(swap) => {
+                        let swap = *swap;
+                        let node = swap.node;
+                        let token_in = swap.token_amount.token;
+                        let token_out = if token_in == node.pool_key.token0 {
+                            node.pool_key.token1
+                        } else {
+                            node.pool_key.token0
+                        };
+                        let erc20_out = IERC20Dispatcher { contract_address: token_out };
+                        let before = erc20_out.balance_of(get_contract_address());
+                        let router_dispatcher = IRouterDispatcher { contract_address: router };
+                        router_dispatcher.swap(node, swap.token_amount);
+                        let after = erc20_out.balance_of(get_contract_address());
+                        balances_after.append(after - before);
+                    },
+                    _ => { panic!("invalid-ekubo-instruction") },
+                }
+            }
+            balances_after.span()
+        }
+
+        // @dev - the core logic loop of the router. It goes protocol by protocol, giving approvals
+        // and transfering from caller before forwarding to the concrete protocol's gateway. Then it
+        // looks at balance diffs and transfers back to the user.
+        fn process_protocol_instructions_internal(
+            ref self: ContractState,
+            instructions: Span<ProtocolInstructions>,
+            should_transfer: bool,
+        ) {
             let mut i: usize = 0;
             let mut previous_protocol_diffs = array![].span();
             while i != instructions.len() {
@@ -273,33 +344,56 @@ mod RouterGateway {
                 // Apply remapping (for redeposit/reborrow) using diffs from the previous protocol
                 let mut instructions_span = *protocol_instruction.instructions;
                 if previous_protocol_diffs.len() != 0 {
-                    instructions_span = self.remap_instructions(instructions_span, previous_protocol_diffs);
+                    instructions_span = self
+                        .remap_instructions(instructions_span, previous_protocol_diffs);
                 }
 
-                // Process all instructions for this protocol at once
-                let balances_before = self.before_send_instructions(gateway, instructions_span, should_transfer);
-                let dispatcher = ILendingInstructionProcessorDispatcher { contract_address: gateway };
-                dispatcher.process_instructions(instructions_span);
-                let diffs = self.after_send_instructions(gateway, instructions_span, balances_before, should_transfer);
-                previous_protocol_diffs = diffs;
+                match instructions_span.at(0) {
+                    LendingInstruction::EkuboSwap(_) => {
+                        let diffs = self.process_ekubo_instructions(gateway, instructions_span);
+                        previous_protocol_diffs = diffs;
+                    },
+                    _ => {
+                        let balances_before = self
+                            .before_send_instructions(gateway, instructions_span, should_transfer);
+                        let dispatcher = ILendingInstructionProcessorDispatcher {
+                            contract_address: gateway,
+                        };
+                        dispatcher.process_instructions(instructions_span);
+                        let diffs = self
+                            .after_send_instructions(
+                                gateway, instructions_span, balances_before, should_transfer,
+                            );
+                        previous_protocol_diffs = diffs;
+                    },
+                }
                 i += 1;
             }
         }
 
 
-        // @dev - gets how much to borrow for a flash loan. If we want to repay all, then we need to pull the current debt
-        // at the time of processing the transaction as it varies with time.
-        fn get_flash_loan_amount(ref self: ContractState, instructions: Span<ProtocolInstructions>) -> (ContractAddress, u256) {
+        // @dev - gets how much to borrow for a flash loan. If we want to repay all, then we need to
+        // pull the current debt at the time of processing the transaction as it varies with time.
+        fn get_flash_loan_amount(
+            ref self: ContractState, instructions: Span<ProtocolInstructions>,
+        ) -> (ContractAddress, u256) {
             let mut flash_loan_amount: u256 = 0;
             let mut token: ContractAddress = Zero::zero();
             for protocolInstruction in instructions {
                 for instruction in protocolInstruction.instructions {
                     if let LendingInstruction::Repay(repay) = instruction {
                         assert(*repay.basic.amount != 0, 'repay-amount-is-zero');
-                        // If repay_all, get the amount from the gateway and add it to the flash loan amount
+                        // If repay_all, get the amount from the gateway and add it to the flash
+                        // loan amount
                         if *repay.repay_all {
-                            let gateway = ILendingInstructionProcessorDispatcher { contract_address: self.gateways.read(*protocolInstruction.protocol_name) };
-                            let (repay_token, repay_amount) = ( *repay.basic.token, gateway.get_flash_loan_amount(*repay) );
+                            let gateway = ILendingInstructionProcessorDispatcher {
+                                contract_address: self
+                                    .gateways
+                                    .read(*protocolInstruction.protocol_name),
+                            };
+                            let (repay_token, repay_amount) = (
+                                *repay.basic.token, gateway.get_flash_loan_amount(*repay),
+                            );
                             // If token is already set, ensure it matches
                             if token != Zero::zero() {
                                 assert(token == repay_token, 'repay-token-mismatch');
@@ -321,10 +415,13 @@ mod RouterGateway {
         }
 
         // @dev - as each instruction is carrying a user, we need to ensure it matches the caller.
-        // A bit ugly, but it was an oversight in the design :/ 
-        fn ensure_user_matches_caller(ref self: ContractState, instructions: Span<ProtocolInstructions>) {
+        // A bit ugly, but it was an oversight in the design :/
+        fn ensure_user_matches_caller(
+            ref self: ContractState, instructions: Span<ProtocolInstructions>,
+        ) {
             for protocolInstruction in instructions {
-                // Ensure there is at most one borrow/withdraw per ERC20 token in this protocol's instruction list
+                // Ensure there is at most one borrow/withdraw per ERC20 token in this protocol's
+                // instruction list
                 self.ensure_unique_diff_tokens(*protocolInstruction.instructions);
                 for instruction in protocolInstruction.instructions {
                     let user = match instruction {
@@ -344,23 +441,21 @@ mod RouterGateway {
                             let basic = deposit.basic;
                             basic.user
                         },
-                        LendingInstruction::Reborrow(reborrow) => {
-                           reborrow.user
-                        },
-                        LendingInstruction::Redeposit(redeposit) => {
-                            redeposit.user
-                        },
-                        _ => {
-                            panic!("bad-instruction-order")
-                        }
+                        LendingInstruction::Reborrow(reborrow) => { reborrow.user },
+                        LendingInstruction::Redeposit(redeposit) => { redeposit.user },
+                        LendingInstruction::EkuboSwap(swap) => { swap.user },
+                        _ => { panic!("bad-instruction-order") },
                     };
                     assert(*user == get_caller_address(), 'user mismatch');
                 }
             }
         }
 
-        // @dev - ensures there is only one Borrow or Withdraw instruction per ERC20 token in the same instructions span.
-        fn ensure_unique_diff_tokens(ref self: ContractState, instructions: Span<LendingInstruction>) {
+        // @dev - ensures there is only one Borrow or Withdraw instruction per ERC20 token in the
+        // same instructions span.
+        fn ensure_unique_diff_tokens(
+            ref self: ContractState, instructions: Span<LendingInstruction>,
+        ) {
             // Keep track of tokens we have already seen in a borrow/withdraw instruction
             let mut seen_tokens = array![];
             for instr in instructions {
@@ -372,9 +467,9 @@ mod RouterGateway {
                         while i != seen_tokens.len() {
                             if *seen_tokens.at(i) == token {
                                 found = true;
-                            };
+                            }
                             i += 1;
-                        };
+                        }
                         assert(!found, 'duplicate-borrow-withdraw-token');
                         seen_tokens.append(token);
                     },
@@ -385,9 +480,9 @@ mod RouterGateway {
                         while i != seen_tokens.len() {
                             if *seen_tokens.at(i) == token {
                                 found = true;
-                            };
+                            }
                             i += 1;
-                        };
+                        }
                         assert(!found, 'duplicate-borrow-withdraw-token');
                         seen_tokens.append(token);
                     },
@@ -398,9 +493,9 @@ mod RouterGateway {
                         while i != seen_tokens.len() {
                             if *seen_tokens.at(i) == token {
                                 found = true;
-                            };
+                            }
                             i += 1;
-                        };
+                        }
                         assert(!found, 'duplicate-borrow-withdraw-token');
                         seen_tokens.append(token);
                     },
@@ -411,13 +506,13 @@ mod RouterGateway {
                         while i != seen_tokens.len() {
                             if *seen_tokens.at(i) == token {
                                 found = true;
-                            };
+                            }
                             i += 1;
-                        };
+                        }
                         assert(!found, 'duplicate-borrow-withdraw-token');
                         seen_tokens.append(token);
                     },
-                    _ => {}
+                    _ => {},
                 }
             }
         }
@@ -433,66 +528,99 @@ mod RouterGateway {
             self.emit(GatewayAdded { protocol_name, gateway });
         }
 
-        // @dev - entrypoint for all processing of logic. Allows bundling multiple operations in one single call,
-        // like deposit and borrow for example. 
-        fn process_protocol_instructions(ref self: ContractState, instructions: Span<ProtocolInstructions>) {
+        // @dev - entrypoint for all processing of logic. Allows bundling multiple operations in one
+        // single call, like deposit and borrow for example.
+        fn process_protocol_instructions(
+            ref self: ContractState, instructions: Span<ProtocolInstructions>,
+        ) {
             self.ensure_user_matches_caller(instructions);
             self.process_protocol_instructions_internal(instructions, true);
         }
 
-        // @dev - view function that returns encoded calls which are used to give approval for the operations desired in the instructions.
-        // This is used in the UI, but can be used by other contracts. Relies on the assumption that none of the contracts are upgradeable.
+        // @dev - view function that returns encoded calls which are used to give approval for the
+        // operations desired in the instructions.
+        // This is used in the UI, but can be used by other contracts. Relies on the assumption that
+        // none of the contracts are upgradeable.
         // Otherwise integrating this function in a contract would be unsafe.
-        fn get_authorizations_for_instructions(ref self: ContractState, instructions: Span<ProtocolInstructions>, rawSelectors: bool) -> Span<(ContractAddress, felt252, Array<felt252>)> {
+        fn get_authorizations_for_instructions(
+            ref self: ContractState, instructions: Span<ProtocolInstructions>, rawSelectors: bool,
+        ) -> Span<(ContractAddress, felt252, Array<felt252>)> {
             let mut authorizations = ArrayTrait::new();
             for instruction in instructions {
                 let gateway = self.gateways.read(*instruction.protocol_name);
-                let dispatcher = ILendingInstructionProcessorDispatcher { contract_address: gateway };
-                let gateway_authorizations = dispatcher.get_authorizations_for_instructions(*instruction.instructions, rawSelectors);
-                for authorization in gateway_authorizations {
-                    let (token, selector, call_data) = authorization;
-                    authorizations.append((*token, *selector, call_data.clone()));
+                match instruction.instructions.at(0) {
+                    LendingInstruction::EkuboSwap(_) => {// no approvals needed
+                    },
+                    _ => {
+                        let dispatcher = ILendingInstructionProcessorDispatcher {
+                            contract_address: gateway,
+                        };
+                        let gateway_authorizations = dispatcher
+                            .get_authorizations_for_instructions(
+                                *instruction.instructions, rawSelectors,
+                            );
+                        for authorization in gateway_authorizations {
+                            let (token, selector, call_data) = authorization;
+                            authorizations.append((*token, *selector, call_data.clone()));
+                        }
+                    },
                 }
-            };
+            }
             return authorizations.span();
         }
 
         // @dev - entrypoint for the logic that refinances debt between two protocols.
-        // It is a wrapper around the flash loan logic, which redirects back to processing protocol instructions.
-        // Ensures that the flash loan reflects accurate debt amounts as they scale with time and you cannot craft a transaction
-        // that exactly matches the debt amount, thus the contract needs to replace the amount to be borrowed if we want to repay all.
+        // It is a wrapper around the flash loan logic, which redirects back to processing protocol
+        // instructions.
+        // Ensures that the flash loan reflects accurate debt amounts as they scale with time and
+        // you cannot craft a transaction that exactly matches the debt amount, thus the contract
+        // needs to replace the amount to be borrowed if we want to repay all.
         fn move_debt(ref self: ContractState, instructions: Span<ProtocolInstructions>) {
             self.ensure_user_matches_caller(instructions);
-            let flashloan_provider = IFlashloanProviderDispatcher { contract_address: self.flashloan_provider.read() };
+            let flashloan_provider = IFlashloanProviderDispatcher {
+                contract_address: self.flashloan_provider.read(),
+            };
             let (asset, amount) = self.get_flash_loan_amount(instructions);
             let is_legacy = false;
 
             // Serialize instructions for flash loan data
             let mut data = ArrayTrait::new();
             Serde::serialize(@instructions, ref data);
-            flashloan_provider.flash_loan(get_contract_address(), asset, amount, is_legacy, data.span());
+            flashloan_provider
+                .flash_loan(get_contract_address(), asset, amount, is_legacy, data.span());
         }
     }
 
     #[abi(embed_v0)]
     impl RouterGatewayFlashloanReceiver of IFlashloanReceiver<ContractState> {
         // @dev - The callback function that vesu calls when the flash loan is executed.
-        // Relies on the assumption that sender cannot be cheated as it prevents other contracts from calling this through
-        // the flash loan provider.
-        fn on_flash_loan(ref self: ContractState, sender: ContractAddress, asset: ContractAddress, amount: u256, data: Span<felt252>) {
-            assert(get_caller_address() == self.flashloan_provider.read(), 'caller-not-flashprovider');
+        // Relies on the assumption that sender cannot be cheated as it prevents other contracts
+        // from calling this through the flash loan provider.
+        fn on_flash_loan(
+            ref self: ContractState,
+            sender: ContractAddress,
+            asset: ContractAddress,
+            amount: u256,
+            data: Span<felt252>,
+        ) {
+            assert(
+                get_caller_address() == self.flashloan_provider.read(), 'caller-not-flashprovider',
+            );
             assert(sender == get_contract_address(), 'sender mismatch');
             let mut data = data;
-            let mut protocol_instructions: Span<ProtocolInstructions> = Serde::deserialize(ref data).unwrap();
-                  // Collect all repay amounts and calculate total
+            let mut protocol_instructions: Span<ProtocolInstructions> = Serde::deserialize(ref data)
+                .unwrap();
+            // Collect all repay amounts and calculate total
             let mut repay_amounts = array![];
             let mut total_repay_amount = 0;
             let mut repay_count = 0;
-            
+
             // First pass: Collect all repay amounts and count
             for protocolInstruction in protocol_instructions {
                 let gateway_addr = self.gateways.read(*protocolInstruction.protocol_name);
-                let gateway = ILendingInstructionProcessorDispatcher { contract_address: gateway_addr };
+                let gateway = ILendingInstructionProcessorDispatcher {
+                    contract_address: gateway_addr,
+                };
                 for instruction in protocolInstruction.instructions {
                     if let LendingInstruction::Repay(repay) = instruction {
                         let repay = *repay;
@@ -507,15 +635,15 @@ mod RouterGateway {
                     }
                 }
             }
-            
+
             // Calculate remaining amount to distribute
             let remaining_amount = amount - total_repay_amount;
             assert(remaining_amount >= 0, 'flashloan insufficient');
-            
+
             // Second pass: Modify instructions with adjusted amounts
             let mut remadeProtocolInstructions = array![];
             let mut repay_index = 0;
-            
+
             for instruction in protocol_instructions {
                 let mut remadeInstructions = array![];
                 for instruction in instruction.instructions {
@@ -523,39 +651,47 @@ mod RouterGateway {
                         LendingInstruction::Repay(repay) => {
                             let repay = *repay;
                             let mut modified_amount = *repay_amounts.at(repay_index);
-                            
+
                             // Add remaining amount to last repay
                             if repay_index == repay_count - 1 {
                                 modified_amount += remaining_amount;
                             }
-                            
+
                             assert(modified_amount <= amount, 'repay amount exceeds flash loan');
-                            
-                            remadeInstructions.append(LendingInstruction::Repay(Repay {
-                                basic: BasicInstruction {
-                                    token: repay.basic.token,
-                                    amount: modified_amount,
-                                    user: repay.basic.user,
-                                },
-                                repay_all: false, // Force explicit amount
-                                context: repay.context,
-                            }));
-                            
+
+                            remadeInstructions
+                                .append(
+                                    LendingInstruction::Repay(
+                                        Repay {
+                                            basic: BasicInstruction {
+                                                token: repay.basic.token,
+                                                amount: modified_amount,
+                                                user: repay.basic.user,
+                                            },
+                                            repay_all: false, // Force explicit amount
+                                            context: repay.context,
+                                        },
+                                    ),
+                                );
+
                             repay_index += 1;
                         },
-                        _ => {
-                            remadeInstructions.append(*instruction);
-                        }
+                        _ => { remadeInstructions.append(*instruction); },
                     }
                 }
-                remadeProtocolInstructions.append(ProtocolInstructions {
-                    protocol_name: *instruction.protocol_name,
-                    instructions: remadeInstructions.span(),
-                });
+                remadeProtocolInstructions
+                    .append(
+                        ProtocolInstructions {
+                            protocol_name: *instruction.protocol_name,
+                            instructions: remadeInstructions.span(),
+                        },
+                    );
             }
-            
 
-            self.process_protocol_instructions_internal(remadeProtocolInstructions.span(), false); //no outside transfer, we do it in place
+            self
+                .process_protocol_instructions_internal(
+                    remadeProtocolInstructions.span(), false,
+                ); //no outside transfer, we do it in place
 
             // settle flash loan
             let erc20 = IERC20Dispatcher { contract_address: asset };

--- a/packages/snfoundry/contracts/src/interfaces/IGateway.cairo
+++ b/packages/snfoundry/contracts/src/interfaces/IGateway.cairo
@@ -1,3 +1,4 @@
+use ekubo::interfaces::router::{RouteNode, TokenAmount};
 use starknet::ContractAddress;
 
 #[derive(Drop, Serde, Copy)]
@@ -52,6 +53,14 @@ pub struct Reborrow {
 }
 
 #[derive(Drop, Serde, Copy)]
+pub struct EkuboSwap {
+    pub router: ContractAddress,
+    pub node: RouteNode,
+    pub token_amount: TokenAmount,
+    pub user: ContractAddress,
+}
+
+#[derive(Drop, Serde, Copy)]
 pub enum LendingInstruction {
     Deposit: Deposit,
     Borrow: Borrow,
@@ -59,12 +68,15 @@ pub enum LendingInstruction {
     Withdraw: Withdraw,
     Redeposit: Redeposit,
     Reborrow: Reborrow,
+    EkuboSwap: EkuboSwap,
 }
 
 #[starknet::interface]
 pub trait ILendingInstructionProcessor<TContractState> {
     fn process_instructions(ref self: TContractState, instructions: Span<LendingInstruction>);
-    fn get_authorizations_for_instructions(ref self: TContractState, instructions: Span<LendingInstruction>, rawSelectors: bool) -> Span<(ContractAddress, felt252, Array<felt252>)>;
+    fn get_authorizations_for_instructions(
+        ref self: TContractState, instructions: Span<LendingInstruction>, rawSelectors: bool,
+    ) -> Span<(ContractAddress, felt252, Array<felt252>)>;
     fn get_flash_loan_amount(ref self: TContractState, repay: Repay) -> u256;
 }
 


### PR DESCRIPTION
## Summary
- add Ekubo protocol ABIs as Scarb dependency
- support EkuboSwap instruction in RouterGateway to swap withdrawn collateral

## Testing
- `scarb build`
- `yarn workspace @ss-2/snfoundry test` *(fails: Universal Sierra Compiler is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b0e6700a808320b78198f1caf54771