### PR TITLE
fix: memoize wagmi connectors

### DIFF
--- a/packages/nextjs/services/web3/wagmiConfig.tsx
+++ b/packages/nextjs/services/web3/wagmiConfig.tsx
@@ -1,4 +1,4 @@
-import { wagmiConnectors } from "./wagmiConnectors";
+import { getWagmiConnectors } from "./wagmiConnectors";
 import { Chain, createClient, fallback, http } from "viem";
 import { hardhat, mainnet } from "viem/chains";
 import { createConfig } from "wagmi";
@@ -14,7 +14,7 @@ export const enabledChains = targetNetworks.find((network: Chain) => network.id 
 
 export const wagmiConfig = createConfig({
   chains: enabledChains,
-  connectors: wagmiConnectors,
+  connectors: getWagmiConnectors(),
   multiInjectedProviderDiscovery: false,
   ssr: true,
   client({ chain }) {

--- a/packages/nextjs/services/web3/wagmiConnectors.tsx
+++ b/packages/nextjs/services/web3/wagmiConnectors.tsx
@@ -34,6 +34,10 @@ declare global {
  * Returns wagmi connectors, initializing them only once.
  */
 export function getWagmiConnectors() {
+  if (typeof window === "undefined") {
+    return [] as ReturnType<typeof connectorsForWallets>;
+  }
+
   if (!globalThis.wagmiConnectors) {
     globalThis.wagmiConnectors = connectorsForWallets(
       [

--- a/packages/nextjs/services/web3/wagmiConnectors.tsx
+++ b/packages/nextjs/services/web3/wagmiConnectors.tsx
@@ -25,19 +25,26 @@ const wallets = [
     : []),
 ];
 
-/**
- * wagmi connectors for the wagmi context
- */
-export const wagmiConnectors = connectorsForWallets(
-  [
-    {
-      groupName: "Supported Wallets",
-      wallets,
-    },
-  ],
+declare global {
+  // eslint-disable-next-line no-var
+  var wagmiConnectors: ReturnType<typeof connectorsForWallets> | undefined;
+}
 
-  {
-    appName: "scaffold-eth-2",
-    projectId: scaffoldConfig.walletConnectProjectId,
-  },
-);
+/**
+ * Returns wagmi connectors, initializing them only once.
+ */
+export function getWagmiConnectors() {
+  if (!globalThis.wagmiConnectors) {
+    globalThis.wagmiConnectors = connectorsForWallets(
+      [
+        {
+          groupName: "Supported Wallets",
+          wallets,
+        },
+      ],
+      { appName: "scaffold-eth-2", projectId: scaffoldConfig.walletConnectProjectId },
+    );
+  }
+
+  return globalThis.wagmiConnectors;
+}


### PR DESCRIPTION
## Summary
- memoize wagmi connectors to avoid multiple WalletConnect initialization
- use memoized connectors in wagmi config

## Testing
- `packages/nextjs/node_modules/.bin/eslint packages/nextjs/services/web3/wagmiConnectors.tsx packages/nextjs/services/web3/wagmiConfig.tsx` *(fails: Pages directory cannot be found at /workspace/kapan/pages or /workspace/kapan/src/pages)*
- `yarn test` *(fails: command not found: hardhat)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e2e0afec832082bc58b627398f33