### PR TITLE
add license page and footer link

### DIFF
--- a/packages/nextjs/app/license/page.tsx
+++ b/packages/nextjs/app/license/page.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import Link from "next/link";
+
+export const metadata = {
+  title: "License | Kapan Finance",
+};
+
+const LicensePage = () => {
+  return (
+    <div className="container mx-auto px-4 py-8 prose">
+      <h1>License</h1>
+      <p>
+        The software and information provided by Kapan Finance are offered on an "as is" and "as available" basis
+        without warranties of any kind, either express or implied. This includes but is not limited to implied
+        warranties of merchantability, fitness for a particular purpose, and noninfringement.
+      </p>
+      <p>
+        In no event shall the authors or copyright holders be liable for any claim, damages, or other liability, whether
+        in an action of contract, tort, or otherwise, arising from, out of, or in connection with the software or the
+        use or other dealings in the software.
+      </p>
+      <p>
+        By using this site or the associated software, you agree that you do so at your own risk. For more details,
+        please review the repository on
+        <Link href="https://github.com/stefaniliev545/kapan">GitHub</Link>.
+      </p>
+    </div>
+  );
+};
+
+export default LicensePage;

--- a/packages/nextjs/components/Footer.tsx
+++ b/packages/nextjs/components/Footer.tsx
@@ -9,7 +9,7 @@ export const Footer = () => {
   return (
     <div className="min-h-0 py-5 px-1 mb-11 lg:mb-0">
       <div>
-        <div className="fixed flex justify-start items-center w-full z-10 p-4 bottom-0 left-0 pointer-events-none">
+        <div className="fixed flex justify-between items-center w-full z-10 p-4 bottom-0 left-0 pointer-events-none">
           <div className="flex flex-col md:flex-row gap-2 pointer-events-auto">
             <Link
               href="https://discord.gg/Vjk6NhkxGv"
@@ -17,12 +17,12 @@ export const Footer = () => {
               rel="noopener noreferrer"
               className="flex items-center gap-1 text-sm bg-base-100 dark:bg-base-200 rounded-full px-3 py-2 shadow-md hover:shadow-lg transition-all"
             >
-              <Image 
-                src="/logos/discord.svg" 
-                alt="Discord Logo" 
-                width={20} 
-                height={20} 
-                className="w-5 h-5 dark:invert dark:brightness-90" 
+              <Image
+                src="/logos/discord.svg"
+                alt="Discord Logo"
+                width={20}
+                height={20}
+                className="w-5 h-5 dark:invert dark:brightness-90"
               />
               <span className="text-base-content">Join our Discord</span>
             </Link>
@@ -42,13 +42,18 @@ export const Footer = () => {
               className="flex items-center justify-center bg-base-100 dark:bg-base-200 rounded-full w-10 h-10 shadow-md hover:shadow-lg transition-all"
               title="Follow us on X"
             >
-              <Image 
-                src="/logos/x-logo.svg" 
-                alt="X Logo" 
-                width={16} 
-                height={16} 
-                className="w-4 h-4 dark:invert dark:brightness-90" 
+              <Image
+                src="/logos/x-logo.svg"
+                alt="X Logo"
+                width={16}
+                height={16}
+                className="w-4 h-4 dark:invert dark:brightness-90"
               />
+            </Link>
+          </div>
+          <div className="pointer-events-auto">
+            <Link href="/license" className="text-xs text-base-content/70 hover:underline">
+              License
             </Link>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add small footer link to new license page
- create license page with no-liability, no-warranty terms

## Testing
- `yarn workspace @se-2/nextjs lint` *(fails: command not found: next)*
- `yarn test` *(fails: command not found: hardhat)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ffcc0eb4832080e169ebc3f38963