### PR TITLE
Fix modal USD values using token prices

### DIFF
--- a/packages/nextjs/components/BorrowPosition.tsx
+++ b/packages/nextjs/components/BorrowPosition.tsx
@@ -306,6 +306,7 @@ export const BorrowPosition: FC<BorrowPositionProps> = ({
               icon,
               address: tokenAddress,
               currentRate,
+              tokenPrice,
             }}
             protocolName={protocolName}
           />
@@ -318,6 +319,7 @@ export const BorrowPosition: FC<BorrowPositionProps> = ({
               address: tokenAddress,
               currentRate,
               protocolAmount: tokenBalance,
+              tokenPrice,
             }}
             protocolName={protocolName}
           />
@@ -344,6 +346,7 @@ export const BorrowPosition: FC<BorrowPositionProps> = ({
               icon,
               address: tokenAddress,
               currentRate,
+              tokenPrice,
             }}
             protocolName={protocolName}
           />
@@ -355,6 +358,7 @@ export const BorrowPosition: FC<BorrowPositionProps> = ({
               icon,
               address: tokenAddress,
               currentRate,
+              tokenPrice,
             }}
             protocolName={protocolName}
           />

--- a/packages/nextjs/components/ProtocolView.tsx
+++ b/packages/nextjs/components/ProtocolView.tsx
@@ -77,6 +77,7 @@ export const ProtocolView: FC<ProtocolViewProps> = ({
     icon: string;
     address: string;
     currentRate: number;
+    tokenPrice?: bigint;
   } | null>(null);
 
   // Update showAll when forceShowAll prop changes
@@ -199,6 +200,7 @@ export const ProtocolView: FC<ProtocolViewProps> = ({
       icon: token.icon,
       address: token.tokenAddress,
       currentRate: token.currentRate,
+      tokenPrice: token.tokenPrice,
     });
     setIsTokenSelectModalOpen(false);
     setIsDepositModalOpen(true);
@@ -438,7 +440,7 @@ export const ProtocolView: FC<ProtocolViewProps> = ({
           }
 
           {/* Borrow Modal for Starknet */}
-          {isTokenBorrowModalOpen && 
+          {isTokenBorrowModalOpen &&
             <BorrowModalStark
               isOpen={isTokenBorrowModalOpen}
               onClose={handleCloseBorrowModal}
@@ -449,12 +451,14 @@ export const ProtocolView: FC<ProtocolViewProps> = ({
                       icon: selectedToken.icon,
                       currentRate: selectedToken.currentRate,
                       address: selectedToken.tokenAddress,
+                      tokenPrice: selectedToken.tokenPrice,
                     }
                   : {
                       name: borrowedPositions[0]?.name || "",
                       icon: borrowedPositions[0]?.icon || "",
                       currentRate: borrowedPositions[0]?.currentRate || 0,
                       address: borrowedPositions[0]?.tokenAddress || "",
+                      tokenPrice: borrowedPositions[0]?.tokenPrice,
                     }
               }
               protocolName={protocolName}
@@ -493,12 +497,14 @@ export const ProtocolView: FC<ProtocolViewProps> = ({
                       icon: selectedToken.icon,
                       address: selectedToken.tokenAddress,
                       currentRate: selectedToken.currentRate,
+                      tokenPrice: selectedToken.tokenPrice,
                     }
                   : {
                       name: borrowedPositions[0]?.name || "",
                       icon: borrowedPositions[0]?.icon || "",
                       address: borrowedPositions[0]?.tokenAddress || "",
                       currentRate: borrowedPositions[0]?.currentRate || 0,
+                      tokenPrice: borrowedPositions[0]?.tokenPrice,
                     }
               }
               protocolName={protocolName}

--- a/packages/nextjs/components/SupplyPosition.tsx
+++ b/packages/nextjs/components/SupplyPosition.tsx
@@ -270,6 +270,7 @@ export const SupplyPosition: FC<SupplyPositionProps> = ({
               icon,
               address: tokenAddress,
               currentRate,
+              tokenPrice,
             }}
             protocolName={protocolName}
           />
@@ -282,6 +283,7 @@ export const SupplyPosition: FC<SupplyPositionProps> = ({
               address: tokenAddress,
               currentRate,
               protocolAmount: tokenBalance,
+              tokenPrice,
             }}
             protocolName={protocolName}
           />
@@ -296,6 +298,7 @@ export const SupplyPosition: FC<SupplyPositionProps> = ({
               icon,
               address: tokenAddress,
               currentRate,
+              tokenPrice,
             }}
             protocolName={protocolName}
           />

--- a/packages/nextjs/components/modals/BaseTokenModal.tsx
+++ b/packages/nextjs/components/modals/BaseTokenModal.tsx
@@ -12,6 +12,7 @@ export interface TokenInfo {
   icon: string;
   currentRate: number;
   address: string;
+  tokenPrice?: bigint; // USD price with 8 decimals
 }
 
 // Different action types supported
@@ -84,8 +85,9 @@ export const BaseTokenModal: FC<BaseTokenModalProps> = ({
 
   // Calculate USD value
   const getUsdValue = () => {
-    if (!amount || isNaN(Number(amount))) return "0.00";
-    return formatDisplayNumber(Number(amount) * token.currentRate);
+    if (!amount || isNaN(Number(amount)) || !token.tokenPrice) return "0.00";
+    const price = Number(token.tokenPrice) / 1e8; // prices have 8 decimals
+    return formatDisplayNumber(Number(amount) * price);
   };
 
   // Reset the state when the modal is closed

--- a/packages/nextjs/components/modals/TokenSelectModal.tsx
+++ b/packages/nextjs/components/modals/TokenSelectModal.tsx
@@ -137,6 +137,7 @@ export const TokenSelectModal: FC<TokenSelectModalProps> = ({
               icon: selectedToken.icon,
               currentRate: selectedToken.currentRate,
               address: selectedToken.tokenAddress,
+              tokenPrice: selectedToken.tokenPrice,
             }}
             protocolName={protocolName}
           />
@@ -149,6 +150,7 @@ export const TokenSelectModal: FC<TokenSelectModalProps> = ({
               icon: selectedToken.icon,
               currentRate: selectedToken.currentRate,
               address: selectedToken.tokenAddress,
+              tokenPrice: selectedToken.tokenPrice,
             }}
             protocolName={protocolName}
           />

--- a/packages/nextjs/components/modals/stark/BaseTokenModal.tsx
+++ b/packages/nextjs/components/modals/stark/BaseTokenModal.tsx
@@ -38,6 +38,7 @@ export interface TokenInfo {
   icon: string;
   currentRate: number;
   address: string;
+  tokenPrice?: bigint; // USD price with 18 decimals
   protocolAmount?: bigint; // Add protocol balance/debt amount for withdraw/repay actions
 }
 
@@ -292,8 +293,9 @@ export const BaseTokenModal: FC<BaseTokenModalProps> = ({
 
   // Calculate USD value
   const getUsdValue = () => {
-    if (!amount || isNaN(Number(amount))) return "0.00";
-    return formatDisplayNumber(Number(amount) * token.currentRate);
+    if (!amount || isNaN(Number(amount)) || !token.tokenPrice) return "0.00";
+    const price = Number(token.tokenPrice) / 1e18; // prices have 18 decimals
+    return formatDisplayNumber(Number(amount) * price);
   };
 
   // Reset the state when the modal is closed

--- a/packages/nextjs/components/modals/stark/BorrowModalStark.tsx
+++ b/packages/nextjs/components/modals/stark/BorrowModalStark.tsx
@@ -12,6 +12,7 @@ interface BorrowModalStarkProps {
     icon: string;
     address: string;
     currentRate: number;
+    tokenPrice?: bigint;
   };
   protocolName: string;
   supportedAssets?: TokenMetadata[];

--- a/packages/nextjs/components/modals/stark/DepositModalStark.tsx
+++ b/packages/nextjs/components/modals/stark/DepositModalStark.tsx
@@ -9,6 +9,7 @@ interface DepositModalStarkProps {
     icon: string;
     address: string;
     currentRate: number;
+    tokenPrice?: bigint;
   };
   protocolName: string;
   vesuContext?: {

--- a/packages/nextjs/components/modals/stark/RepayModalStark.tsx
+++ b/packages/nextjs/components/modals/stark/RepayModalStark.tsx
@@ -10,6 +10,7 @@ interface RepayModalStarkProps {
     address: string;
     currentRate: number;
     protocolAmount?: bigint;
+    tokenPrice?: bigint;
   };
   protocolName: string;
   vesuContext?: {

--- a/packages/nextjs/components/modals/stark/TokenSelectModalStark.tsx
+++ b/packages/nextjs/components/modals/stark/TokenSelectModalStark.tsx
@@ -151,6 +151,7 @@ export const TokenSelectModalStark: FC<TokenSelectModalStarkProps> = ({
             icon: tokenNameToLogo(feltToString(selectedToken.symbol).toLowerCase()),
             address: `0x${BigInt(selectedToken.address).toString(16).padStart(64, "0")}`,
             currentRate: selectedToken.borrowAPR ? selectedToken.borrowAPR * 100 : 0,
+            tokenPrice: selectedToken.price.value,
           }}
           protocolName={protocolName}
           supportedAssets={tokens}

--- a/packages/nextjs/components/modals/stark/WithdrawModalStark.tsx
+++ b/packages/nextjs/components/modals/stark/WithdrawModalStark.tsx
@@ -10,6 +10,7 @@ interface WithdrawModalStarkProps {
     address: string;
     currentRate: number;
     protocolAmount?: bigint;
+    tokenPrice?: bigint;
   };
   protocolName: string;
   vesuContext?: {

--- a/packages/nextjs/components/specific/vesu/VesuPosition.tsx
+++ b/packages/nextjs/components/specific/vesu/VesuPosition.tsx
@@ -292,6 +292,7 @@ export const VesuPosition: FC<VesuPositionProps> = ({
           icon: tokenNameToLogo(collateralSymbol.toLowerCase()),
           address: collateralAsset,
           currentRate: collateralRates.supplyAPY * 100,
+          tokenPrice: collateralMetadata.price.value,
         }}
         protocolName="Vesu"
         vesuContext={{
@@ -309,6 +310,7 @@ export const VesuPosition: FC<VesuPositionProps> = ({
           address: collateralAsset,
           currentRate: collateralRates.supplyAPY * 100,
           protocolAmount: BigInt(collateralAmount),
+          tokenPrice: collateralMetadata.price.value,
         }}
         protocolName="Vesu"
         vesuContext={{
@@ -332,15 +334,16 @@ export const VesuPosition: FC<VesuPositionProps> = ({
 
       {debtMetadata && (
         <>
-          <BorrowModalStark
-            isOpen={isBorrowModalOpen}
-            onClose={() => setIsBorrowModalOpen(false)}
-            token={{
-              name: debtSymbol,
-              icon: tokenNameToLogo(debtSymbol.toLowerCase()),
-              address: debtAsset,
-              currentRate: debtRates.borrowAPR * 100,
-            }}
+        <BorrowModalStark
+          isOpen={isBorrowModalOpen}
+          onClose={() => setIsBorrowModalOpen(false)}
+          token={{
+            name: debtSymbol,
+            icon: tokenNameToLogo(debtSymbol.toLowerCase()),
+            address: debtAsset,
+            currentRate: debtRates.borrowAPR * 100,
+            tokenPrice: debtMetadata.price.value,
+          }}
             protocolName="Vesu"
             supportedAssets={supportedAssets}
             isVesu={true}
@@ -350,16 +353,17 @@ export const VesuPosition: FC<VesuPositionProps> = ({
             }}
           />
 
-          <RepayModalStark
-            isOpen={isRepayModalOpen}
-            onClose={() => setIsRepayModalOpen(false)}
-            token={{
-              name: debtSymbol,
-              icon: tokenNameToLogo(debtSymbol.toLowerCase()),
-              address: debtAsset,
-              currentRate: debtRates.borrowAPR * 100,
-              protocolAmount: BigInt(nominalDebt),
-            }}
+        <RepayModalStark
+          isOpen={isRepayModalOpen}
+          onClose={() => setIsRepayModalOpen(false)}
+          token={{
+            name: debtSymbol,
+            icon: tokenNameToLogo(debtSymbol.toLowerCase()),
+            address: debtAsset,
+            currentRate: debtRates.borrowAPR * 100,
+            protocolAmount: BigInt(nominalDebt),
+            tokenPrice: debtMetadata.price.value,
+          }}
             protocolName="Vesu"
             vesuContext={{
               pool_id: 0n,


### PR DESCRIPTION
## Summary
- use token price for USD conversions in EVM and StarkNet modals
- propagate token price through protocol views and position components

## Testing
- `yarn test` *(fails: command not found: hardhat)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ea59166c8320a6780a3afc72f30d