### PR TITLE
Remove token balance limit from borrow modal

### DIFF
--- a/packages/nextjs/components/modals/TokenActionModal.tsx
+++ b/packages/nextjs/components/modals/TokenActionModal.tsx
@@ -195,6 +195,7 @@ export const TokenActionModal: FC<TokenActionModalProps> = ({
   const [txState, setTxState] = useState<"idle" | "pending" | "success">("idle");
   const txRequest = buildTx ? buildTx(amount, isMax) : undefined;
   const gasCostUsd = useGasEstimate(network, txRequest);
+  const effectiveMax = action === "Borrow" ? 0n : max;
 
   const parsed = parseFloat(amount || "0");
   const afterValue = (() => {
@@ -269,7 +270,7 @@ export const TokenActionModal: FC<TokenActionModalProps> = ({
                 setIsMax(maxed);
               }}
               percentBase={percentBase}
-              max={max}
+              max={effectiveMax}
             />
             <div className="grid grid-cols-2 gap-2 text-xs pt-2">
               <HealthFactor value={hf} />


### PR DESCRIPTION
## Summary
- stop enforcing wallet balance as max when borrowing so users can specify any amount

## Testing
- `yarn workspace @se-2/nextjs eslint components/modals/TokenActionModal.tsx`
- `yarn next:check-types` *(fails: Cannot find module '@starknet-react/core')*
- `yarn test` *(fails: command not found: hardhat)*

------
https://chatgpt.com/codex/tasks/task_e_68b5bc3b12688320b5087dafa698a24f