### PR TITLE
Enable Starknet auto connect

### DIFF
--- a/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx
+++ b/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx
@@ -13,13 +13,14 @@ import { Header } from "~~/components/Header";
 import { BlockieAvatar } from "~~/components/scaffold-eth";
 import { useInitializeNativeCurrencyPrice } from "~~/hooks/scaffold-eth";
 import { BlockNumberProvider } from "~~/hooks/scaffold-eth";
-import { StarkBlockNumberProvider } from "~~/hooks/scaffold-stark";
+import { StarkBlockNumberProvider, useAutoConnect } from "~~/hooks/scaffold-stark";
 import { appChains } from "~~/services/web3/connectors";
 import provider from "~~/services/web3/provider";
 import { wagmiConfig } from "~~/services/web3/wagmiConfig";
 
 const ScaffoldEthApp = ({ children }: { children: React.ReactNode }) => {
   useInitializeNativeCurrencyPrice();
+  useAutoConnect();
 
   return (
     <>

--- a/packages/nextjs/components/scaffold-stark/CustomConnectButton/ConnectModal.tsx
+++ b/packages/nextjs/components/scaffold-stark/CustomConnectButton/ConnectModal.tsx
@@ -1,5 +1,6 @@
 import { useConnect } from "@starknet-react/core";
 import { type StarknetkitConnector, useStarknetkitConnectModal } from "starknetkit";
+import { LAST_CONNECTED_TIME_LOCALSTORAGE_KEY } from "~~/utils/Constants";
 
 const ConnectModal = () => {
   const { connect, connectors } = useConnect();
@@ -17,6 +18,10 @@ const ConnectModal = () => {
     try {
       if (typeof window !== "undefined") {
         window.localStorage.setItem("lastUsedConnector", JSON.stringify({ id: connector.id }));
+        window.localStorage.setItem(
+          LAST_CONNECTED_TIME_LOCALSTORAGE_KEY,
+          Date.now().toString(),
+        );
       }
     } catch {}
   }

--- a/packages/nextjs/hooks/scaffold-stark/useAutoConnect.ts
+++ b/packages/nextjs/hooks/scaffold-stark/useAutoConnect.ts
@@ -49,6 +49,12 @@ export const useAutoConnect = (): void => {
 
         if (connector) {
           connect({ connector });
+          if (typeof window !== "undefined") {
+            window.localStorage.setItem(
+              LAST_CONNECTED_TIME_LOCALSTORAGE_KEY,
+              currentTime.toString(),
+            );
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
- use Starknet auto-connect hook at the app level
- remember last wallet and connection timestamp
- refresh timestamp after an auto-connect

## Testing
- `npx next lint`
- `npx vitest run` *(fails: Cannot find package '@testing-library/react')*
- `yarn test` *(fails: command not found: hardhat)*

------
https://chatgpt.com/codex/tasks/task_e_68b5eb05cab48320aa3403e9a87b4b1c