### PR TITLE
Limit Vesu to Genesis pool

### DIFF
--- a/packages/nextjs/app/markets/page.tsx
+++ b/packages/nextjs/app/markets/page.tsx
@@ -20,15 +20,16 @@ const networkOptions: NetworkOption[] = [
 
 const MarketsPage: NextPage = () => {
   const [selectedNetwork, setSelectedNetwork] = useState<string>("starknet");
-  const [selectedPoolId, setSelectedPoolId] = useState<bigint>(POOL_IDS["Genesis"]);
   const [viewMode, setViewMode] = useState<"list" | "grid">("grid");
   const [search, setSearch] = useState("");
   const [groupMode, setGroupMode] = useState<"token" | "protocol">("token");
 
+  const poolId = POOL_IDS["Genesis"];
+
   const { data: supportedAssets } = useScaffoldReadContract({
     contractName: "VesuGateway",
     functionName: "get_supported_assets_ui",
-    args: [selectedPoolId],
+    args: [poolId],
     refetchInterval: 0,
   });
 
@@ -103,8 +104,6 @@ const MarketsPage: NextPage = () => {
             {selectedNetwork === "starknet" && (
               <>
                 <VesuMarkets
-                  selectedPoolId={selectedPoolId}
-                  onPoolChange={setSelectedPoolId}
                   supportedAssets={supportedAssets as ContractResponse | undefined}
                   viewMode={viewMode}
                   search={search}

--- a/packages/nextjs/components/modals/stark/MovePositionModal.tsx
+++ b/packages/nextjs/components/modals/stark/MovePositionModal.tsx
@@ -40,8 +40,6 @@ type MoveStep = "idle" | "executing" | "done";
 // Define pool IDs
 const POOL_IDS = {
   Genesis: 0n,
-  "Re7 USDC": 3592370751539490711610556844458488648008775713878064059760995781404350938653n,
-  "Alterscope wstETH": 2612229586214495842527551768232431476062656055007024497123940017576986139174n,
 } as const;
 
 // Helper function to get pool name from ID
@@ -1102,14 +1100,13 @@ export const MovePositionModal: FC<MovePositionModalProps> = ({
                         .map(([name, id]) => (
                           <li key={name}>
                             <button className="flex items-center gap-3 py-2" onClick={() => setSelectedPoolId(id)}>
-                              {name === "Genesis" && <Image src="/logos/vesu.svg" alt="Vesu" width={32} height={32} className="rounded-full min-w-[32px]" />}
-                              {name === "Re7 USDC" && <Image src="/logos/re7.svg" alt="Re7" width={32} height={32} className="rounded-full min-w-[32px]" />}
-                              {name === "Alterscope wstETH" && (
-                                <>
-                                  <Image src="/logos/alterscope_symbol_black.svg" alt="Alterscope" width={32} height={32} className="rounded-full min-w-[32px] dark:hidden" />
-                                  <Image src="/logos/alterscope_symbol_white.svg" alt="Alterscope" width={32} height={32} className="rounded-full min-w-[32px] hidden dark:block" />
-                                </>
-                              )}
+                              <Image
+                                src="/logos/vesu.svg"
+                                alt="Vesu"
+                                width={32}
+                                height={32}
+                                className="rounded-full min-w-[32px]"
+                              />
                               <span className="truncate text-lg">{name}</span>
                             </button>
                           </li>

--- a/packages/nextjs/components/specific/vesu/VesuMarkets.tsx
+++ b/packages/nextjs/components/specific/vesu/VesuMarkets.tsx
@@ -1,5 +1,4 @@
 import { FC, useMemo } from "react";
-import Image from "next/image";
 import { MarketsSection, MarketData } from "~~/components/markets/MarketsSection";
 import { tokenNameToLogo } from "~~/contracts/externalContracts";
 import {
@@ -12,8 +11,6 @@ import {
 
 export const POOL_IDS = {
   Genesis: 2198503327643286920898110335698706244522220458610657370981979460625005526824n,
-  "Re7 USDC": 3592370751539490711610556844458488648008775713878064059760995781404350938653n,
-  "Alterscope wstETH": 2612229586214495842527551768232431476062656055007024497123940017576986139174n,
 } as const;
 
 export type ContractResponse = {
@@ -31,20 +28,12 @@ export type ContractResponse = {
 }[];
 
 interface VesuMarketsProps {
-  selectedPoolId: bigint;
-  onPoolChange: (id: bigint) => void;
   supportedAssets?: ContractResponse;
   viewMode: "list" | "grid";
   search: string;
 }
 
-export const VesuMarkets: FC<VesuMarketsProps> = ({
-  selectedPoolId,
-  onPoolChange,
-  supportedAssets,
-  viewMode,
-  search,
-}) => {
+export const VesuMarkets: FC<VesuMarketsProps> = ({ supportedAssets, viewMode, search }) => {
 
   const markets: MarketData[] = useMemo(() => {
     if (!supportedAssets) return [];
@@ -72,46 +61,7 @@ export const VesuMarkets: FC<VesuMarketsProps> = ({
     });
   }, [supportedAssets]);
 
-  const poolTabs = (
-    <div className="tabs tabs-boxed mb-4">
-      <button
-        className={`tab ${selectedPoolId === POOL_IDS["Genesis"] ? "tab-active" : ""}`}
-        onClick={() => onPoolChange(POOL_IDS["Genesis"])}
-      >
-        <Image src="/logos/vesu.svg" alt="Vesu" width={20} height={20} className="rounded-full min-w-[20px]" />
-        Genesis
-      </button>
-      <button
-        className={`tab ${selectedPoolId === POOL_IDS["Re7 USDC"] ? "tab-active" : ""}`}
-        onClick={() => onPoolChange(POOL_IDS["Re7 USDC"])}
-      >
-        <Image src="/logos/re7.svg" alt="Re7" width={20} height={20} className="rounded-full min-w-[20px]" />
-        Re7 USDC
-      </button>
-      <button
-        className={`tab ${selectedPoolId === POOL_IDS["Alterscope wstETH"] ? "tab-active" : ""}`}
-        onClick={() => onPoolChange(POOL_IDS["Alterscope wstETH"])}
-      >
-        <Image
-          src="/logos/alterscope_symbol_black.svg"
-          alt="Alterscope"
-          width={20}
-          height={20}
-          className="rounded-full min-w-[20px] dark:hidden"
-        />
-        <Image
-          src="/logos/alterscope_symbol_white.svg"
-          alt="Alterscope"
-          width={20}
-          height={20}
-          className="rounded-full min-w-[20px] hidden dark:block"
-        />
-        Alterscope wstETH
-      </button>
-    </div>
-  );
-
-  return <MarketsSection title="Vesu Markets" markets={markets} extra={poolTabs} viewMode={viewMode} search={search} />;
+  return <MarketsSection title="Vesu Markets" markets={markets} viewMode={viewMode} search={search} />;
 };
 
 export default VesuMarkets;

--- a/packages/nextjs/components/specific/vesu/VesuProtocolView.tsx
+++ b/packages/nextjs/components/specific/vesu/VesuProtocolView.tsx
@@ -13,12 +13,12 @@ type PositionTuple = {
 
 export const VesuProtocolView: FC = () => {
   const { address: userAddress } = useAccount();
-  const [selectedPoolId, setSelectedPoolId] = useState<bigint>(POOL_IDS["Genesis"]);
+  const poolId = POOL_IDS["Genesis"];
 
   const { data: supportedAssets, error: assetsError } = useScaffoldReadContract({
     contractName: "VesuGateway",
     functionName: "get_supported_assets_ui",
-    args: [selectedPoolId],
+    args: [poolId],
     refetchInterval: 0,
   });
 
@@ -30,14 +30,14 @@ export const VesuProtocolView: FC = () => {
   const { data: userPositionsPart1, error: positionsError1, isFetching: isFetching1 } = useScaffoldReadContract({
     contractName: "VesuGateway",
     functionName: "get_all_positions_range",
-    args: [userAddress || "0x0", selectedPoolId, 0n, 3n],
+    args: [userAddress || "0x0", poolId, 0n, 3n],
     watch: true,
     refetchInterval: 5000,
   });
   const { data: userPositionsPart2, error: positionsError2, isFetching: isFetching2 } = useScaffoldReadContract({
     contractName: "VesuGateway",
     functionName: "get_all_positions_range",
-    args: [userAddress || "0x0", selectedPoolId, 3n, 10n],
+    args: [userAddress || "0x0", poolId, 3n, 10n],
     watch: true,
     refetchInterval: 5000,
   });
@@ -99,11 +99,11 @@ export const VesuProtocolView: FC = () => {
           nominalDebt={positionData.nominal_debt.toString()}
           isVtoken={positionData.is_vtoken}
           supportedAssets={assetsWithRates as unknown as TokenMetadata[]}
-          poolId={selectedPoolId}
+          poolId={poolId}
         />
       );
     });
-  }, [cachedPositions, supportedAssets, selectedPoolId]);
+  }, [cachedPositions, supportedAssets, poolId]);
 
   if (assetsError) {
     console.error("Error fetching supported assets:", assetsError);
@@ -113,8 +113,6 @@ export const VesuProtocolView: FC = () => {
   return (
     <div className="space-y-4">
       <VesuMarkets
-        selectedPoolId={selectedPoolId}
-        onPoolChange={setSelectedPoolId}
         supportedAssets={supportedAssets as ContractResponse | undefined}
         viewMode="grid"
         search=""


### PR DESCRIPTION
## Summary
- remove Re7 and Alterscope pools from Vesu listings
- default all Vesu views to Genesis pool

## Testing
- `yarn lint`
- `yarn test` *(fails: File @chainlink/contracts/src/v0.8/interfaces/FeedRegistryInterface.sol, imported from contracts/gateways/CompoundGateway.sol, not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf2e6332d4832096e9bc841a352494