### PR TITLE
fix: improve Vesu positions loading state

### DIFF
--- a/packages/nextjs/components/specific/vesu/VesuProtocolView.tsx
+++ b/packages/nextjs/components/specific/vesu/VesuProtocolView.tsx
@@ -1,5 +1,5 @@
 import { FC, useEffect, useMemo, useState } from "react";
-import { useAccount } from "@starknet-react/core";
+import { useAccount } from "~~/hooks/useAccount";
 import { useScaffoldReadContract } from "~~/hooks/scaffold-stark";
 import { VesuMarkets, POOL_IDS, ContractResponse } from "./VesuMarkets";
 import { VesuPosition } from "./VesuPosition";
@@ -12,7 +12,7 @@ type PositionTuple = {
 };
 
 export const VesuProtocolView: FC = () => {
-  const { address: userAddress } = useAccount();
+  const { address: userAddress, status } = useAccount();
   const poolId = POOL_IDS["Genesis"];
 
   const { data: supportedAssets, error: assetsError } = useScaffoldReadContract({
@@ -30,14 +30,14 @@ export const VesuProtocolView: FC = () => {
   const { data: userPositionsPart1, error: positionsError1, isFetching: isFetching1 } = useScaffoldReadContract({
     contractName: "VesuGateway",
     functionName: "get_all_positions_range",
-    args: [userAddress || "0x0", poolId, 0n, 3n],
+    args: [userAddress, poolId, 0n, 3n],
     watch: true,
     refetchInterval: 5000,
   });
   const { data: userPositionsPart2, error: positionsError2, isFetching: isFetching2 } = useScaffoldReadContract({
     contractName: "VesuGateway",
     functionName: "get_all_positions_range",
-    args: [userAddress || "0x0", poolId, 3n, 10n],
+    args: [userAddress, poolId, 3n, 10n],
     watch: true,
     refetchInterval: 5000,
   });
@@ -61,10 +61,14 @@ export const VesuProtocolView: FC = () => {
   const [cachedPositions, setCachedPositions] = useState<PositionTuple[]>([]);
 
   useEffect(() => {
+    if (!userAddress) {
+      setCachedPositions([]);
+      return;
+    }
     if (!isUpdating) {
       setCachedPositions(mergedUserPositions);
     }
-  }, [mergedUserPositions, isUpdating]);
+  }, [mergedUserPositions, isUpdating, userAddress]);
 
   const positionRows = useMemo(() => {
     if (!supportedAssets) return null;
@@ -118,65 +122,71 @@ export const VesuProtocolView: FC = () => {
         search=""
       />
 
-      {userAddress && (
-        <div className="card bg-base-100 shadow-md">
-          <div className="card-body p-4">
-            <div className="flex justify-between items-center mb-4">
-              <h2 className="card-title text-lg">Your Positions</h2>
-              {positionRows?.length ? (
-                <div className="text-right">
-                  <div className="text-sm text-gray-500">Total Net Balance</div>
-                  <div className="text-xl font-bold">
-                    $
-                    {positionRows
-                      .reduce((total, position) => {
-                        const collateralMetadata = position.props.supportedAssets.find(
-                          (asset: TokenMetadata) =>
-                            `0x${BigInt(asset.address).toString(16).padStart(64, "0")}` ===
-                            position.props.collateralAsset,
-                        );
-                        const debtMetadata = position.props.supportedAssets.find(
-                          (asset: TokenMetadata) =>
-                            `0x${BigInt(asset.address).toString(16).padStart(64, "0")}` === position.props.debtAsset,
-                        );
+      <div className="card bg-base-100 shadow-md">
+        <div className="card-body p-4">
+          <div className="flex justify-between items-center mb-4">
+            <h2 className="card-title text-lg">Your Positions</h2>
+            {userAddress && positionRows?.length ? (
+              <div className="text-right">
+                <div className="text-sm text-gray-500">Total Net Balance</div>
+                <div className="text-xl font-bold">
+                  $
+                  {positionRows
+                    .reduce((total, position) => {
+                      const collateralMetadata = position.props.supportedAssets.find(
+                        (asset: TokenMetadata) =>
+                          `0x${BigInt(asset.address).toString(16).padStart(64, "0")}` ===
+                          position.props.collateralAsset,
+                      );
+                      const debtMetadata = position.props.supportedAssets.find(
+                        (asset: TokenMetadata) =>
+                          `0x${BigInt(asset.address).toString(16).padStart(64, "0")}` === position.props.debtAsset,
+                      );
 
-                        if (!collateralMetadata) return total;
+                      if (!collateralMetadata) return total;
 
-                        const collateralAmtNum = parseFloat(
-                          formatTokenAmount(position.props.collateralAmount, collateralMetadata.decimals),
-                        );
-                        const collateralPriceNum = parseFloat(
-                          formatTokenAmount(collateralMetadata.price.value.toString(), 18),
-                        );
-                        const collateralValue = collateralAmtNum * collateralPriceNum;
+                      const collateralAmtNum = parseFloat(
+                        formatTokenAmount(position.props.collateralAmount, collateralMetadata.decimals),
+                      );
+                      const collateralPriceNum = parseFloat(
+                        formatTokenAmount(collateralMetadata.price.value.toString(), 18),
+                      );
+                      const collateralValue = collateralAmtNum * collateralPriceNum;
 
-                        let debtValue = 0;
-                        if (position.props.nominalDebt !== "0" && debtMetadata) {
-                          const debtAmtNum = parseFloat(formatTokenAmount(position.props.nominalDebt, 18));
-                          const debtPriceNum = parseFloat(formatTokenAmount(debtMetadata.price.value.toString(), 18));
-                          debtValue = debtAmtNum * debtPriceNum;
-                        }
+                      let debtValue = 0;
+                      if (position.props.nominalDebt !== "0" && debtMetadata) {
+                        const debtAmtNum = parseFloat(formatTokenAmount(position.props.nominalDebt, 18));
+                        const debtPriceNum = parseFloat(formatTokenAmount(debtMetadata.price.value.toString(), 18));
+                        debtValue = debtAmtNum * debtPriceNum;
+                      }
 
-                        return total + (collateralValue - debtValue);
-                      }, 0)
-                      .toLocaleString("en-US", {
-                        minimumFractionDigits: 2,
-                        maximumFractionDigits: 2,
-                      })}
-                  </div>
+                      return total + (collateralValue - debtValue);
+                    }, 0)
+                    .toLocaleString("en-US", {
+                      minimumFractionDigits: 2,
+                      maximumFractionDigits: 2,
+                    })}
                 </div>
-              ) : null}
-            </div>
-            <div className={`flex flex-wrap gap-4 justify-start ${isUpdating ? "" : ""}`}>
-              {positionRows?.length ? (
-                positionRows
-              ) : (
-                <div className="text-center py-4 text-gray-500 w-full">No positions found</div>
-              )}
-            </div>
+              </div>
+            ) : null}
+          </div>
+          <div className={`flex flex-wrap gap-4 justify-start ${isUpdating ? "" : ""}`}>
+            {status === "connecting" ? (
+              <div className="text-center py-4 w-full">
+                <span className="loading loading-spinner" />
+              </div>
+            ) : !userAddress ? (
+              <div className="text-center py-4 text-gray-500 w-full">
+                Connect your Starknet wallet to view
+              </div>
+            ) : positionRows?.length ? (
+              positionRows
+            ) : (
+              <div className="text-center py-4 text-gray-500 w-full">No positions found</div>
+            )}
           </div>
         </div>
-      )}
+      </div>
     </div>
   );
 };

--- a/packages/nextjs/components/specific/vesu/VesuProtocolView.tsx
+++ b/packages/nextjs/components/specific/vesu/VesuProtocolView.tsx
@@ -145,7 +145,7 @@ export const VesuProtocolView: FC = () => {
   }
 
   return (
-    <div className="space-y-4">
+    <div className="w-full flex flex-col p-4 space-y-4">
       <VesuMarkets
         supportedAssets={supportedAssets as ContractResponse | undefined}
         viewMode="grid"

--- a/packages/nextjs/hooks/scaffold-eth/useTransactor.tsx
+++ b/packages/nextjs/hooks/scaffold-eth/useTransactor.tsx
@@ -88,6 +88,10 @@ export const useTransactor = (_walletClient?: WalletClient): TransactionFunc => 
         },
       );
 
+      if (typeof window !== "undefined") {
+        window.dispatchEvent(new Event("txCompleted"));
+      }
+
       if (options?.onBlockConfirmation) options.onBlockConfirmation(transactionReceipt);
     } catch (error: any) {
       if (notificationId) {

--- a/packages/nextjs/hooks/scaffold-stark/useTransactor.tsx
+++ b/packages/nextjs/hooks/scaffold-stark/useTransactor.tsx
@@ -84,6 +84,10 @@ export const useTransactor = (_walletClient?: AccountInterface): TransactionFunc
           icon: "🎉",
         },
       );
+
+      if (typeof window !== "undefined") {
+        window.dispatchEvent(new Event("txCompleted"));
+      }
     } catch (error: any) {
       if (notificationId) {
         notification.remove(notificationId);


### PR DESCRIPTION
## Summary
- show a Vesu Positions card even when no wallet is connected
- avoid fetching positions for the zero address and clear cached data on disconnect
- display a spinner while the wallet connects

## Testing
- `yarn lint`
- `yarn check-types && echo "Type check passed"`


------
https://chatgpt.com/codex/tasks/task_e_68bf41fb5dd08320bfe41d65e7cd98f5