### PR TITLE
Soften rate pill corners across market views

### DIFF
--- a/packages/nextjs/components/markets/InterestPillRow.tsx
+++ b/packages/nextjs/components/markets/InterestPillRow.tsx
@@ -12,7 +12,7 @@ export const RatePill: FC<{
   alt: string;
   sameProtocol?: boolean;
 }> = ({ current, optimal, color, logo, alt, sameProtocol = false }) => (
-  <div className="flex rounded-full overflow-hidden shadow text-sm text-white">
+  <div className="flex rounded-lg overflow-hidden shadow text-sm text-white">
     <span className={`px-3 py-1 ${color}`}>{current}</span>
     <span
       className={`px-3 py-1 flex items-center gap-1 ${

--- a/packages/nextjs/components/markets/RatePill.tsx
+++ b/packages/nextjs/components/markets/RatePill.tsx
@@ -26,7 +26,7 @@ const protocolIcons: Record<"aave" | "nostra" | "venus" | "vesu" | "compound", s
 export const RatePill: FC<RatePillProps> = ({ variant, label, rate, networkType, protocol, showIcons = true }) => {
   const color = variant === "supply" ? "bg-success text-success-content" : "bg-warning text-warning-content";
   return (
-    <div className="flex items-center rounded-full border border-base-300 text-sm overflow-hidden bg-base-100">
+    <div className="flex items-center rounded-lg border border-base-300 text-sm overflow-hidden bg-base-100">
       <span className={`px-3 py-1 ${color}`}>{label}</span>
       <span className="px-3 py-1 flex items-center gap-2">
         {rate}

--- a/packages/nextjs/components/specific/vesu/InterestPillRow.tsx
+++ b/packages/nextjs/components/specific/vesu/InterestPillRow.tsx
@@ -12,7 +12,7 @@ export const RatePill: FC<{
   alt: string;
   sameProtocol?: boolean;
 }> = ({ current, optimal, color, logo, alt, sameProtocol = false }) => (
-  <div className="flex rounded-full overflow-hidden shadow text-sm text-white">
+  <div className="flex rounded-lg overflow-hidden shadow text-sm text-white">
     <span className={`px-3 py-1 ${color}`}>{current}</span>
     <span
       className={`px-3 py-1 flex items-center gap-1 ${


### PR DESCRIPTION
## Summary
- switch market rate pill border radius from fully rounded to standard rounded style
- update interest pill rows in general and Vesu-specific views to match

## Testing
- `yarn workspace @se-2/nextjs lint`
- `yarn test` *(fails: File @chainlink/contracts/src/v0.8/interfaces/FeedRegistryInterface.sol not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f799b52c8320ae58003fdd7d53aa