### PR TITLE
Cache Starknet account and gate Vesu watchers

### DIFF
--- a/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx
+++ b/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx
@@ -4,7 +4,6 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { RainbowKitProvider, darkTheme, lightTheme } from "@rainbow-me/rainbowkit";
 import {
   Connector,
-  ConnectorData,
   StarknetConfig,
   argent,
   braavos,
@@ -67,7 +66,9 @@ export const ScaffoldEthAppWithProviders = ({ children }: { children: React.Reac
 
   // Debug wrapper to trace connector method calls and suppress duplicate connects
   const connectedMap = useRef<Record<string, boolean>>({});
-  const connectedDataMap = useRef<Record<string, ConnectorData | undefined>>({});
+  const connectedDataMap = useRef<
+    Record<string, Awaited<ReturnType<Connector["connect"]>> | undefined>
+  >({});
   const wrapConnector = (connector: Connector): Connector => {
     const originalConnect = connector.connect.bind(connector);
     const originalAvailable = connector.available.bind(connector);

--- a/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx
+++ b/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { RainbowKitProvider, darkTheme, lightTheme } from "@rainbow-me/rainbowkit";
 import {
   Connector,
+  ConnectorData,
   StarknetConfig,
   argent,
   braavos,
@@ -66,6 +67,7 @@ export const ScaffoldEthAppWithProviders = ({ children }: { children: React.Reac
 
   // Debug wrapper to trace connector method calls and suppress duplicate connects
   const connectedMap = useRef<Record<string, boolean>>({});
+  const connectedDataMap = useRef<Record<string, ConnectorData | undefined>>({});
   const wrapConnector = (connector: Connector): Connector => {
     const originalConnect = connector.connect.bind(connector);
     const originalAvailable = connector.available.bind(connector);
@@ -80,11 +82,12 @@ export const ScaffoldEthAppWithProviders = ({ children }: { children: React.Reac
               console.debug(
                 `[starknet connector] connect skipped: ${connector.id}`,
               );
-              return { account: (connector as any).account } as any;
+              return connectedDataMap.current[connector.id];
             }
             console.debug(`[starknet connector] connect: ${connector.id}`);
             const result = await originalConnect(...args);
             connectedMap.current[connector.id] = true;
+            connectedDataMap.current[connector.id] = result;
             console.debug(
               `[starknet connector] connect resolved: ${connector.id}`,
             );

--- a/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx
+++ b/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx
@@ -67,7 +67,7 @@ export const ScaffoldEthAppWithProviders = ({ children }: { children: React.Reac
       provider={provider}
       connectors={connectorsRef.current ?? []}
       explorer={starkscan}
-      autoConnect={false}
+      autoConnect
     >
       <WagmiProvider config={wagmiConfig}>
         <QueryClientProvider client={queryClient}>

--- a/packages/nextjs/components/scaffold-stark/CustomConnectButton/NetworkOptions.tsx
+++ b/packages/nextjs/components/scaffold-stark/CustomConnectButton/NetworkOptions.tsx
@@ -2,9 +2,9 @@ import { useTheme } from "next-themes";
 import { ArrowsRightLeftIcon } from "@heroicons/react/24/solid";
 import { getNetworkColor, useSwitchNetwork } from "~~/hooks/scaffold-stark";
 import { getTargetNetworks } from "~~/utils/scaffold-stark";
-import { useAccount, useSwitchChain } from "@starknet-react/core";
+import { useSwitchChain } from "@starknet-react/core";
 import { useEffect, useMemo } from "react";
-import { constants } from "starknet";
+import { useAccount } from "~~/hooks/useAccount";
 
 type NetworkOptionsProps = {
   hidden?: boolean;

--- a/packages/nextjs/components/scaffold-stark/Faucet.tsx
+++ b/packages/nextjs/components/scaffold-stark/Faucet.tsx
@@ -3,7 +3,8 @@
 import { useEffect, useState } from "react";
 import GenericModal from "./CustomConnectButton/GenericModal";
 import { Address as AddressType, devnet } from "@starknet-react/chains";
-import { useAccount, useNetwork, useProvider } from "@starknet-react/core";
+import { useNetwork, useProvider } from "@starknet-react/core";
+import { useAccount } from "~~/hooks/useAccount";
 import { BanknotesIcon, CurrencyDollarIcon } from "@heroicons/react/24/outline";
 import { cairo, CallData } from "starknet";
 import { AddressInput, EtherInput } from "~~/components/scaffold-stark";

--- a/packages/nextjs/components/specific/nostra/NostraProtocolView.tsx
+++ b/packages/nextjs/components/specific/nostra/NostraProtocolView.tsx
@@ -30,6 +30,7 @@ export const NostraProtocolView: FC = () => {
 
   // Determine the address to use for queries - use contract's own address as fallback
   const queryAddress = connectedAddress;
+  const enabled = !!connectedAddress;
 
   // Get user positions
   const { data: userPositions } = useNetworkAwareReadContract({
@@ -37,7 +38,8 @@ export const NostraProtocolView: FC = () => {
     contractName: "NostraGateway",
     functionName: "get_user_positions",
     args: [queryAddress],
-    refetchInterval: 10000,
+    refetchInterval: enabled ? 10000 : 0,
+    enabled,
   });
 
   // Memoize the unique contract addresses from user positions
@@ -58,6 +60,7 @@ export const NostraProtocolView: FC = () => {
     functionName: "get_interest_rates",
     args: [uniqueContractAddresses],
     refetchInterval: 0,
+    enabled,
   });
 
   const { tokenAddresses } = useMemo(() => {
@@ -73,6 +76,7 @@ export const NostraProtocolView: FC = () => {
     contractName: "UiHelper",
     functionName: "get_token_decimals",
     args: [tokenAddresses],
+    enabled,
   });
 
   const { data: tokenPrices } = useNetworkAwareReadContract({
@@ -80,6 +84,7 @@ export const NostraProtocolView: FC = () => {
     contractName: "UiHelper",
     functionName: "get_asset_prices",
     args: [tokenAddresses],
+    enabled,
   });
 
   const { tokenToDecimals, tokenToPrices } = useMemo(() => {

--- a/packages/nextjs/components/specific/vesu/VesuProtocolView.tsx
+++ b/packages/nextjs/components/specific/vesu/VesuProtocolView.tsx
@@ -3,7 +3,7 @@ import Image from "next/image";
 import { MarketCard } from "./MarketCard";
 import { MarketRow } from "./MarketRow";
 import { VesuPosition } from "./VesuPosition";
-import { useAccount } from "@starknet-react/core";
+import { useAccount } from "~~/hooks/useAccount";
 import { ListBulletIcon, Squares2X2Icon } from "@heroicons/react/24/outline";
 import { tokenNameToLogo } from "~~/contracts/externalContracts";
 import { useScaffoldReadContract } from "~~/hooks/scaffold-stark";

--- a/packages/nextjs/components/specific/vesu/VesuProtocolView.tsx
+++ b/packages/nextjs/components/specific/vesu/VesuProtocolView.tsx
@@ -59,7 +59,7 @@ export const VesuProtocolView: FC = () => {
     contractName: "VesuGateway",
     functionName: "get_supported_assets_ui",
     args: [selectedPoolId],
-    refetchInterval: 0,
+    watch: false,
   });
 
   if (assetsError) {
@@ -67,21 +67,24 @@ export const VesuProtocolView: FC = () => {
   }
 
   // Paginated user positions reads
+  const enabled = !!userAddress;
   const { data: userPositionsPart1, error: positionsError1 } = useScaffoldReadContract({
     contractName: "VesuGateway",
     functionName: "get_all_positions_range",
     // start at 0, end at 50 (exclusive). Adjust page size as needed.
     args: [userAddress || "0x0", selectedPoolId, 0n, 3n],
-    watch: true,
-    refetchInterval: 5000,
+    watch: enabled,
+    enabled,
+    refetchInterval: enabled ? 5000 : false,
   });
   const { data: userPositionsPart2, error: positionsError2 } = useScaffoldReadContract({
     contractName: "VesuGateway",
     functionName: "get_all_positions_range",
     // second page 50..100
     args: [userAddress || "0x0", selectedPoolId, 3n, 10n],
-    watch: true,
-    refetchInterval: 5000,
+    watch: enabled,
+    enabled,
+    refetchInterval: enabled ? 5000 : false,
   });
 
   if (positionsError1) {

--- a/packages/nextjs/hooks/scaffold-stark/__tests__/useScaffoldContract.test.ts
+++ b/packages/nextjs/hooks/scaffold-stark/__tests__/useScaffoldContract.test.ts
@@ -2,7 +2,7 @@ import { vi, describe, it, expect, beforeEach } from "vitest";
 import { renderHook } from "@testing-library/react";
 import { useScaffoldContract } from "~~/hooks/scaffold-stark/useScaffoldContract";
 import { useDeployedContractInfo } from "~~/hooks/scaffold-stark/useDeployedContractInfo";
-import { useAccount } from "@starknet-react/core";
+import { useAccount } from "~~/hooks/useAccount";
 import { Contract, RpcProvider } from "starknet";
 
 import type { Mock } from "vitest";
@@ -12,6 +12,7 @@ import { useProvider } from "@starknet-react/core";
 //Using vitest's functionality to mock modules from different paths
 vi.mock("~~/hooks/scaffold-stark/useDeployedContractInfo");
 vi.mock("@starknet-react/core");
+vi.mock("~~/hooks/useAccount");
 vi.mock("starknet", () => {
   const actualStarknet = vi.importActual("starknet");
   return {

--- a/packages/nextjs/hooks/scaffold-stark/__tests__/useTransactor.test.ts
+++ b/packages/nextjs/hooks/scaffold-stark/__tests__/useTransactor.test.ts
@@ -219,4 +219,13 @@ describe("useTransactor", () => {
       "Incorrect transaction passed to transactor",
     );
   });
+
+  it("should resolve function-based wallet clients", async () => {
+    const walletFn = vi.fn().mockResolvedValue(walletClientMock);
+    const { result } = renderHook(() => useTransactor(walletFn as any));
+
+    const txHash = await result.current(() => Promise.resolve("mock-tx-hash"));
+    expect(txHash).toBe("mock-tx-hash");
+    expect(walletFn).toHaveBeenCalled();
+  });
 });

--- a/packages/nextjs/hooks/scaffold-stark/useAutoConnect.ts
+++ b/packages/nextjs/hooks/scaffold-stark/useAutoConnect.ts
@@ -48,7 +48,14 @@ export const useAutoConnect = (): void => {
         );
 
         if (connector) {
-          connect({ connector });
+          (async () => {
+            try {
+              await (connector as any).connect?.({ showModal: false });
+            } catch {
+              // Fallback to standard connect which may show the wallet UI
+              await connect({ connector });
+            }
+          })();
         }
       }
     }

--- a/packages/nextjs/hooks/useAccount.ts
+++ b/packages/nextjs/hooks/useAccount.ts
@@ -62,10 +62,18 @@ export function useAccount(): UseAccountResult {
             chainId = constants.StarknetChainId.SN_MAIN;
           }
 
-          if (chainId) {
-            setAccountChainId(BigInt(chainId.toString()));
+          if (chainId !== undefined && chainId !== null) {
+            try {
+              const parsedChainId =
+                typeof chainId === "bigint" ? chainId : BigInt(chainId.toString());
+              setAccountChainId(parsedChainId);
+            } catch (err) {
+              console.warn("useAccount: failed to parse chainId", chainId, err);
+              setAccountChainId(BigInt(constants.StarknetChainId.SN_MAIN));
+            }
           }
         } catch (error) {
+          console.warn("useAccount: getChainId threw", error);
           setAccountChainId(BigInt(constants.StarknetChainId.SN_MAIN));
         }
       };

--- a/packages/nextjs/hooks/useAccount.ts
+++ b/packages/nextjs/hooks/useAccount.ts
@@ -47,11 +47,17 @@ export function useAccount(): UseAccountResult {
   // Cache the account instance so re-renders don't trigger a fresh enable
   const accountRef = useRef<AccountInterface | undefined>();
   useEffect(() => {
-    if (account) {
+    if (account && typeof (account as any).execute === "function") {
       accountRef.current = account;
     }
   }, [account]);
-  const stableAccount = account ?? accountRef.current;
+  const stableAccount = useMemo(() => {
+    const a = account ?? accountRef.current;
+    if (a && typeof (a as any).execute === "function") {
+      return a;
+    }
+    return undefined;
+  }, [account]);
 
   // Log status and address changes to help trace unexpected reconnects
   useEffect(() => {

--- a/packages/nextjs/hooks/useAccount.ts
+++ b/packages/nextjs/hooks/useAccount.ts
@@ -25,6 +25,25 @@ export function useAccount(): UseAccountResult {
   const starknetAccount = useStarknetReactAccount();
   const { account, address, status } = starknetAccount;
 
+  // Persist the last known address to avoid reconnect prompts when wallets lock
+  const [persistedAddress, setPersistedAddress] = useState<`0x${string}` | undefined>(
+    undefined,
+  );
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const stored = window.localStorage.getItem("lastStarknetAddress");
+    if (stored) {
+      setPersistedAddress(stored as `0x${string}`);
+    }
+  }, []);
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (address) {
+      window.localStorage.setItem("lastStarknetAddress", address);
+      setPersistedAddress(address);
+    }
+  }, [address]);
+
   // Cache the account instance so re-renders don't trigger a fresh enable
   const accountRef = useRef<AccountInterface | undefined>();
   useEffect(() => {
@@ -114,5 +133,6 @@ export function useAccount(): UseAccountResult {
     account: patchedAccount,
     status: correctedStatus,
     chainId: accountChainId,
+    address: address ?? persistedAddress,
   } as UseAccountResult;
 }

--- a/packages/nextjs/hooks/useAccount.ts
+++ b/packages/nextjs/hooks/useAccount.ts
@@ -34,6 +34,11 @@ export function useAccount(): UseAccountResult {
   }, [account]);
   const stableAccount = account ?? accountRef.current;
 
+  // Log status and address changes to help trace unexpected reconnects
+  useEffect(() => {
+    console.debug("useAccount", { status, address, hasAccount: !!account });
+  }, [status, address, account]);
+
   const correctedStatus = useMemo(() => {
     if (status === "connected" && !stableAccount) {
       return "connecting";

--- a/packages/nextjs/hooks/useNetworkAwareReadContract.ts
+++ b/packages/nextjs/hooks/useNetworkAwareReadContract.ts
@@ -26,8 +26,9 @@ export const useNetworkAwareReadContract = <
   contractName,
   functionName,
   args,
+  enabled = true,
   ...readConfig
-}: ReadContractConfig<T, TContractName, TFunctionName>): Omit<ReturnType<typeof useReadContract>, "data"> & {
+}: ReadContractConfig<T, TContractName, TFunctionName> & { enabled?: boolean }): Omit<ReturnType<typeof useReadContract>, "data"> & {
   data: T extends "evm" 
     ? AbiFunctionReturnType<ContractAbiEth, TFunctionName> | undefined
     : AbiFunctionOutputs<ContractAbiStark, TFunctionName> | undefined;
@@ -40,7 +41,7 @@ export const useNetworkAwareReadContract = <
     ...readConfig,
     query: {
       ...readConfig.query,
-      enabled: networkType === "evm",
+      enabled: networkType === "evm" && enabled,
     },
   });
 
@@ -50,7 +51,7 @@ export const useNetworkAwareReadContract = <
     functionName: functionName as any,
     args: args as any,
     ...readConfig,
-    enabled: networkType === "starknet",
+    enabled: networkType === "starknet" && enabled,
   });
 
   // Return the appropriate result based on network type


### PR DESCRIPTION
## Summary
- cache last Starknet account to avoid repeated wallet prompts
- enable Starknet autoConnect with stable connectors
- only poll Vesu positions when a Starknet account is present

## Testing
- `yarn test` *(fails: command not found: hardhat)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ed0287dc83209599513ae3b7fada