### PR TITLE
Fix pair instructions for Vesu migrations

### DIFF
--- a/packages/nextjs/components/modals/stark/MovePositionModal.tsx
+++ b/packages/nextjs/components/modals/stark/MovePositionModal.tsx
@@ -596,7 +596,13 @@ export const MovePositionModal: FC<MovePositionModalProps> = ({
     return {
       fullInstruction: fullInstructionData,
       authInstruction: authInstructionData,
-      pairInstructions: instructions,
+      // Wrap instructions in an array so that callers always
+      // receive a list of instruction pairs. This ensures we
+      // execute a single move_debt call when moving between
+      // Vesu and Nostra while still supporting multiple calls
+      // for scenarios that require it (e.g. Nostra -> Vesu with
+      // several collaterals).
+      pairInstructions: [instructions],
     };
   }, [amount, userAddress, routerGateway?.address, position.decimals, position.tokenAddress, fromProtocol, selectedProtocol, selectedCollateralsWithAmounts, isAmountMaxClicked, tokenToPrices, maxClickedCollaterals, currentPoolId, selectedPoolId]);
 


### PR DESCRIPTION
## Summary
- ensure `pairInstructions` wraps single instruction sets so move_debt receives a proper pair

## Testing
- `yarn lint`
- `yarn test` *(fails: command not found: hardhat)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d71b2cfc8320a0e1073d6c8d835b