### PR TITLE
feat: add compound markets to listings

### DIFF
--- a/packages/nextjs/app/markets/page.tsx
+++ b/packages/nextjs/app/markets/page.tsx
@@ -3,14 +3,15 @@
 import { useState } from "react";
 import type { NextPage } from "next";
 import { ListBulletIcon, Squares2X2Icon } from "@heroicons/react/24/outline";
+import { LendingSidebar } from "~~/components/LendingSidebar";
 import { NetworkFilter, NetworkOption } from "~~/components/NetworkFilter";
+import { MarketsGrouped } from "~~/components/markets/MarketsGrouped";
 import { AaveMarkets } from "~~/components/specific/aave/AaveMarkets";
+import { CompoundMarkets } from "~~/components/specific/compound/CompoundMarkets";
 import { NostraMarkets } from "~~/components/specific/nostra/NostraMarkets";
 import { VenusMarkets } from "~~/components/specific/venus/VenusMarkets";
-import { VesuMarkets, POOL_IDS, ContractResponse } from "~~/components/specific/vesu/VesuMarkets";
+import { ContractResponse, POOL_IDS, VesuMarkets } from "~~/components/specific/vesu/VesuMarkets";
 import { useScaffoldReadContract } from "~~/hooks/scaffold-stark";
-import { LendingSidebar } from "~~/components/LendingSidebar";
-import { MarketsGrouped } from "~~/components/markets/MarketsGrouped";
 
 const networkOptions: NetworkOption[] = [
   { id: "starknet", name: "Starknet", logo: "/logos/starknet.svg" },
@@ -35,11 +36,7 @@ const MarketsPage: NextPage = () => {
     <div className="container mx-auto px-5 flex">
       <LendingSidebar />
       <div className="flex-1">
-        <div
-          className={`flex items-center mb-4 ${
-            groupMode === "protocol" ? "justify-between" : "justify-end"
-          }`}
-        >
+        <div className={`flex items-center mb-4 ${groupMode === "protocol" ? "justify-between" : "justify-end"}`}>
           {groupMode === "protocol" && (
             <NetworkFilter networks={networkOptions} defaultNetwork="starknet" onNetworkChange={setSelectedNetwork} />
           )}
@@ -92,6 +89,7 @@ const MarketsPage: NextPage = () => {
             {selectedNetwork === "arbitrum" && (
               <>
                 <AaveMarkets viewMode={viewMode} search={search} />
+                <CompoundMarkets viewMode={viewMode} search={search} />
                 <VenusMarkets viewMode={viewMode} search={search} />
               </>
             )}

--- a/packages/nextjs/components/markets/MarketsSection.tsx
+++ b/packages/nextjs/components/markets/MarketsSection.tsx
@@ -11,7 +11,7 @@ export interface MarketData {
   utilization: string;
   address: string;
   networkType: "evm" | "starknet";
-  protocol: "aave" | "nostra" | "venus" | "vesu";
+  protocol: "aave" | "nostra" | "venus" | "vesu" | "compound";
 }
 
 interface MarketsSectionProps {
@@ -44,7 +44,9 @@ export const MarketsSection: FC<MarketsSectionProps> = ({ title, markets, viewMo
       <div className="card-body p-4">
         <h2 className="card-title text-lg mb-4">{title}</h2>
         {extra}
-        <div className={viewMode === "grid" ? "grid gap-4 sm:grid-cols-2 lg:grid-cols-3" : "space-y-2"}>{marketItems}</div>
+        <div className={viewMode === "grid" ? "grid gap-4 sm:grid-cols-2 lg:grid-cols-3" : "space-y-2"}>
+          {marketItems}
+        </div>
       </div>
     </div>
   );

--- a/packages/nextjs/components/markets/RatePill.tsx
+++ b/packages/nextjs/components/markets/RatePill.tsx
@@ -1,12 +1,12 @@
-import Image from "next/image";
 import { FC } from "react";
+import Image from "next/image";
 
 interface RatePillProps {
   variant: "supply" | "borrow";
   label: string;
   rate: string;
   networkType: "evm" | "starknet";
-  protocol: "aave" | "nostra" | "venus" | "vesu";
+  protocol: "aave" | "nostra" | "venus" | "vesu" | "compound";
   showIcons?: boolean;
 }
 
@@ -15,21 +15,15 @@ const networkIcons: Record<"evm" | "starknet", string> = {
   starknet: "/logos/starknet.svg",
 };
 
-const protocolIcons: Record<"aave" | "nostra" | "venus" | "vesu", string> = {
+const protocolIcons: Record<"aave" | "nostra" | "venus" | "vesu" | "compound", string> = {
   aave: "/logos/aave.svg",
   nostra: "/logos/nostra.svg",
   venus: "/logos/venus.svg",
   vesu: "/logos/vesu.svg",
+  compound: "/logos/compound.svg",
 };
 
-export const RatePill: FC<RatePillProps> = ({
-  variant,
-  label,
-  rate,
-  networkType,
-  protocol,
-  showIcons = true,
-}) => {
+export const RatePill: FC<RatePillProps> = ({ variant, label, rate, networkType, protocol, showIcons = true }) => {
   const color = variant === "supply" ? "bg-success text-success-content" : "bg-warning text-warning-content";
   return (
     <div className="flex items-center rounded-full border border-base-300 text-sm overflow-hidden bg-base-100">

--- a/packages/nextjs/components/specific/compound/CompoundMarkets.tsx
+++ b/packages/nextjs/components/specific/compound/CompoundMarkets.tsx
@@ -1,0 +1,86 @@
+import { FC, useMemo } from "react";
+import { formatUnits } from "viem";
+import { MarketData, MarketsSection } from "~~/components/markets/MarketsSection";
+import { tokenNameToLogo } from "~~/contracts/externalContracts";
+import { useDeployedContractInfo } from "~~/hooks/scaffold-eth";
+import { useNetworkAwareReadContract } from "~~/hooks/useNetworkAwareReadContract";
+
+// Helper to convert Compound's per-second rate to APR percentage
+const convertRateToAPR = (ratePerSecond: bigint): number => {
+  const SECONDS_PER_YEAR = 60 * 60 * 24 * 365;
+  const SCALE = 1e18;
+  return (Number(ratePerSecond) * SECONDS_PER_YEAR * 100) / SCALE;
+};
+
+interface CompoundMarketsProps {
+  viewMode: "list" | "grid";
+  search: string;
+}
+
+export const CompoundMarkets: FC<CompoundMarketsProps> = ({ viewMode, search }) => {
+  const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+  const { data: weth } = useDeployedContractInfo({ contractName: "eth" });
+  const { data: usdc } = useDeployedContractInfo({ contractName: "USDC" });
+  const { data: usdt } = useDeployedContractInfo({ contractName: "USDT" });
+  const { data: usdcE } = useDeployedContractInfo({ contractName: "USDCe" });
+
+  const { data: wethData } = useNetworkAwareReadContract({
+    networkType: "evm",
+    contractName: "CompoundGateway",
+    functionName: "getCompoundData",
+    args: [weth?.address, ZERO_ADDRESS],
+  });
+  const { data: usdcData } = useNetworkAwareReadContract({
+    networkType: "evm",
+    contractName: "CompoundGateway",
+    functionName: "getCompoundData",
+    args: [usdc?.address, ZERO_ADDRESS],
+  });
+  const { data: usdtData } = useNetworkAwareReadContract({
+    networkType: "evm",
+    contractName: "CompoundGateway",
+    functionName: "getCompoundData",
+    args: [usdt?.address, ZERO_ADDRESS],
+  });
+  const { data: usdcEData } = useNetworkAwareReadContract({
+    networkType: "evm",
+    contractName: "CompoundGateway",
+    functionName: "getCompoundData",
+    args: [usdcE?.address, ZERO_ADDRESS],
+  });
+
+  const markets: MarketData[] = useMemo(() => {
+    const tokens = [
+      { symbol: "WETH", address: weth?.address, data: wethData },
+      { symbol: "USDC", address: usdc?.address, data: usdcData },
+      { symbol: "USDT", address: usdt?.address, data: usdtData },
+      { symbol: "USDC.e", address: usdcE?.address, data: usdcEData },
+    ];
+
+    return tokens
+      .filter(t => t.address && t.data)
+      .map(t => {
+        const [supplyRate, borrowRate, , , price] = t.data as any;
+        const supplyAPR = supplyRate ? convertRateToAPR(BigInt(supplyRate)) : 0;
+        const borrowAPR = borrowRate ? convertRateToAPR(BigInt(borrowRate)) : 0;
+        const priceFormatted = price ? Number(formatUnits(price, 8)).toFixed(2) : "0.00";
+        const utilization = borrowAPR > 0 ? (supplyAPR / borrowAPR) * 100 : 0;
+        return {
+          icon: tokenNameToLogo(t.symbol),
+          name: t.symbol,
+          supplyRate: `${supplyAPR.toFixed(2)}%`,
+          borrowRate: `${borrowAPR.toFixed(2)}%`,
+          price: priceFormatted,
+          utilization: utilization.toFixed(2),
+          address: t.address as string,
+          networkType: "evm",
+          protocol: "compound",
+        } as MarketData;
+      });
+  }, [weth?.address, usdc?.address, usdt?.address, usdcE?.address, wethData, usdcData, usdtData, usdcEData]);
+
+  return <MarketsSection title="Compound Markets" markets={markets} viewMode={viewMode} search={search} />;
+};
+
+export default CompoundMarkets;


### PR DESCRIPTION
## Summary
- add CompoundMarkets component and include it on markets page
- support "compound" protocol across market utilities
- group compound data when viewing markets by token

## Testing
- `npx next lint`
- `npx tsc --noEmit --incremental` *(fails: Cannot find module '@starknet-react/core', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b468b313348320a9b032353fdc9dd6