### PR TITLE
Forward Vesu context to deposit modal

### DIFF
--- a/packages/nextjs/components/LendingSidebar.tsx
+++ b/packages/nextjs/components/LendingSidebar.tsx
@@ -12,8 +12,8 @@ export const LendingSidebar = () => {
   ];
 
   return (
-    <aside className="group w-16 hover:w-40 transition-all duration-300 overflow-hidden mr-4">
-      <ul className="menu bg-base-200 rounded-box py-2 pr-2 pl-0">
+    <aside className="group sticky top-0 self-start h-screen flex-shrink-0 w-16 hover:w-40 transition-all duration-300 overflow-hidden mr-4">
+      <ul className="menu bg-base-200 rounded-box py-2 pr-2 pl-0 h-full">
         {links.map(({ href, label, icon: Icon }) => (
           <li key={href}>
             <Link

--- a/packages/nextjs/components/LendingSidebar.tsx
+++ b/packages/nextjs/components/LendingSidebar.tsx
@@ -12,7 +12,7 @@ export const LendingSidebar = () => {
   ];
 
   return (
-    <aside className="group sticky top-0 self-start h-screen flex-shrink-0 w-16 hover:w-40 transition-all duration-300 overflow-hidden mr-4">
+    <aside className="group sticky top-[4.5rem] h-[calc(100vh-4.5rem)] self-start flex-shrink-0 w-16 hover:w-40 transition-all duration-300 overflow-hidden mr-4">
       <ul className="menu bg-base-200 rounded-box py-2 pr-2 pl-0 h-full">
         {links.map(({ href, label, icon: Icon }) => (
           <li key={href}>

--- a/packages/nextjs/components/LendingSidebar.tsx
+++ b/packages/nextjs/components/LendingSidebar.tsx
@@ -13,7 +13,7 @@ export const LendingSidebar = () => {
 
   return (
     <aside className="group w-16 hover:w-40 transition-all duration-300 overflow-hidden mr-4">
-      <ul className="menu bg-base-200 rounded-box p-2">
+      <ul className="menu bg-base-200 rounded-box py-2 pr-2 pl-0">
         {links.map(({ href, label, icon: Icon }) => (
           <li key={href}>
             <Link

--- a/packages/nextjs/components/LendingSidebar.tsx
+++ b/packages/nextjs/components/LendingSidebar.tsx
@@ -2,20 +2,28 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { RectangleStackIcon, BanknotesIcon } from "@heroicons/react/24/outline";
 
 export const LendingSidebar = () => {
   const pathname = usePathname();
   const links = [
-    { href: "/app", label: "Positions" },
-    { href: "/markets", label: "Markets" },
+    { href: "/app", label: "Positions", icon: RectangleStackIcon },
+    { href: "/markets", label: "Markets", icon: BanknotesIcon },
   ];
+
   return (
-    <aside className="w-32 mr-4">
+    <aside className="group w-16 hover:w-40 transition-all duration-300 overflow-hidden mr-4">
       <ul className="menu bg-base-200 rounded-box p-2">
-        {links.map(link => (
-          <li key={link.href}>
-            <Link href={link.href} className={pathname === link.href ? "active" : ""}>
-              {link.label}
+        {links.map(({ href, label, icon: Icon }) => (
+          <li key={href}>
+            <Link
+              href={href}
+              className={`flex items-center justify-center group-hover:justify-start gap-0 group-hover:gap-2 ${
+                pathname === href ? "active" : ""
+              }`}
+            >
+              <Icon className="h-6 w-6" />
+              <span className="hidden group-hover:inline">{label}</span>
             </Link>
           </li>
         ))}

--- a/packages/nextjs/components/LendingSidebar.tsx
+++ b/packages/nextjs/components/LendingSidebar.tsx
@@ -12,8 +12,8 @@ export const LendingSidebar = () => {
   ];
 
   return (
-    <aside className="group sticky top-[4.5rem] h-[calc(100vh-4.5rem)] self-start flex-shrink-0 w-16 hover:w-40 transition-all duration-300 overflow-hidden mr-4">
-      <ul className="menu bg-base-200 rounded-box py-2 pr-2 pl-0 h-full">
+    <aside className="group sticky top-[4.5rem] min-h-[calc(100vh-4.5rem)] self-start flex-shrink-0 w-16 hover:w-40 transition-all duration-300 overflow-hidden mr-4">
+      <ul className="menu bg-base-200 rounded-box py-2 pr-2 pl-0 min-h-full">
         {links.map(({ href, label, icon: Icon }) => (
           <li key={href}>
             <Link

--- a/packages/nextjs/components/modals/stark/DepositModalStark.tsx
+++ b/packages/nextjs/components/modals/stark/DepositModalStark.tsx
@@ -1,6 +1,6 @@
 import { FC } from "react";
 import { TokenActionModal, TokenInfo } from "../TokenActionModal";
-import { useLendingAction } from "~~/hooks/useLendingAction";
+import { VesuContext, useLendingAction } from "~~/hooks/useLendingAction";
 import { useTokenBalance } from "~~/hooks/useTokenBalance";
 import { PositionManager } from "~~/utils/position";
 
@@ -9,12 +9,20 @@ interface DepositModalStarkProps {
   onClose: () => void;
   token: TokenInfo;
   protocolName: string;
+  vesuContext?: VesuContext;
   position?: PositionManager;
 }
 
-export const DepositModalStark: FC<DepositModalStarkProps> = ({ isOpen, onClose, token, protocolName, position }) => {
+export const DepositModalStark: FC<DepositModalStarkProps> = ({
+  isOpen,
+  onClose,
+  token,
+  protocolName,
+  vesuContext,
+  position,
+}) => {
   const { balance, decimals } = useTokenBalance(token.address, "stark");
-  const { execute } = useLendingAction("stark", "Deposit", token.address, protocolName, decimals);
+  const { execute } = useLendingAction("stark", "Deposit", token.address, protocolName, decimals, vesuContext);
   return (
     <TokenActionModal
       isOpen={isOpen}

--- a/packages/nextjs/components/specific/vesu/VesuPosition.tsx
+++ b/packages/nextjs/components/specific/vesu/VesuPosition.tsx
@@ -326,6 +326,7 @@ export const VesuPosition: FC<VesuPositionProps> = ({
           decimals: Number(collateralMetadata.decimals),
         }}
         protocolName="Vesu"
+        vesuContext={nominalDebt !== "0" ? { poolId, counterpartToken: debtAsset } : undefined}
         position={position}
       />
 


### PR DESCRIPTION
## Summary
- forward Vesu context into Stark deposit modal
- use debt token when forwarding deposit context from Vesu positions

## Testing
- `yarn next:lint`
- `yarn test` *(fails: File @chainlink/contracts/src/v0.8/interfaces/FeedRegistryInterface.sol, imported from contracts/gateways/CompoundGateway.sol, not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6c4f104808320a662ddda9c883f21