### PR TITLE
feat: disable move supply for nostra

### DIFF
--- a/packages/nextjs/components/ProtocolView.tsx
+++ b/packages/nextjs/components/ProtocolView.tsx
@@ -34,6 +34,7 @@ interface ProtocolViewProps {
   hideUtilization?: boolean;
   forceShowAll?: boolean; // If true, always show all assets regardless of showAll toggle
   networkType: "evm" | "starknet"; // Specify which network this protocol view is for
+  disableMoveSupply?: boolean;
 }
 
 // Health status indicator component that shows utilization percentage
@@ -65,6 +66,7 @@ export const ProtocolView: FC<ProtocolViewProps> = ({
   hideUtilization = false,
   forceShowAll = false,
   networkType,
+  disableMoveSupply = false,
 }) => {
   const [showAll, setShowAll] = useState(false);
   const [isTokenSelectModalOpen, setIsTokenSelectModalOpen] = useState(false);
@@ -295,6 +297,7 @@ export const ProtocolView: FC<ProtocolViewProps> = ({
                         protocolName={protocolName}
                         networkType={networkType}
                         position={positionManager}
+                        disableMove={disableMoveSupply}
                       />
                     </div>
                   ))}

--- a/packages/nextjs/components/SupplyPosition.tsx
+++ b/packages/nextjs/components/SupplyPosition.tsx
@@ -19,6 +19,7 @@ export type SupplyPositionProps = ProtocolPosition & {
   afterInfoContent?: React.ReactNode;
   networkType: "evm" | "starknet";
   position?: PositionManager;
+  disableMove?: boolean;
 };
 
 export const SupplyPosition: FC<SupplyPositionProps> = ({
@@ -34,6 +35,7 @@ export const SupplyPosition: FC<SupplyPositionProps> = ({
   afterInfoContent,
   networkType,
   position,
+  disableMove = false,
 }) => {
   const moveModal = useModal();
   const depositModal = useModal();
@@ -211,22 +213,24 @@ export const SupplyPosition: FC<SupplyPositionProps> = ({
                   <span>Withdraw</span>
                 </div>
               </button>
-              <button
-                className="btn btn-sm btn-outline w-full flex justify-center items-center"
-                onClick={moveModal.open}
-                disabled={!isWalletConnected || !hasBalance}
-                title={
-                  !isWalletConnected
-                    ? "Connect wallet to move supply"
-                    : !hasBalance
-                      ? "No balance to move"
-                      : "Move supply to another protocol"
-                }
-              >
-                <div className="flex items-center justify-center">
-                  <span>Move</span>
-                </div>
-              </button>
+              {!disableMove && (
+                <button
+                  className="btn btn-sm btn-outline w-full flex justify-center items-center"
+                  onClick={moveModal.open}
+                  disabled={!isWalletConnected || !hasBalance}
+                  title={
+                    !isWalletConnected
+                      ? "Connect wallet to move supply"
+                      : !hasBalance
+                        ? "No balance to move"
+                        : "Move supply to another protocol"
+                  }
+                >
+                  <div className="flex items-center justify-center">
+                    <span>Move</span>
+                  </div>
+                </button>
+              )}
             </div>
 
             {/* Desktop layout - evenly distributed buttons in a row */}
@@ -257,22 +261,24 @@ export const SupplyPosition: FC<SupplyPositionProps> = ({
                   <span>Withdraw</span>
                 </div>
               </button>
-              <button
-                className="btn btn-sm btn-outline flex justify-center items-center"
-                onClick={moveModal.open}
-                disabled={!isWalletConnected || !hasBalance}
-                title={
-                  !isWalletConnected
-                    ? "Connect wallet to move supply"
-                    : !hasBalance
-                      ? "No balance to move"
-                      : "Move supply to another protocol"
-                }
-              >
-                <div className="flex items-center justify-center">
-                  <span>Move</span>
-                </div>
-              </button>
+              {!disableMove && (
+                <button
+                  className="btn btn-sm btn-outline flex justify-center items-center"
+                  onClick={moveModal.open}
+                  disabled={!isWalletConnected || !hasBalance}
+                  title={
+                    !isWalletConnected
+                      ? "Connect wallet to move supply"
+                      : !hasBalance
+                        ? "No balance to move"
+                        : "Move supply to another protocol"
+                  }
+                >
+                  <div className="flex items-center justify-center">
+                    <span>Move</span>
+                  </div>
+                </button>
+              )}
             </div>
           </div>
         )}
@@ -330,20 +336,22 @@ export const SupplyPosition: FC<SupplyPositionProps> = ({
         </>
       )}
 
-      <MoveSupplyModal
-        isOpen={moveModal.isOpen}
-        onClose={moveModal.close}
-        token={{
-          name,
-          icon,
-          address: tokenAddress,
-          currentRate,
-          rawBalance: typeof tokenBalance === "bigint" ? tokenBalance : BigInt(tokenBalance || 0),
-          decimals: tokenDecimals,
-          price: tokenPrice,
-        }}
-        fromProtocol={protocolName}
-      />
+      {!disableMove && (
+        <MoveSupplyModal
+          isOpen={moveModal.isOpen}
+          onClose={moveModal.close}
+          token={{
+            name,
+            icon,
+            address: tokenAddress,
+            currentRate,
+            rawBalance: typeof tokenBalance === "bigint" ? tokenBalance : BigInt(tokenBalance || 0),
+            decimals: tokenDecimals,
+            price: tokenPrice,
+          }}
+          fromProtocol={protocolName}
+        />
+      )}
     </>
   );
 };

--- a/packages/nextjs/components/specific/nostra/NostraProtocolView.tsx
+++ b/packages/nextjs/components/specific/nostra/NostraProtocolView.tsx
@@ -171,6 +171,7 @@ export const NostraProtocolView: FC = () => {
       borrowedPositions={borrowedPositions}
       forceShowAll={forceShowAll}
       networkType="starknet"
+      disableMoveSupply
     />
   );
 };


### PR DESCRIPTION
## Summary
- support disabling move supply button in protocol view
- hide move supply option for Nostra protocol

## Testing
- `yarn lint`
- `yarn test` *(fails: File @chainlink/contracts/src/v0.8/interfaces/FeedRegistryInterface.sol not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf317c9b988320aa1c9844c3689a62