### PR TITLE
feat: keep Vesu positions visible during refetch

### DIFF
--- a/packages/nextjs/components/specific/vesu/VesuProtocolView.tsx
+++ b/packages/nextjs/components/specific/vesu/VesuProtocolView.tsx
@@ -27,14 +27,14 @@ export const VesuProtocolView: FC = () => {
   }
 
   // Paginated user positions reads
-  const { data: userPositionsPart1, error: positionsError1 } = useScaffoldReadContract({
+  const { data: userPositionsPart1, error: positionsError1, isFetching: isFetching1 } = useScaffoldReadContract({
     contractName: "VesuGateway",
     functionName: "get_all_positions_range",
     args: [userAddress || "0x0", selectedPoolId, 0n, 3n],
     watch: true,
     refetchInterval: 5000,
   });
-  const { data: userPositionsPart2, error: positionsError2 } = useScaffoldReadContract({
+  const { data: userPositionsPart2, error: positionsError2, isFetching: isFetching2 } = useScaffoldReadContract({
     contractName: "VesuGateway",
     functionName: "get_all_positions_range",
     args: [userAddress || "0x0", selectedPoolId, 3n, 10n],
@@ -54,6 +54,8 @@ export const VesuProtocolView: FC = () => {
     const p2 = (userPositionsPart2 as unknown as PositionTuple[]) || [];
     return [...p1, ...p2];
   }, [userPositionsPart1, userPositionsPart2]);
+
+  const isUpdating = isFetching1 || isFetching2;
 
   const positionRows = useMemo(() => {
     if (!mergedUserPositions || !supportedAssets) return null;
@@ -158,7 +160,7 @@ export const VesuProtocolView: FC = () => {
                 </div>
               ) : null}
             </div>
-            <div className="flex flex-wrap gap-4 justify-start">
+            <div className={`flex flex-wrap gap-4 justify-start ${isUpdating ? "animate-pulse" : ""}`}>
               {positionRows?.length ? (
                 positionRows
               ) : (

--- a/packages/nextjs/hooks/scaffold-stark/useScaffoldReadContract.ts
+++ b/packages/nextjs/hooks/scaffold-stark/useScaffoldReadContract.ts
@@ -24,7 +24,7 @@ export const useScaffoldReadContract = <
   const { data: deployedContract } = useDeployedContractInfo(contractName);
   const blockNumber = useStarkBlockNumber();
 
-  const { watch: watchConfig, ...restConfig } = readConfig as any;
+  const { watch: watchConfig, query: queryOptions, ...restConfig } = readConfig as any;
 
   const serializedArgs = args ? JSON.parse(JSON.stringify(args, replacer)) : [];
 
@@ -42,6 +42,7 @@ export const useScaffoldReadContract = <
     enabled: args && (!Array.isArray(args) || !args.some(arg => arg === undefined)),
     blockIdentifier,
     ...restConfig,
+    query: { keepPreviousData: true, ...(queryOptions || {}) },
   }) as Omit<ReturnType<typeof useReadContract>, "data"> & {
     data: AbiFunctionOutputs<ContractAbi, TFunctionName> | undefined;
   };


### PR DESCRIPTION
## Summary
- retain previous contract read data while fetching new blocks
- show a subtle animation on Vesu positions when data is updating

## Testing
- `./node_modules/.bin/next lint`
- `./node_modules/.bin/tsc --noEmit --incremental`
- `yarn test` (fails: File @chainlink/contracts/src/v0.8/interfaces/FeedRegistryInterface.sol not found)


------
https://chatgpt.com/codex/tasks/task_e_68b72968d0908320b9cec149c33bc5df