### PR TITLE
feat: add protocol instruction processing

### DIFF
--- a/packages/hardhat/contracts/interfaces/chainlink/AggregatorV3Interface.sol
+++ b/packages/hardhat/contracts/interfaces/chainlink/AggregatorV3Interface.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface AggregatorV3Interface {
+    function latestRoundData()
+        external
+        view
+        returns (
+            uint80 roundId,
+            int256 answer,
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        );
+}

--- a/packages/hardhat/contracts/interfaces/chainlink/Denominations.sol
+++ b/packages/hardhat/contracts/interfaces/chainlink/Denominations.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+library Denominations {
+    address constant USD = address(840);
+}

--- a/packages/hardhat/contracts/interfaces/chainlink/FeedRegistryInterface.sol
+++ b/packages/hardhat/contracts/interfaces/chainlink/FeedRegistryInterface.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface FeedRegistryInterface {
+    function latestRoundData(address base, address quote)
+        external
+        view
+        returns (
+            uint80 roundId,
+            int256 answer,
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        );
+}

--- a/packages/hardhat/contracts/mocks/MockGateway.sol
+++ b/packages/hardhat/contracts/mocks/MockGateway.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../interfaces/IGateway.sol";
+
+contract MockGateway is IGateway {
+    uint256 public mockBalance;
+    uint256 public mockDebt;
+    uint256 public lastAmount;
+
+    function setMockBalance(uint256 bal) external { mockBalance = bal; }
+    function setMockDebt(uint256 debt) external { mockDebt = debt; }
+
+    function deposit(address, address, uint256 amount) external override { lastAmount = amount; }
+    function borrow(address, address, uint256 amount) external override { lastAmount = amount; }
+    function repay(address, address, uint256 amount) external override { lastAmount = amount; }
+    function depositCollateral(address, address, uint256, address) external override {}
+    function withdrawCollateral(address, address collateral, address, uint256 amount) external override returns (address, uint256) {
+        lastAmount = amount; return (collateral, amount);
+    }
+    function getBalance(address, address) external view override returns (uint256) { return mockBalance; }
+    function getBorrowBalance(address, address) external view override returns (uint256) { return mockDebt; }
+    function getBorrowBalanceCurrent(address, address) external pure override returns (uint256) { return 0; }
+    function getBorrowRate(address) external pure override returns (uint256, bool) { return (0, false); }
+    function getSupplyRate(address) external pure override returns (uint256, bool) { return (0, false); }
+    function getLtv(address, address) external pure override returns (uint256) { return 0; }
+    function getPossibleCollaterals(address, address) external pure override returns (address[] memory, uint256[] memory, string[] memory, uint8[] memory) {
+        return (new address[](0), new uint256[](0), new string[](0), new uint8[](0));
+    }
+    function isCollateralSupported(address, address) external pure override returns (bool) { return false; }
+    function getSupportedCollaterals(address) external pure override returns (address[] memory) {
+        return new address[](0);
+    }
+    function getEncodedCollateralApprovals(address, Collateral[] calldata) external pure override returns (address[] memory target, bytes[] memory data) {
+        return (new address[](0), new bytes[](0));
+    }
+    function getEncodedDebtApproval(address, uint256, address) external pure override returns (address[] memory target, bytes[] memory data) {
+        return (new address[](0), new bytes[](0));
+    }
+    function getInboundCollateralActions(address, Collateral[] calldata) external pure override returns (address[] memory target, bytes[] memory data) {
+        return (new address[](0), new bytes[](0));
+    }
+}


### PR DESCRIPTION
## Summary
- allow RouterGateway to cap deposit, repay, and withdraw amounts using sender balances and protocol debt
- enable Aave, Compound, and Venus gateways to handle `*_all` semantics via sentinel values
- cover oversized inputs and withdraw-all flows with an enhanced mock gateway test

## Testing
- `yarn test`
- `yarn workspace @se-2/hardhat test:fork` *(0 passing, 18 pending)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5bf997d48320ad31e449c14adc19