### PR TITLE
Ensure debt move authorizations precede execution

### DIFF
--- a/packages/nextjs/components/modals/stark/MovePositionModal.tsx
+++ b/packages/nextjs/components/modals/stark/MovePositionModal.tsx
@@ -590,7 +590,6 @@ export const MovePositionModal: FC<MovePositionModalProps> = ({
           instructions: [borrowInstruction],
         },
       ],
-      rawSelectors: false,
     });
 
     return {
@@ -611,7 +610,7 @@ export const MovePositionModal: FC<MovePositionModalProps> = ({
   const { data: protocolInstructions, error: protocolInstructionsError } = useScaffoldReadContract({
     contractName: "RouterGateway" as const,
     functionName: "get_authorizations_for_instructions" as const,
-    args: [authInstruction],
+    args: [authInstruction, false],
     enabled: !!authInstruction && isOpen,
     refetchInterval: 1000,
   } as any);


### PR DESCRIPTION
## Summary
- compile authorization instructions separately
- request authorizations with explicit raw selector flag before sending `move_debt`

## Testing
- `yarn workspace @se-2/nextjs lint` *(fails: command not found: next)*
- `yarn test` *(fails: command not found: hardhat)*

------
https://chatgpt.com/codex/tasks/task_e_68b726c465648320b4c72c2d13dbbd0f