### PR TITLE
chore: block eslint-config-prettier

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,7 @@ Contributions are made via Issues and Pull Requests (PRs). A few general guideli
 - Contributions should only fix/add the functionality in the issue OR address style issues, not both.
 - If you're running into an error, please give context. Explain what you're trying to do and how to reproduce the error.
 - Please use the same formatting in the code repository. You can configure your IDE to do it by using the prettier / linting config files included in each package.
+- Avoid adding `eslint-config-prettier` as a dependency. The package has been hijacked and may contain malware.
 - If applicable, please edit the README.md file to reflect the changes.
 
 ### Issues

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "playwright": "^1.51.1"
   },
   "resolutions": {
+    "eslint-config-prettier": "0.0.0",
     "react": "~18.3.1",
     "react-dom": "~18.3.1"
   }


### PR DESCRIPTION
## Summary
- block compromised eslint-config-prettier via Yarn resolutions
- document eslint-config-prettier is forbidden in contributing guide

## Testing
- `yarn install`
- `yarn lint` *(fails: @typescript-eslint/no-unused-vars errors)*
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68b2e11ac26c83209ca248911498878a