### PR TITLE
Add Cairo CI workflow

### DIFF
--- a/.github/workflows/cairo.yml
+++ b/.github/workflows/cairo.yml
@@ -1,0 +1,21 @@
+name: Cairo CI
+
+on:
+  pull_request:
+    paths:
+      - '**/*.cairo'
+      - '**/Scarb.toml'
+      - '**/Scarb.lock'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run Scarb build and Snforge tests
+        uses: devcontainers/ci@v0.3
+        with:
+          runCmd: |
+            cd packages/snfoundry/contracts
+            scarb build
+            snforge test


### PR DESCRIPTION
## Summary
- add GitHub workflow to build Cairo contracts and run snforge tests

## Testing
- `scarb build`
- `snforge test` *(fails: Package snforge_std version does not meet the minimum required version >=0.48.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ea982f9c8320bc2499d17b8cc580