### PR TITLE
Improve token markets table and search layout

### DIFF
--- a/packages/nextjs/app/markets/page.tsx
+++ b/packages/nextjs/app/markets/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import type { NextPage } from "next";
-import { ListBulletIcon, Squares2X2Icon } from "@heroicons/react/24/outline";
+import { ListBulletIcon, MagnifyingGlassIcon, Squares2X2Icon } from "@heroicons/react/24/outline";
 import { LendingSidebar } from "~~/components/LendingSidebar";
 import { NetworkFilter, NetworkOption } from "~~/components/NetworkFilter";
 import { MarketsGrouped } from "~~/components/markets/MarketsGrouped";
@@ -36,8 +36,41 @@ const MarketsPage: NextPage = () => {
     <div className="container mx-auto px-5 flex">
       <LendingSidebar />
       <div className="flex-1">
-        {(() => {
-          const groupButtons = (
+        <div className="flex items-center mb-4">
+          {groupMode === "protocol" && (
+            <NetworkFilter networks={networkOptions} defaultNetwork="starknet" onNetworkChange={setSelectedNetwork} />
+          )}
+          <div className="flex-1 flex justify-center">
+            <div className="relative w-full max-w-md">
+              <MagnifyingGlassIcon className="pointer-events-none absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-base-content/50" />
+              <input
+                type="text"
+                placeholder="Search"
+                className="input input-bordered w-full rounded-full pl-10"
+                value={search}
+                onChange={e => setSearch(e.target.value)}
+              />
+            </div>
+          </div>
+          <div className="flex items-center gap-2 ml-4">
+            {groupMode === "protocol" && (
+              <div className="join">
+                <button
+                  className={`btn btn-xs join-item ${viewMode === "list" ? "btn-primary" : "btn-ghost"}`}
+                  onClick={() => setViewMode("list")}
+                  aria-label="List view"
+                >
+                  <ListBulletIcon className="h-4 w-4" />
+                </button>
+                <button
+                  className={`btn btn-xs join-item ${viewMode === "grid" ? "btn-primary" : "btn-ghost"}`}
+                  onClick={() => setViewMode("grid")}
+                  aria-label="Grid view"
+                >
+                  <Squares2X2Icon className="h-4 w-4" />
+                </button>
+              </div>
+            )}
             <div className="join">
               <button
                 className={`btn btn-xs join-item ${groupMode === "token" ? "btn-primary" : "btn-ghost"}`}
@@ -52,59 +85,8 @@ const MarketsPage: NextPage = () => {
                 Protocol
               </button>
             </div>
-          );
-
-          return (
-            <div
-              className={`mb-4 ${
-                groupMode === "protocol" ? "flex items-center justify-between" : "flex flex-col items-center gap-4"
-              }`}
-            >
-              {groupMode === "protocol" && (
-                <NetworkFilter
-                  networks={networkOptions}
-                  defaultNetwork="starknet"
-                  onNetworkChange={setSelectedNetwork}
-                />
-              )}
-              <div
-                className={`flex items-center gap-2 ${
-                  groupMode === "token" ? "w-full justify-center" : ""
-                }`}
-              >
-                <input
-                  type="text"
-                  placeholder="Search"
-                  className={`input input-bordered ${
-                    groupMode === "protocol" ? "input-xs w-28" : "input-md w-full max-w-md text-center"
-                  }`}
-                  value={search}
-                  onChange={e => setSearch(e.target.value)}
-                />
-                {groupMode === "protocol" && (
-                  <div className="join">
-                    <button
-                      className={`btn btn-xs join-item ${viewMode === "list" ? "btn-primary" : "btn-ghost"}`}
-                      onClick={() => setViewMode("list")}
-                      aria-label="List view"
-                    >
-                      <ListBulletIcon className="h-4 w-4" />
-                    </button>
-                    <button
-                      className={`btn btn-xs join-item ${viewMode === "grid" ? "btn-primary" : "btn-ghost"}`}
-                      onClick={() => setViewMode("grid")}
-                      aria-label="Grid view"
-                    >
-                      <Squares2X2Icon className="h-4 w-4" />
-                    </button>
-                  </div>
-                )}
-                {groupMode === "protocol" && groupButtons}
-              </div>
-              {groupMode === "token" && groupButtons}
-            </div>
-          );
-        })()}
+          </div>
+        </div>
         {groupMode === "token" ? (
           <MarketsGrouped search={search} />
         ) : (

--- a/packages/nextjs/app/markets/page.tsx
+++ b/packages/nextjs/app/markets/page.tsx
@@ -36,36 +36,8 @@ const MarketsPage: NextPage = () => {
     <div className="container mx-auto px-5 flex">
       <LendingSidebar />
       <div className="flex-1">
-        <div className={`flex items-center mb-4 ${groupMode === "protocol" ? "justify-between" : "justify-end"}`}>
-          {groupMode === "protocol" && (
-            <NetworkFilter networks={networkOptions} defaultNetwork="starknet" onNetworkChange={setSelectedNetwork} />
-          )}
-          <div className="flex items-center gap-2">
-            <input
-              type="text"
-              placeholder="Search"
-              className="input input-bordered input-xs w-28"
-              value={search}
-              onChange={e => setSearch(e.target.value)}
-            />
-            {groupMode === "protocol" && (
-              <div className="join">
-                <button
-                  className={`btn btn-xs join-item ${viewMode === "list" ? "btn-primary" : "btn-ghost"}`}
-                  onClick={() => setViewMode("list")}
-                  aria-label="List view"
-                >
-                  <ListBulletIcon className="h-4 w-4" />
-                </button>
-                <button
-                  className={`btn btn-xs join-item ${viewMode === "grid" ? "btn-primary" : "btn-ghost"}`}
-                  onClick={() => setViewMode("grid")}
-                  aria-label="Grid view"
-                >
-                  <Squares2X2Icon className="h-4 w-4" />
-                </button>
-              </div>
-            )}
+        {(() => {
+          const groupButtons = (
             <div className="join">
               <button
                 className={`btn btn-xs join-item ${groupMode === "token" ? "btn-primary" : "btn-ghost"}`}
@@ -80,8 +52,59 @@ const MarketsPage: NextPage = () => {
                 Protocol
               </button>
             </div>
-          </div>
-        </div>
+          );
+
+          return (
+            <div
+              className={`mb-4 ${
+                groupMode === "protocol" ? "flex items-center justify-between" : "flex flex-col items-center gap-4"
+              }`}
+            >
+              {groupMode === "protocol" && (
+                <NetworkFilter
+                  networks={networkOptions}
+                  defaultNetwork="starknet"
+                  onNetworkChange={setSelectedNetwork}
+                />
+              )}
+              <div
+                className={`flex items-center gap-2 ${
+                  groupMode === "token" ? "w-full justify-center" : ""
+                }`}
+              >
+                <input
+                  type="text"
+                  placeholder="Search"
+                  className={`input input-bordered ${
+                    groupMode === "protocol" ? "input-xs w-28" : "input-md w-full max-w-md text-center"
+                  }`}
+                  value={search}
+                  onChange={e => setSearch(e.target.value)}
+                />
+                {groupMode === "protocol" && (
+                  <div className="join">
+                    <button
+                      className={`btn btn-xs join-item ${viewMode === "list" ? "btn-primary" : "btn-ghost"}`}
+                      onClick={() => setViewMode("list")}
+                      aria-label="List view"
+                    >
+                      <ListBulletIcon className="h-4 w-4" />
+                    </button>
+                    <button
+                      className={`btn btn-xs join-item ${viewMode === "grid" ? "btn-primary" : "btn-ghost"}`}
+                      onClick={() => setViewMode("grid")}
+                      aria-label="Grid view"
+                    >
+                      <Squares2X2Icon className="h-4 w-4" />
+                    </button>
+                  </div>
+                )}
+                {groupMode === "protocol" && groupButtons}
+              </div>
+              {groupMode === "token" && groupButtons}
+            </div>
+          );
+        })()}
         {groupMode === "token" ? (
           <MarketsGrouped search={search} />
         ) : (

--- a/packages/nextjs/components/markets/MarketsGrouped.tsx
+++ b/packages/nextjs/components/markets/MarketsGrouped.tsx
@@ -393,42 +393,57 @@ export const MarketsGrouped: FC<{ search: string }> = ({ search }) => {
                 </div>
               </div>
             </summary>
-            <div className="collapse-content p-0 mt-2 space-y-2">
-              {group.markets.map(m => (
-                <div
-                  key={m.protocol + m.address}
-                  className="grid grid-cols-4 items-center gap-4 p-3 rounded-lg bg-base-100"
-                >
-                  <div className="flex items-center gap-2">
-                    <Image src={networkIcons[m.networkType]} alt={m.networkType} width={16} height={16} />
-                    <span>{networkNames[m.networkType]}</span>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <Image src={protocolIcons[m.protocol]} alt={m.protocol} width={16} height={16} />
-                    <span className="capitalize">{protocolNames[m.protocol]}</span>
-                  </div>
-                  <div className="justify-self-center">
-                    <RatePill
-                      variant="supply"
-                      label="Supply Rate"
-                      rate={m.supplyRate}
-                      networkType={m.networkType}
-                      protocol={m.protocol}
-                      showIcons={false}
-                    />
-                  </div>
-                  <div className="justify-self-center">
-                    <RatePill
-                      variant="borrow"
-                      label="Borrow Rate"
-                      rate={m.borrowRate}
-                      networkType={m.networkType}
-                      protocol={m.protocol}
-                      showIcons={false}
-                    />
-                  </div>
-                </div>
-              ))}
+            <div className="collapse-content p-0 mt-2">
+              <div className="overflow-x-auto">
+                <table className="table table-sm w-full">
+                  <thead>
+                    <tr className="bg-base-200">
+                      <th>Network</th>
+                      <th>Protocol</th>
+                      <th className="text-center">Supply Rate</th>
+                      <th className="text-center">Borrow Rate</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {group.markets.map(m => (
+                      <tr key={m.protocol + m.address} className="bg-base-100 hover:bg-base-200">
+                        <td>
+                          <div className="flex items-center gap-2">
+                            <Image src={networkIcons[m.networkType]} alt={m.networkType} width={16} height={16} />
+                            <span>{networkNames[m.networkType]}</span>
+                          </div>
+                        </td>
+                        <td>
+                          <div className="flex items-center gap-2">
+                            <Image src={protocolIcons[m.protocol]} alt={m.protocol} width={16} height={16} />
+                            <span className="capitalize">{protocolNames[m.protocol]}</span>
+                          </div>
+                        </td>
+                        <td className="text-center">
+                          <RatePill
+                            variant="supply"
+                            label="Supply Rate"
+                            rate={m.supplyRate}
+                            networkType={m.networkType}
+                            protocol={m.protocol}
+                            showIcons={false}
+                          />
+                        </td>
+                        <td className="text-center">
+                          <RatePill
+                            variant="borrow"
+                            label="Borrow Rate"
+                            rate={m.borrowRate}
+                            networkType={m.networkType}
+                            protocol={m.protocol}
+                            showIcons={false}
+                          />
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
             </div>
           </details>
         ))}

--- a/packages/nextjs/components/markets/MarketsGrouped.tsx
+++ b/packages/nextjs/components/markets/MarketsGrouped.tsx
@@ -370,9 +370,9 @@ export const MarketsGrouped: FC<{ search: string }> = ({ search }) => {
       </div>
       <div className="space-y-4">
         {filtered.map(group => (
-          <details key={group.name} className="collapse collapse-arrow bg-base-100 rounded-lg">
+          <details key={group.name} className="collapse collapse-arrow rounded-lg">
             <summary className="collapse-title p-0 list-none">
-              <div className="flex items-center gap-4 p-4 bg-base-200 rounded-lg">
+              <div className="flex items-center gap-4 p-4 rounded-lg bg-base-100 border border-base-300 hover:bg-base-200 cursor-pointer">
                 <Image src={group.icon} alt={group.name} width={24} height={24} className="rounded-full" />
                 <span className="font-medium">{group.name}</span>
                 <div className="ml-auto mr-8 flex gap-4">
@@ -393,57 +393,42 @@ export const MarketsGrouped: FC<{ search: string }> = ({ search }) => {
                 </div>
               </div>
             </summary>
-            <div className="collapse-content p-0 mt-2">
-              <div className="overflow-x-auto">
-                <table className="table table-sm w-full">
-                  <thead>
-                    <tr className="bg-base-200">
-                      <th>Network</th>
-                      <th>Protocol</th>
-                      <th className="text-center">Supply Rate</th>
-                      <th className="text-center">Borrow Rate</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {group.markets.map(m => (
-                      <tr key={m.protocol + m.address} className="bg-base-100 hover:bg-base-200">
-                        <td>
-                          <div className="flex items-center gap-2">
-                            <Image src={networkIcons[m.networkType]} alt={m.networkType} width={16} height={16} />
-                            <span>{networkNames[m.networkType]}</span>
-                          </div>
-                        </td>
-                        <td>
-                          <div className="flex items-center gap-2">
-                            <Image src={protocolIcons[m.protocol]} alt={m.protocol} width={16} height={16} />
-                            <span className="capitalize">{protocolNames[m.protocol]}</span>
-                          </div>
-                        </td>
-                        <td className="text-center">
-                          <RatePill
-                            variant="supply"
-                            label="Supply Rate"
-                            rate={m.supplyRate}
-                            networkType={m.networkType}
-                            protocol={m.protocol}
-                            showIcons={false}
-                          />
-                        </td>
-                        <td className="text-center">
-                          <RatePill
-                            variant="borrow"
-                            label="Borrow Rate"
-                            rate={m.borrowRate}
-                            networkType={m.networkType}
-                            protocol={m.protocol}
-                            showIcons={false}
-                          />
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
+            <div className="collapse-content p-0 mt-2 space-y-2">
+              {group.markets.map(m => (
+                <div
+                  key={m.protocol + m.address}
+                  className="grid grid-cols-4 items-center gap-4 p-3 rounded-lg bg-base-100"
+                >
+                  <div className="flex items-center gap-2">
+                    <Image src={networkIcons[m.networkType]} alt={m.networkType} width={16} height={16} />
+                    <span>{networkNames[m.networkType]}</span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Image src={protocolIcons[m.protocol]} alt={m.protocol} width={16} height={16} />
+                    <span className="capitalize">{protocolNames[m.protocol]}</span>
+                  </div>
+                  <div className="justify-self-center">
+                    <RatePill
+                      variant="supply"
+                      label="Supply Rate"
+                      rate={m.supplyRate}
+                      networkType={m.networkType}
+                      protocol={m.protocol}
+                      showIcons={false}
+                    />
+                  </div>
+                  <div className="justify-self-center">
+                    <RatePill
+                      variant="borrow"
+                      label="Borrow Rate"
+                      rate={m.borrowRate}
+                      networkType={m.networkType}
+                      protocol={m.protocol}
+                      showIcons={false}
+                    />
+                  </div>
+                </div>
+              ))}
             </div>
           </details>
         ))}


### PR DESCRIPTION
## Summary
- Center and enlarge search bar on markets page
- Redesign token-grouped markets with table layout and row backgrounds

## Testing
- `yarn workspace @se-2/nextjs lint` *(fails: command not found: next)*

------
https://chatgpt.com/codex/tasks/task_e_68b470b58cd48320981bfcef82677046