### PR TITLE
refactor: centralize protocol helpers and visibility logic

### DIFF
--- a/packages/nextjs/components/BorrowPosition.tsx
+++ b/packages/nextjs/components/BorrowPosition.tsx
@@ -8,8 +8,9 @@ import { RepayModal } from "./modals/RepayModal";
 import { BorrowModalStark } from "./modals/stark/BorrowModalStark";
 import { MovePositionModal as MovePositionModalStark } from "./modals/stark/MovePositionModal";
 import { RepayModalStark } from "./modals/stark/RepayModalStark";
-import { FiChevronDown, FiChevronUp, FiInfo, FiMinus, FiPlus, FiRepeat } from "react-icons/fi";
-import { tokenNameToLogo } from "~~/contracts/externalContracts";
+import { FiChevronDown, FiChevronUp, FiMinus, FiPlus, FiRepeat } from "react-icons/fi";
+import { InfoDropdown } from "./InfoDropdown";
+import { getProtocolLogo } from "~~/utils/protocol";
 import { useWalletConnection } from "~~/hooks/useWalletConnection";
 import { useOptimalRate } from "~~/hooks/useOptimalRate";
 import { useModal, useToggle } from "~~/hooks/useModal";
@@ -58,14 +59,6 @@ export const BorrowPosition: FC<BorrowPositionProps> = ({
     type: "borrow",
   });
 
