### PR TITLE
Hide sidebar on mobile and add markets menu

### DIFF
--- a/packages/nextjs/app/app/page.tsx
+++ b/packages/nextjs/app/app/page.tsx
@@ -69,7 +69,9 @@ const App: NextPage = () => {
 
   return (
     <div className="container mx-auto px-5 flex">
-      <LendingSidebar />
+      <div className="hidden lg:block">
+        <LendingSidebar />
+      </div>
       <div className="flex-1">
         <NetworkFilter networks={networkOptions} defaultNetwork="starknet" onNetworkChange={setSelectedNetwork} />
 

--- a/packages/nextjs/app/markets/page.tsx
+++ b/packages/nextjs/app/markets/page.tsx
@@ -34,7 +34,9 @@ const MarketsPage: NextPage = () => {
 
   return (
     <div className="container mx-auto px-5 flex">
-      <LendingSidebar />
+      <div className="hidden lg:block">
+        <LendingSidebar />
+      </div>
       <div className="flex-1">
         <div className="flex items-center mb-4">
           {groupMode === "protocol" && (

--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -12,6 +12,7 @@ import {
   DocumentChartBarIcon,
   SparklesIcon,
   WalletIcon,
+  BanknotesIcon,
   XMarkIcon,
 } from "@heroicons/react/24/outline";
 import { SwitchTheme } from "~~/components/SwitchTheme";
@@ -43,12 +44,21 @@ export const menuLinks: HeaderMenuLink[] = [
   }
 ];
 
-export const HeaderMenuLinks = () => {
+const mobileOnlyLinks: HeaderMenuLink[] = [
+  {
+    label: "Markets",
+    href: "/markets",
+    icon: <BanknotesIcon className="h-5 w-5" />,
+  },
+];
+
+export const HeaderMenuLinks = ({ isMobile = false }: { isMobile?: boolean }) => {
   const pathname = usePathname();
+  const links = isMobile ? [...menuLinks, ...mobileOnlyLinks] : menuLinks;
 
   return (
     <>
-      {menuLinks.map(({ label, href, icon }, index) => {
+      {links.map(({ label, href, icon }, index) => {
         const isActive = pathname === href;
         return (
           <motion.li
@@ -229,7 +239,7 @@ export const Header = () => {
                           </div>
                         </div>
                         <ul className="space-y-2">
-                          <HeaderMenuLinks />
+                          <HeaderMenuLinks isMobile />
                         </ul>
                         <div className="mt-6 pt-4 border-t border-base-300/50 dark:border-base-content/10">
                           <div className="flex flex-col space-y-2 items-stretch relative z-50">


### PR DESCRIPTION
## Summary
- Hide lending sidebar on mobile layouts
- Add mobile-only Markets link to header dropdown

## Testing
- `yarn lint` *(fails: command not found: next)*
- `yarn test` *(fails: command not found: hardhat)*

------
https://chatgpt.com/codex/tasks/task_e_68b710039a288320ba96f4ab1790236b