### PR TITLE
feat: apply Inter font globally

### DIFF
--- a/packages/nextjs/app/layout.tsx
+++ b/packages/nextjs/app/layout.tsx
@@ -2,6 +2,7 @@ import "@rainbow-me/rainbowkit/styles.css";
 import { Analytics } from "@vercel/analytics/react";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { Metadata } from "next";
+import { Inter } from "next/font/google";
 import { ScaffoldEthAppWithProviders } from "~~/components/ScaffoldEthAppWithProviders";
 import { ThemeProvider } from "~~/components/ThemeProvider";
 import "~~/styles/globals.css";
@@ -22,10 +23,15 @@ export const viewport = {
   maximumScale: 1,
 };
 
+const inter = Inter({
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+});
+
 const ScaffoldEthApp = ({ children }: { children: React.ReactNode }) => {
   return (
     <html suppressHydrationWarning>
-      <body>
+      <body className={inter.className}>
         <ThemeProvider>
           <ScaffoldEthAppWithProviders>{children}</ScaffoldEthAppWithProviders>
         </ThemeProvider>


### PR DESCRIPTION
## Summary
- load Inter from next/font and apply to body for consistent typography

## Testing
- `yarn lint`
- `yarn next:check-types`
- `yarn test` *(fails: HH404 File @chainlink/contracts/src/v0.8/interfaces/FeedRegistryInterface.sol, imported from contracts/gateways/CompoundGateway.sol, not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf279f4f5c8320858714a8fe0894d6