### PR TITLE
fix token price badge

### DIFF
--- a/packages/nextjs/components/BorrowPosition.tsx
+++ b/packages/nextjs/components/BorrowPosition.tsx
@@ -41,6 +41,8 @@ export const BorrowPosition: FC<BorrowPositionProps> = ({
   const expanded = useToggle();
   const isExpanded = expanded.isOpen;
 
+  const usdPrice = tokenPrice ? Number(tokenPrice) / 1e8 : 0;
+
   // Get wallet connection status for both networks
   const { evm, starknet } = useWalletConnection();
   const address = networkType === "evm" ? evm.address : starknet.address;
@@ -306,6 +308,7 @@ export const BorrowPosition: FC<BorrowPositionProps> = ({
               icon,
               address: tokenAddress,
               currentRate,
+              usdPrice,
             }}
             protocolName={protocolName}
           />
@@ -317,6 +320,7 @@ export const BorrowPosition: FC<BorrowPositionProps> = ({
               icon,
               address: tokenAddress,
               currentRate,
+              usdPrice,
               protocolAmount: tokenBalance,
             }}
             protocolName={protocolName}
@@ -344,6 +348,7 @@ export const BorrowPosition: FC<BorrowPositionProps> = ({
               icon,
               address: tokenAddress,
               currentRate,
+              usdPrice,
             }}
             protocolName={protocolName}
           />
@@ -355,6 +360,7 @@ export const BorrowPosition: FC<BorrowPositionProps> = ({
               icon,
               address: tokenAddress,
               currentRate,
+              usdPrice,
             }}
             protocolName={protocolName}
           />

--- a/packages/nextjs/components/ProtocolView.tsx
+++ b/packages/nextjs/components/ProtocolView.tsx
@@ -428,11 +428,19 @@ export const ProtocolView: FC<ProtocolViewProps> = ({
           />
 
           {/* Deposit Modal for Starknet */}
-          {selectedSupplyToken && 
+          {selectedSupplyToken &&
             <DepositModalStark
               isOpen={isDepositModalOpen}
               onClose={handleCloseDepositModal}
-              token={selectedSupplyToken}
+              token={{
+                name: selectedSupplyToken.name,
+                icon: selectedSupplyToken.icon,
+                address: selectedSupplyToken.tokenAddress,
+                currentRate: selectedSupplyToken.currentRate,
+                usdPrice: selectedSupplyToken.tokenPrice
+                  ? Number(selectedSupplyToken.tokenPrice) / 1e8
+                  : 0,
+              }}
               protocolName={protocolName}
             />
           }
@@ -449,12 +457,18 @@ export const ProtocolView: FC<ProtocolViewProps> = ({
                       icon: selectedToken.icon,
                       currentRate: selectedToken.currentRate,
                       address: selectedToken.tokenAddress,
+                      usdPrice: selectedToken.tokenPrice
+                        ? Number(selectedToken.tokenPrice) / 1e8
+                        : 0,
                     }
                   : {
                       name: borrowedPositions[0]?.name || "",
                       icon: borrowedPositions[0]?.icon || "",
                       currentRate: borrowedPositions[0]?.currentRate || 0,
                       address: borrowedPositions[0]?.tokenAddress || "",
+                      usdPrice: borrowedPositions[0]?.tokenPrice
+                        ? Number(borrowedPositions[0]?.tokenPrice) / 1e8
+                        : 0,
                     }
               }
               protocolName={protocolName}
@@ -493,12 +507,18 @@ export const ProtocolView: FC<ProtocolViewProps> = ({
                       icon: selectedToken.icon,
                       address: selectedToken.tokenAddress,
                       currentRate: selectedToken.currentRate,
+                      usdPrice: selectedToken.tokenPrice
+                        ? Number(selectedToken.tokenPrice) / 1e8
+                        : 0,
                     }
                   : {
                       name: borrowedPositions[0]?.name || "",
                       icon: borrowedPositions[0]?.icon || "",
                       address: borrowedPositions[0]?.tokenAddress || "",
                       currentRate: borrowedPositions[0]?.currentRate || 0,
+                      usdPrice: borrowedPositions[0]?.tokenPrice
+                        ? Number(borrowedPositions[0]?.tokenPrice) / 1e8
+                        : 0,
                     }
               }
               protocolName={protocolName}

--- a/packages/nextjs/components/ProtocolView.tsx
+++ b/packages/nextjs/components/ProtocolView.tsx
@@ -77,6 +77,7 @@ export const ProtocolView: FC<ProtocolViewProps> = ({
     icon: string;
     address: string;
     currentRate: number;
+    tokenPrice?: bigint;
   } | null>(null);
 
   // Update showAll when forceShowAll prop changes
@@ -199,6 +200,7 @@ export const ProtocolView: FC<ProtocolViewProps> = ({
       icon: token.icon,
       address: token.tokenAddress,
       currentRate: token.currentRate,
+      tokenPrice: token.tokenPrice,
     });
     setIsTokenSelectModalOpen(false);
     setIsDepositModalOpen(true);
@@ -435,7 +437,7 @@ export const ProtocolView: FC<ProtocolViewProps> = ({
               token={{
                 name: selectedSupplyToken.name,
                 icon: selectedSupplyToken.icon,
-                address: selectedSupplyToken.tokenAddress,
+                address: selectedSupplyToken.address,
                 currentRate: selectedSupplyToken.currentRate,
                 usdPrice: selectedSupplyToken.tokenPrice
                   ? Number(selectedSupplyToken.tokenPrice) / 1e8

--- a/packages/nextjs/components/SupplyPosition.tsx
+++ b/packages/nextjs/components/SupplyPosition.tsx
@@ -37,6 +37,8 @@ export const SupplyPosition: FC<SupplyPositionProps> = ({
   const expanded = useToggle();
   const isExpanded = expanded.isOpen;
 
+  const usdPrice = tokenPrice ? Number(tokenPrice) / 1e8 : 0;
+
   // Get wallet connection status for both networks
   const { evm, starknet } = useWalletConnection();
   const address = networkType === "evm" ? evm.address : starknet.address;
@@ -270,6 +272,7 @@ export const SupplyPosition: FC<SupplyPositionProps> = ({
               icon,
               address: tokenAddress,
               currentRate,
+              usdPrice,
             }}
             protocolName={protocolName}
           />
@@ -281,6 +284,7 @@ export const SupplyPosition: FC<SupplyPositionProps> = ({
               icon,
               address: tokenAddress,
               currentRate,
+              usdPrice,
               protocolAmount: tokenBalance,
             }}
             protocolName={protocolName}
@@ -296,6 +300,7 @@ export const SupplyPosition: FC<SupplyPositionProps> = ({
               icon,
               address: tokenAddress,
               currentRate,
+              usdPrice,
             }}
             protocolName={protocolName}
           />

--- a/packages/nextjs/components/modals/BaseTokenModal.tsx
+++ b/packages/nextjs/components/modals/BaseTokenModal.tsx
@@ -12,6 +12,7 @@ export interface TokenInfo {
   icon: string;
   currentRate: number;
   address: string;
+  usdPrice?: number;
 }
 
 // Different action types supported
@@ -82,10 +83,11 @@ export const BaseTokenModal: FC<BaseTokenModalProps> = ({
 
   const formattedBalance = balance && decimals ? formatUnits(balance as bigint, decimals as number) : "0";
 
-  // Calculate USD value
+  // Calculate USD value using token price if available
   const getUsdValue = () => {
     if (!amount || isNaN(Number(amount))) return "0.00";
-    return formatDisplayNumber(Number(amount) * token.currentRate);
+    const price = token.usdPrice ?? 0;
+    return formatDisplayNumber(Number(amount) * price);
   };
 
   // Reset the state when the modal is closed

--- a/packages/nextjs/components/modals/TokenSelectModal.tsx
+++ b/packages/nextjs/components/modals/TokenSelectModal.tsx
@@ -141,6 +141,7 @@ export const TokenSelectModal: FC<TokenSelectModalProps> = ({
               icon: selectedToken.icon,
               currentRate: selectedToken.currentRate,
               address: selectedToken.tokenAddress,
+              usdPrice: selectedToken.tokenPrice ? Number(selectedToken.tokenPrice) / 1e8 : 0,
             }}
             protocolName={protocolName}
           />
@@ -153,6 +154,7 @@ export const TokenSelectModal: FC<TokenSelectModalProps> = ({
               icon: selectedToken.icon,
               currentRate: selectedToken.currentRate,
               address: selectedToken.tokenAddress,
+              usdPrice: selectedToken.tokenPrice ? Number(selectedToken.tokenPrice) / 1e8 : 0,
             }}
             protocolName={protocolName}
           />

--- a/packages/nextjs/components/modals/stark/BaseTokenModal.tsx
+++ b/packages/nextjs/components/modals/stark/BaseTokenModal.tsx
@@ -38,6 +38,7 @@ export interface TokenInfo {
   currentRate: number;
   address: string;
   protocolAmount?: bigint; // Add protocol balance/debt amount for withdraw/repay actions
+  usdPrice?: number;
 }
 
 export interface VesuContext {
@@ -289,10 +290,11 @@ export const BaseTokenModal: FC<BaseTokenModalProps> = ({
 
   const { sendAsync } = useScaffoldMultiWriteContract({ calls });
 
-  // Calculate USD value
+  // Calculate USD value using token price if available
   const getUsdValue = () => {
     if (!amount || isNaN(Number(amount))) return "0.00";
-    return formatDisplayNumber(Number(amount) * token.currentRate);
+    const price = token.usdPrice ?? 0;
+    return formatDisplayNumber(Number(amount) * price);
   };
 
   // Reset the state when the modal is closed

--- a/packages/nextjs/components/modals/stark/BorrowModalStark.tsx
+++ b/packages/nextjs/components/modals/stark/BorrowModalStark.tsx
@@ -12,6 +12,7 @@ interface BorrowModalStarkProps {
     icon: string;
     address: string;
     currentRate: number;
+    usdPrice?: number;
   };
   protocolName: string;
   supportedAssets?: TokenMetadata[];

--- a/packages/nextjs/components/modals/stark/DepositModalStark.tsx
+++ b/packages/nextjs/components/modals/stark/DepositModalStark.tsx
@@ -9,6 +9,7 @@ interface DepositModalStarkProps {
     icon: string;
     address: string;
     currentRate: number;
+    usdPrice?: number;
   };
   protocolName: string;
   vesuContext?: {

--- a/packages/nextjs/components/modals/stark/RepayModalStark.tsx
+++ b/packages/nextjs/components/modals/stark/RepayModalStark.tsx
@@ -10,6 +10,7 @@ interface RepayModalStarkProps {
     address: string;
     currentRate: number;
     protocolAmount?: bigint;
+    usdPrice?: number;
   };
   protocolName: string;
   vesuContext?: {

--- a/packages/nextjs/components/modals/stark/TokenSelectModalStark.tsx
+++ b/packages/nextjs/components/modals/stark/TokenSelectModalStark.tsx
@@ -151,6 +151,10 @@ export const TokenSelectModalStark: FC<TokenSelectModalStarkProps> = ({
             icon: tokenNameToLogo(feltToString(selectedToken.symbol).toLowerCase()),
             address: `0x${BigInt(selectedToken.address).toString(16).padStart(64, "0")}`,
             currentRate: selectedToken.borrowAPR ? selectedToken.borrowAPR * 100 : 0,
+            usdPrice:
+              selectedToken.price && selectedToken.price.is_valid
+                ? Number(selectedToken.price.value) / 1e18
+                : 0,
           }}
           protocolName={protocolName}
           supportedAssets={tokens}

--- a/packages/nextjs/components/modals/stark/WithdrawModalStark.tsx
+++ b/packages/nextjs/components/modals/stark/WithdrawModalStark.tsx
@@ -10,6 +10,7 @@ interface WithdrawModalStarkProps {
     address: string;
     currentRate: number;
     protocolAmount?: bigint;
+    usdPrice?: number;
   };
   protocolName: string;
   vesuContext?: {

--- a/packages/nextjs/components/specific/vesu/VesuPosition.tsx
+++ b/packages/nextjs/components/specific/vesu/VesuPosition.tsx
@@ -93,6 +93,15 @@ export const VesuPosition: FC<VesuPositionProps> = ({
     asset => `0x${BigInt(asset.address).toString(16).padStart(64, "0")}` === debtAsset,
   );
 
+  const collateralUsdPrice =
+    collateralMetadata && collateralMetadata.price && collateralMetadata.price.is_valid
+      ? Number(collateralMetadata.price.value) / 1e18
+      : 0;
+  const debtUsdPrice =
+    debtMetadata && debtMetadata.price && debtMetadata.price.is_valid
+      ? Number(debtMetadata.price.value) / 1e18
+      : 0;
+
   if (!collateralMetadata) {
     console.error("Collateral metadata not found for asset:", collateralAsset);
     return null;
@@ -292,6 +301,7 @@ export const VesuPosition: FC<VesuPositionProps> = ({
           icon: tokenNameToLogo(collateralSymbol.toLowerCase()),
           address: collateralAsset,
           currentRate: collateralRates.supplyAPY * 100,
+          usdPrice: collateralUsdPrice,
         }}
         protocolName="Vesu"
         vesuContext={{
@@ -309,6 +319,7 @@ export const VesuPosition: FC<VesuPositionProps> = ({
           address: collateralAsset,
           currentRate: collateralRates.supplyAPY * 100,
           protocolAmount: BigInt(collateralAmount),
+          usdPrice: collateralUsdPrice,
         }}
         protocolName="Vesu"
         vesuContext={{
@@ -335,16 +346,17 @@ export const VesuPosition: FC<VesuPositionProps> = ({
           <BorrowModalStark
             isOpen={isBorrowModalOpen}
             onClose={() => setIsBorrowModalOpen(false)}
-            token={{
-              name: debtSymbol,
-              icon: tokenNameToLogo(debtSymbol.toLowerCase()),
-              address: debtAsset,
-              currentRate: debtRates.borrowAPR * 100,
-            }}
-            protocolName="Vesu"
-            supportedAssets={supportedAssets}
-            isVesu={true}
-            vesuContext={{
+          token={{
+            name: debtSymbol,
+            icon: tokenNameToLogo(debtSymbol.toLowerCase()),
+            address: debtAsset,
+            currentRate: debtRates.borrowAPR * 100,
+            usdPrice: debtUsdPrice,
+          }}
+          protocolName="Vesu"
+          supportedAssets={supportedAssets}
+          isVesu={true}
+          vesuContext={{
               pool_id: 0n,
               counterpart_token: collateralAsset,
             }}
@@ -353,17 +365,18 @@ export const VesuPosition: FC<VesuPositionProps> = ({
           <RepayModalStark
             isOpen={isRepayModalOpen}
             onClose={() => setIsRepayModalOpen(false)}
-            token={{
-              name: debtSymbol,
-              icon: tokenNameToLogo(debtSymbol.toLowerCase()),
-              address: debtAsset,
-              currentRate: debtRates.borrowAPR * 100,
-              protocolAmount: BigInt(nominalDebt),
-            }}
-            protocolName="Vesu"
-            vesuContext={{
-              pool_id: 0n,
-              counterpart_token: collateralAsset,
+          token={{
+            name: debtSymbol,
+            icon: tokenNameToLogo(debtSymbol.toLowerCase()),
+            address: debtAsset,
+            currentRate: debtRates.borrowAPR * 100,
+            protocolAmount: BigInt(nominalDebt),
+            usdPrice: debtUsdPrice,
+          }}
+          protocolName="Vesu"
+          vesuContext={{
+            pool_id: 0n,
+            counterpart_token: collateralAsset,
             }}
           />
 


### PR DESCRIPTION
## Summary
- use token usd price in BaseTokenModal for accurate USD badge
- plumb usdPrice through borrow/supply positions and token select modals

## Testing
- `yarn next:check-types` (fails: Cannot find module '@starknet-react/chains')
- `yarn lint` (fails: Couldn't find a script named "nextjs:lint")
- `yarn next:lint` (fails: command not found: next)
- `yarn hardhat:lint`
- `yarn test` (fails: command not found: hardhat)


------
https://chatgpt.com/codex/tasks/task_e_68b1b318961483209cb8ef27ba00f9bb