### PR TITLE
Refine UI spacing and theme colors

### DIFF
--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -222,7 +222,7 @@ export const Header = () => {
                               />
                             </div>
                             <div>
-                              <div className="font-bold text-xl text-primary dark:text-accent">Kapan Finance</div>
+                              <div className="font-serif font-semibold text-xl text-base-content">Kapan Finance</div>
                               <div className="text-xs text-base-content/60">Lending Made Easy</div>
                             </div>
                           </div>
@@ -284,7 +284,7 @@ export const Header = () => {
                   </div>
                 </div>
                 <div className={`ml-2 transition-all duration-300 ${scrolled ? "scale-95" : ""}`}>
-                  <div className="font-bold text-lg text-primary dark:text-accent">Kapan Finance</div>
+                  <div className="font-serif font-semibold text-lg text-base-content">Kapan Finance</div>
                   <div className="text-[10px] text-base-content/60 -mt-1">Lending Made Easy</div>
                 </div>
               </div>

--- a/packages/nextjs/components/specific/vesu/VesuPosition.tsx
+++ b/packages/nextjs/components/specific/vesu/VesuPosition.tsx
@@ -195,9 +195,10 @@ export const VesuPosition: FC<VesuPositionProps> = ({
                     {(collateralRates.supplyAPY * 100).toFixed(3)}%
                   </span>
                 </div>
-                <div className="flex justify-between">
-                  <span className="text-sm text-gray-500">Monthly yield</span>
-                  <span className="text-sm font-medium">${(Number(monthlyYield) / 1e18).toFixed(3)}</span>
+                <div className="flex justify-end">
+                  <span className="text-sm font-medium">
+                    ${(Number(monthlyYield) / 1e18).toFixed(3)} per month
+                  </span>
                 </div>
               </div>
             </div>

--- a/packages/nextjs/styles/globals.css
+++ b/packages/nextjs/styles/globals.css
@@ -82,3 +82,11 @@ p {
 .animate-fadeIn {
   animation: fadeIn 0.5s ease-out forwards;
 }
+
+/* Ensure ETH logos match other token icon sizes */
+img[src$="/logos/eth.svg"],
+img[src$="/logos/ethereum.svg"] {
+  width: 1rem;
+  height: 1rem;
+  object-fit: contain;
+}

--- a/packages/nextjs/tailwind.config.js
+++ b/packages/nextjs/tailwind.config.js
@@ -26,9 +26,9 @@ module.exports = {
           "base-300": "#E2E8F0",
           "base-content": "#1F2937",
           info: "#3ABFF8",
-          success: "#34D399",
+          success: "#3B82F6",
           warning: "#FBBF24",
-          error: "#FB7185",
+          error: "#F97316",
           "--rounded-btn": "0.375rem",
           ".tooltip": { "--tooltip-tail": "6px" },
           ".link": { textUnderlineOffset: "2px" },
@@ -62,9 +62,9 @@ module.exports = {
 
           // Retain some dynamic colors:
           info: "#0FF0FC",
-          success: "#34D399",
+          success: "#3B82F6",
           warning: "#FFCF72",
-          error: "#FF8863",
+          error: "#F97316",
 
           "--rounded-btn": "0.375rem",
           ".tooltip": {


### PR DESCRIPTION
## Summary
- present monthly yield as `$X per month` for Vesu positions
- normalize ETH logo sizing across the app
- swap out green/red balance colors for blue/orange and refresh header styling

## Testing
- `node_modules/.bin/next build`

------
https://chatgpt.com/codex/tasks/task_e_68b1cd9900e48320a818197a47f73c2c