-  const formatNumber = (num: number) =>
-    new Intl.NumberFormat("en-US", {
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
-    }).format(Math.abs(num));
-
-  const getProtocolLogo = (protocol: string) => tokenNameToLogo(protocol);
-
   // Toggle expanded state
   const toggleExpanded = (e: React.MouseEvent) => {
     // Don't expand if clicking on the info button or its dropdown
@@ -97,54 +90,28 @@ export const BorrowPosition: FC<BorrowPositionProps> = ({
               <Image src={icon} alt={`${name} icon`} layout="fill" className="rounded-full" />
             </div>
             <span className="ml-2 font-semibold text-lg truncate">{name}</span>
-            <div
-              className="dropdown dropdown-end dropdown-bottom flex-shrink-0 ml-1"
-              onClick={e => e.stopPropagation()}
+            <InfoDropdown
+              name={name}
+              tokenAddress={tokenAddress}
+              protocolName={protocolName}
+              positionType="Borrow Position"
             >
-              <div tabIndex={0} role="button" className="cursor-pointer flex items-center justify-center h-[1.125em]">
-                <FiInfo
-                  className="w-4 h-4 text-base-content/50 hover:text-base-content/80 transition-colors"
-                  aria-hidden="true"
-                />
-              </div>
-              <div
-                tabIndex={0}
-                className="dropdown-content z-[1] card card-compact p-2 shadow bg-base-100 w-64 max-w-[90vw]"
-                style={{
-                  right: "auto",
-                  transform: "translateX(-50%)",
-                  left: "50%",
-                  borderRadius: "4px",
-                }}
-              >
-                <div className="card-body p-3">
-                  <h3 className="card-title text-sm">{name} Details</h3>
-                  <div className="text-xs space-y-1">
-                    <p className="text-base-content/70">Contract Address:</p>
-                    <p className="font-mono break-all">{tokenAddress}</p>
-                    <p className="text-base-content/70">Protocol:</p>
-                    <p>{protocolName}</p>
-                    <p className="text-base-content/70">Type:</p>
-                    <p className="capitalize">Borrow Position</p>
-                    {collateralValue && (
-                      <>
-                        <p className="text-base-content/70">Collateral Value:</p>
-                        <p>
-                          <FiatBalance
-                            tokenAddress={tokenAddress}
-                            rawValue={BigInt(Math.round(collateralValue * 10 ** 8))}
-                            price={BigInt(10 ** 8)}
-                            decimals={8}
-                            tokenSymbol={name}
-                            isNegative={false}
-                          />
-                        </p>
-                      </>
-                    )}
-                  </div>
-                </div>
-              </div>
-            </div>
+              {collateralValue && (
+                <>
+                  <p className="text-base-content/70">Collateral Value:</p>
+                  <p>
+                    <FiatBalance
+                      tokenAddress={tokenAddress}
+                      rawValue={BigInt(Math.round(collateralValue * 10 ** 8))}
+                      price={BigInt(10 ** 8)}
+                      decimals={8}
+                      tokenSymbol={name}
+                      isNegative={false}
+                    />
+                  </p>
+                </>
+              )}
+            </InfoDropdown>
           </div>
 
           {/* Stats: Rates */}

--- a/packages/nextjs/components/InfoDropdown.tsx
+++ b/packages/nextjs/components/InfoDropdown.tsx
@@ -1,0 +1,49 @@
+import { FC } from "react";
+import { FiInfo } from "react-icons/fi";
+
+interface InfoDropdownProps {
+  name: string;
+  tokenAddress: string;
+  protocolName: string;
+  positionType: string;
+  children?: React.ReactNode;
+}
+
+export const InfoDropdown: FC<InfoDropdownProps> = ({
+  name,
+  tokenAddress,
+  protocolName,
+  positionType,
+  children,
+}) => (
+  <div className="dropdown dropdown-end dropdown-bottom flex-shrink-0 ml-1" onClick={e => e.stopPropagation()}>
+    <div tabIndex={0} role="button" className="cursor-pointer flex items-center justify-center h-[1.125em]">
+      <FiInfo className="w-4 h-4 text-base-content/50 hover:text-base-content/80 transition-colors" aria-hidden="true" />
+    </div>
+    <div
+      tabIndex={0}
+      className="dropdown-content z-[1] card card-compact p-2 shadow bg-base-100 w-64 max-w-[90vw]"
+      style={{
+        right: "auto",
+        transform: "translateX(-50%)",
+        left: "50%",
+        borderRadius: "4px",
+      }}
+    >
+      <div className="card-body p-3">
+        <h3 className="card-title text-sm">{name} Details</h3>
+        <div className="text-xs space-y-1">
+          <p className="text-base-content/70">Contract Address:</p>
+          <p className="font-mono break-all">{tokenAddress}</p>
+          <p className="text-base-content/70">Protocol:</p>
+          <p>{protocolName}</p>
+          <p className="text-base-content/70">Type:</p>
+          <p className="capitalize">{positionType}</p>
+          {children}
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+export default InfoDropdown;

--- a/packages/nextjs/components/ProtocolView.tsx
+++ b/packages/nextjs/components/ProtocolView.tsx
@@ -140,9 +140,6 @@ export const ProtocolView: FC<ProtocolViewProps> = ({
     ? borrowedPositions // Show all potential borrowable tokens
     : borrowedPositions.filter(p => p.balance < 0); // Only show positions with debt
 
-  // Assuming tokenNameToLogo is defined elsewhere, we use a fallback here.
-  const getProtocolLogo = (protocol: string) => `/logos/${protocol.toLowerCase()}-logo.svg`;
-
   // Handle opening the token select modal for supply
   const handleAddSupply = () => {
     setIsTokenSelectModalOpen(true);

--- a/packages/nextjs/components/SupplyPosition.tsx
+++ b/packages/nextjs/components/SupplyPosition.tsx
@@ -6,8 +6,9 @@ import { DepositModal } from "./modals/DepositModal";
 import { DepositModalStark } from "./modals/stark/DepositModalStark";
 import { WithdrawModalStark } from "./modals/stark/WithdrawModalStark";
 import { MoveSupplyModal } from "./modals/MoveSupplyModal";
-import { FiChevronDown, FiChevronUp, FiInfo } from "react-icons/fi";
-import { tokenNameToLogo } from "~~/contracts/externalContracts";
+import { FiChevronDown, FiChevronUp } from "react-icons/fi";
+import { InfoDropdown } from "./InfoDropdown";
+import { getProtocolLogo } from "~~/utils/protocol";
 import { useWalletConnection } from "~~/hooks/useWalletConnection";
 import { useOptimalRate } from "~~/hooks/useOptimalRate";
 import { useModal, useToggle } from "~~/hooks/useModal";
@@ -54,14 +55,6 @@ export const SupplyPosition: FC<SupplyPositionProps> = ({
     type: "supply",
   });
 
-  const formatNumber = (num: number) =>
-    new Intl.NumberFormat("en-US", {
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
-    }).format(Math.abs(num));
-
-  const getProtocolLogo = (protocol: string) => tokenNameToLogo(protocol);
-
   // Toggle expanded state
   const toggleExpanded = (e: React.MouseEvent) => {
     // Don't expand if clicking on the info button or its dropdown
@@ -85,39 +78,12 @@ export const SupplyPosition: FC<SupplyPositionProps> = ({
               <Image src={icon} alt={`${name} icon`} layout="fill" className="rounded-full" />
             </div>
             <span className="ml-2 font-semibold text-lg truncate">{name}</span>
-            <div
-              className="dropdown dropdown-end dropdown-bottom flex-shrink-0 ml-1"
-              onClick={e => e.stopPropagation()}
-            >
-              <div tabIndex={0} role="button" className="cursor-pointer flex items-center justify-center h-[1.125em]">
-                <FiInfo
-                  className="w-4 h-4 text-base-content/50 hover:text-base-content/80 transition-colors"
-                  aria-hidden="true"
-                />
-              </div>
-              <div
-                tabIndex={0}
-                className="dropdown-content z-[1] card card-compact p-2 shadow bg-base-100 w-64 max-w-[90vw]"
-                style={{
-                  right: "auto",
-                  transform: "translateX(-50%)",
-                  left: "50%",
-                  borderRadius: "4px",
-                }}
-              >
-                <div className="card-body p-3">
-                  <h3 className="card-title text-sm">{name} Details</h3>
-                  <div className="text-xs space-y-1">
-                    <p className="text-base-content/70">Contract Address:</p>
-                    <p className="font-mono break-all">{tokenAddress}</p>
-                    <p className="text-base-content/70">Protocol:</p>
-                    <p>{protocolName}</p>
-                    <p className="text-base-content/70">Type:</p>
-                    <p className="capitalize">Supply Position</p>
-                  </div>
-                </div>
-              </div>
-            </div>
+            <InfoDropdown
+              name={name}
+              tokenAddress={tokenAddress}
+              protocolName={protocolName}
+              positionType="Supply Position"
+            />
 
             {/* Render additional content after the info button if provided */}
             {afterInfoContent && <div onClick={e => e.stopPropagation()}>{afterInfoContent}</div>}

--- a/packages/nextjs/components/specific/aave/AaveProtocolView.tsx
+++ b/packages/nextjs/components/specific/aave/AaveProtocolView.tsx
@@ -1,44 +1,22 @@
-import { FC, useMemo, useState, useEffect } from "react";
+import { FC, useMemo } from "react";
 import { ProtocolPosition, ProtocolView } from "../../ProtocolView";
-import { formatUnits } from "viem";
 import { useAccount } from "wagmi";
-import { tokenNameToLogo } from "~~/contracts/externalContracts";
 import { useDeployedContractInfo } from "~~/hooks/scaffold-eth";
 import { useNetworkAwareReadContract } from "~~/hooks/useNetworkAwareReadContract";
+import { useForceShowAll } from "~~/hooks/useForceShowAll";
+import { buildProtocolPositions, convertAaveRate, TokenPositionInput } from "~~/utils/positions";
 
 export const AaveProtocolView: FC = () => {
-  const { address: connectedAddress } = useAccount();
-  
+  const { address: connectedAddress, isConnected } = useAccount();
+
   // Get the AaveGateway contract info to use its address as a fallback
   const { data: contractInfo } = useDeployedContractInfo({ contractName: "AaveGateway" });
-  
-  // State to track if we should force showing all assets when wallet is not connected
-  const [forceShowAll, setForceShowAll] = useState(false);
-  
+
+  // Determine if we should force showing all assets when wallet is not connected
+  const forceShowAll = useForceShowAll(isConnected);
+
   // Determine the address to use for queries - use contract's own address as fallback
   const queryAddress = connectedAddress || contractInfo?.address;
-  
-  // Update forceShowAll when wallet connection status changes with a delay
-  useEffect(() => {
-    // If wallet is connected, immediately set forceShowAll to false
-    if (connectedAddress) {
-      setForceShowAll(false);
-      return;
-    }
-    
-    // If wallet is not connected, wait a bit before forcing show all
-    // This gives time for wallet to connect during initial page load
-    const timeout = setTimeout(() => {
-      if (!connectedAddress) {
-        setForceShowAll(true);
-      }
-    }, 2500); // Wait 2.5 seconds before deciding wallet is not connected
-    
-    return () => clearTimeout(timeout);
-  }, [connectedAddress]);
-
-  // Helper: Convert Aave RAY (1e27) rates to APY percentage.
-  const convertRateToAPY = (rate: bigint): number => Number(rate) / 1e25;
 
   // Get all token info, including supply and borrow balances, using query address
   const { data: allTokensInfo } = useNetworkAwareReadContract({
@@ -50,51 +28,28 @@ export const AaveProtocolView: FC = () => {
 
   // Aggregate positions by iterating over the returned tokens.
   const { suppliedPositions, borrowedPositions } = useMemo(() => {
-    const supplied: ProtocolPosition[] = [];
-    const borrowed: ProtocolPosition[] = [];
+    if (!allTokensInfo) {
+      return { suppliedPositions: [] as ProtocolPosition[], borrowedPositions: [] as ProtocolPosition[] };
+    }
 
-    if (!allTokensInfo) return { suppliedPositions: supplied, borrowedPositions: borrowed };
-
-    allTokensInfo.forEach((token: any) => {
+    const tokens: TokenPositionInput[] = allTokensInfo.map((token: any) => {
       let decimals = 18;
       if (token.symbol === "USDC" || token.symbol === "USD₮0" || token.symbol === "USDC.e") {
         decimals = 6;
       }
-
-      const supplyAPY = convertRateToAPY(token.supplyRate);
-      const borrowAPY = convertRateToAPY(token.borrowRate);
-      const tokenPrice = Number(formatUnits(token.price, 8));
-
-      // Add supply position
-      const supplyBalance = token.balance ? Number(formatUnits(token.balance, decimals)) : 0;
-      const supplyUsdBalance = supplyBalance * tokenPrice;
-      supplied.push({
-        icon: tokenNameToLogo(token.symbol),
-        name: token.symbol,
-        balance: supplyUsdBalance,
-        tokenBalance: token.balance,
-        currentRate: supplyAPY,
-        tokenAddress: token.token,
-        tokenPrice: token.price,
-        tokenSymbol: token.symbol,
-      });
-
-      // Add borrow position
-      const borrowBalance = token.borrowBalance ? Number(formatUnits(token.borrowBalance, decimals)) : 0;
-      const borrowUsdBalance = borrowBalance * tokenPrice;
-      borrowed.push({
-        icon: tokenNameToLogo(token.symbol),
-        name: token.symbol,
-        balance: -borrowUsdBalance,
-        tokenBalance: token.borrowBalance,
-        currentRate: borrowAPY,
-        tokenAddress: token.token,
-        tokenPrice: token.price,
-        tokenSymbol: token.symbol,
-      });
+      return {
+        symbol: token.symbol,
+        token: token.token,
+        balance: token.balance,
+        borrowBalance: token.borrowBalance,
+        supplyRate: token.supplyRate,
+        borrowRate: token.borrowRate,
+        price: token.price,
+        decimals,
+      } as TokenPositionInput;
     });
 
-    return { suppliedPositions: supplied, borrowedPositions: borrowed };
+    return buildProtocolPositions(tokens, convertAaveRate);
   }, [allTokensInfo]);
 
   return (

--- a/packages/nextjs/components/specific/nostra/NostraProtocolView.tsx
+++ b/packages/nextjs/components/specific/nostra/NostraProtocolView.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useMemo, useState } from "react";
+import { FC, useMemo } from "react";
 import { ProtocolPosition, ProtocolView } from "../../ProtocolView";
 import { formatUnits } from "viem";
 import { tokenNameToLogo } from "~~/contracts/externalContracts";
@@ -7,6 +7,7 @@ import { useAccount } from "~~/hooks/useAccount";
 import { useNetworkAwareReadContract } from "~~/hooks/useNetworkAwareReadContract";
 import { feltToString } from "~~/utils/protocols";
 import { ContractName } from "~~/utils/scaffold-stark/contract";
+import { useForceShowAll } from "~~/hooks/useForceShowAll";
 
 type UserPositionTuple = {
   0: bigint; // underlying token address
@@ -24,9 +25,9 @@ type InterestState = {
 };
 
 export const NostraProtocolView: FC = () => {
-  const { address: connectedAddress } = useAccount();
-  // State to track if we should force showing all assets when wallet is not connected
-  const [forceShowAll, setForceShowAll] = useState(false);
+  const { address: connectedAddress, isConnected } = useAccount();
+  // Determine if we should force showing all assets when wallet is not connected
+  const forceShowAll = useForceShowAll(isConnected);
 
   // Determine the address to use for queries - use contract's own address as fallback
   const queryAddress = connectedAddress;

--- a/packages/nextjs/components/specific/venus/VenusProtocolView.tsx
+++ b/packages/nextjs/components/specific/venus/VenusProtocolView.tsx
@@ -24,7 +24,7 @@
  * 4. Allow users to supply, borrow, repay, and migrate debt between protocols
  */
 
-import { FC, useMemo, useState, useEffect } from "react";
+import { FC, useMemo } from "react";
 import { ProtocolPosition, ProtocolView } from "../../ProtocolView";
 import { SupplyPositionProps } from "../../SupplyPosition";
 import { VenusMarketEntry } from "./VenusMarketEntry";
@@ -32,12 +32,13 @@ import { useScaffoldContract, useScaffoldReadContract } from "~~/hooks/scaffold-
 import { formatUnits } from "viem";
 import { useAccount } from "wagmi";
 import { tokenNameToLogo } from "~~/contracts/externalContracts";
+import { useForceShowAll } from "~~/hooks/useForceShowAll";
 
 // Create a Venus supply position type
 type VenusSupplyPosition = SupplyPositionProps;
 
 export const VenusProtocolView: FC = () => {
-  const { address: connectedAddress } = useAccount();
+  const { address: connectedAddress, isConnected } = useAccount();
   const { data: venusGatewayContract } = useScaffoldContract({ contractName: "VenusGateway" });
   
   // Get Comptroller address from VenusGateway
@@ -46,27 +47,8 @@ export const VenusProtocolView: FC = () => {
     functionName: "comptroller",
   });
   
-  // State to track if we should force showing all assets when wallet is not connected
-  const [forceShowAll, setForceShowAll] = useState(false);
-  
-  // Update forceShowAll when wallet connection status changes with a delay
-  useEffect(() => {
-    // If wallet is connected, immediately set forceShowAll to false
-    if (connectedAddress) {
-      setForceShowAll(false);
-      return;
-    }
-    
-    // If wallet is not connected, wait a bit before forcing show all
-    // This gives time for wallet to connect during initial page load
-    const timeout = setTimeout(() => {
-      if (!connectedAddress) {
-        setForceShowAll(true);
-      }
-    }, 2500); // Wait 2.5 seconds before deciding wallet is not connected
-    
-    return () => clearTimeout(timeout);
-  }, [connectedAddress]);
+  // Determine if we should force showing all assets when wallet is not connected
+  const forceShowAll = useForceShowAll(isConnected);
 
   // Helper: Convert Venus rates to APY percentage
   // Venus uses rates per block, so we need to convert to annual rates

--- a/packages/nextjs/components/specific/vesu/MarketRow.tsx
+++ b/packages/nextjs/components/specific/vesu/MarketRow.tsx
@@ -2,7 +2,7 @@ import { FC, useState } from "react";
 import Image from "next/image";
 import { DepositModalStark } from "~~/components/modals/stark/DepositModalStark";
 import { useNetworkAwareReadContract } from "~~/hooks/useNetworkAwareReadContract";
-import { tokenNameToLogo } from "~~/contracts/externalContracts";
+import { getProtocolLogo } from "~~/utils/protocol";
 import { feltToString } from "~~/utils/protocols";
 
 type MarketRowProps = {
@@ -76,8 +76,6 @@ export const MarketRow: FC<MarketRowProps> = ({
     optimalBorrowProtocol = proto;
     optimalBorrowRateDisplay = Number(rate) / 1e8;
   }
-
-  const getProtocolLogo = (protocol: string) => tokenNameToLogo(protocol);
 
   return (
     <>

--- a/packages/nextjs/hooks/useForceShowAll.ts
+++ b/packages/nextjs/hooks/useForceShowAll.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Determines whether protocol views should display all assets when no wallet is connected.
+ * This avoids using timeouts that can cause layout shifts on mobile devices.
+ *
+ * @param isConnected - Wallet connection status
+ * @returns Boolean indicating if the view should force showing all assets
+ */
+export const useForceShowAll = (isConnected?: boolean): boolean => {
+  const [forceShowAll, setForceShowAll] = useState(!isConnected);
+
+  useEffect(() => {
+    setForceShowAll(!isConnected);
+  }, [isConnected]);
+
+  return forceShowAll;
+};
+
+export default useForceShowAll;

--- a/packages/nextjs/utils/positions.ts
+++ b/packages/nextjs/utils/positions.ts
@@ -1,0 +1,69 @@
+import { ReactNode } from "react";
+import { formatUnits } from "viem";
+import { tokenNameToLogo } from "~~/contracts/externalContracts";
+import { ProtocolPosition } from "~~/components/ProtocolView";
+
+export interface TokenPositionInput {
+  symbol: string;
+  token: string;
+  balance?: bigint;
+  borrowBalance?: bigint;
+  supplyRate?: bigint;
+  borrowRate?: bigint;
+  price: bigint;
+  decimals: number;
+  collateralView?: ReactNode;
+}
+
+/**
+ * Builds supplied and borrowed protocol positions from raw token data.
+ */
+export const buildProtocolPositions = (
+  tokens: TokenPositionInput[],
+  convertRate: (rate: bigint) => number,
+): { suppliedPositions: ProtocolPosition[]; borrowedPositions: ProtocolPosition[] } => {
+  const supplied: ProtocolPosition[] = [];
+  const borrowed: ProtocolPosition[] = [];
+
+  tokens.forEach(token => {
+    const tokenPrice = Number(formatUnits(token.price, 8));
+    const balance = token.balance ? Number(formatUnits(token.balance, token.decimals)) : 0;
+    const borrowBalance = token.borrowBalance ? Number(formatUnits(token.borrowBalance, token.decimals)) : 0;
+
+    supplied.push({
+      icon: tokenNameToLogo(token.symbol),
+      name: token.symbol,
+      balance: balance * tokenPrice,
+      tokenBalance: token.balance || 0n,
+      currentRate: token.supplyRate ? convertRate(token.supplyRate) : 0,
+      tokenAddress: token.token,
+      tokenPrice: token.price,
+      tokenDecimals: token.decimals,
+      tokenSymbol: token.symbol,
+    });
+
+    borrowed.push({
+      icon: tokenNameToLogo(token.symbol),
+      name: token.symbol,
+      balance: -(borrowBalance * tokenPrice),
+      tokenBalance: token.borrowBalance || 0n,
+      currentRate: token.borrowRate ? convertRate(token.borrowRate) : 0,
+      tokenAddress: token.token,
+      tokenPrice: token.price,
+      tokenDecimals: token.decimals,
+      tokenSymbol: token.symbol,
+      collateralView: token.collateralView,
+    });
+  });
+
+  return { suppliedPositions: supplied, borrowedPositions: borrowed };
+};
+
+// Specific rate converters for various protocols
+export const convertAaveRate = (rate: bigint): number => Number(rate) / 1e25;
+
+export const convertCompoundRate = (ratePerSecond: bigint): number => {
+  const SECONDS_PER_YEAR = 60 * 60 * 24 * 365;
+  const SCALE = 1e18;
+  return (Number(ratePerSecond) * SECONDS_PER_YEAR * 100) / SCALE;
+};


### PR DESCRIPTION
## Summary
- DRY up protocol card details with a new `InfoDropdown` component
- Centralize protocol logo lookup and rate conversions
- Replace ad‑hoc `forceShowAll` logic with `useForceShowAll` hook

## Testing
- `yarn lint` *(fails: command not found: next)*
- `yarn check-types` *(fails: Cannot find module '@starknet-react/chains', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b1bc0b21088320b7298b1dea48408c