### PR TITLE
Hide placeholder gas cost info in modals

### DIFF
--- a/packages/nextjs/components/modals/MovePositionModal.tsx
+++ b/packages/nextjs/components/modals/MovePositionModal.tsx
@@ -10,7 +10,6 @@ import { useScaffoldReadContract } from "~~/hooks/scaffold-eth";
 import { useNetworkAwareReadContract } from "~~/hooks/useNetworkAwareReadContract";
 import { useCollateralSupport } from "~~/hooks/scaffold-eth/useCollateralSupport";
 import { useCollaterals } from "~~/hooks/scaffold-eth/useCollaterals";
-import { useGasEstimate } from "~~/hooks/useGasEstimate";
 import { getProtocolLogo } from "~~/utils/protocol";
 import { CollateralSelector, CollateralWithAmount } from "~~/components/specific/collateral/CollateralSelector";
 import { CollateralAmounts } from "~~/components/specific/collateral/CollateralAmounts";
@@ -122,7 +121,6 @@ export const MovePositionModal: FC<MovePositionModalProps> = ({ isOpen, onClose,
 
   // Move debt hook.
   const { moveDebt } = useMoveDebtScaffold();
-  const gasCostUsd = useGasEstimate("evm");
 
   // Read on-chain borrow balance.
   const { data: tokenBalance } = useScaffoldReadContract({
@@ -574,7 +572,7 @@ export const MovePositionModal: FC<MovePositionModalProps> = ({ isOpen, onClose,
                   {getActionButtonText()}
                 </span>
                 <span className="flex items-center gap-1 text-xs">
-                  <FaGasPump /> ${formatDisplayNumber(gasCostUsd)}
+                  <FaGasPump className="text-gray-400" />
                 </span>
               </button>
             </div>

--- a/packages/nextjs/components/modals/TokenActionModal.tsx
+++ b/packages/nextjs/components/modals/TokenActionModal.tsx
@@ -2,7 +2,6 @@ import { FC, useMemo, useState } from "react";
 import Image from "next/image";
 import { FaGasPump } from "react-icons/fa";
 import { formatUnits, parseUnits } from "viem";
-import { useGasEstimate } from "~~/hooks/useGasEstimate";
 import type { Network } from "~~/hooks/useTokenBalance";
 import { PositionManager } from "~~/utils/position";
 
@@ -39,12 +38,6 @@ export interface TokenActionModalProps {
 
 const format = (num: number) => new Intl.NumberFormat("en-US", { maximumFractionDigits: 2 }).format(num);
 
-const formatUsd = (usd: number) => {
-  if (usd === 0) return "0.000";
-  if (usd < 0.01) return usd.toFixed(4);
-  if (usd < 1) return usd.toFixed(3);
-  return usd.toFixed(2);
-};
 
 const formatApy = (apy: number) => (apy < 1 ? apy.toFixed(4) : apy.toFixed(2));
 
@@ -186,8 +179,6 @@ export const TokenActionModal: FC<TokenActionModalProps> = ({
   balance,
   percentBase,
   max,
-  network,
-  buildTx,
   hf = 1.9,
   utilization = 65,
   ltv = 75,
@@ -197,8 +188,6 @@ export const TokenActionModal: FC<TokenActionModalProps> = ({
   const [amount, setAmount] = useState("");
   const [isMax, setIsMax] = useState(false);
   const [txState, setTxState] = useState<"idle" | "pending" | "success">("idle");
-  const txRequest = buildTx ? buildTx(amount, isMax) : undefined;
-  const gasCostUsd = useGasEstimate(network, txRequest);
   const parsed = parseFloat(amount || "0");
 
   const price = token.usdPrice || 0;
@@ -320,7 +309,7 @@ export const TokenActionModal: FC<TokenActionModalProps> = ({
                   )}
                 </span>
                 <span className="flex items-center gap-1 text-xs">
-                  <FaGasPump /> ${formatUsd(gasCostUsd)}
+                  <FaGasPump className="text-gray-400" />
                 </span>
               </button>
             </div>

--- a/packages/nextjs/components/modals/stark/MovePositionModal.tsx
+++ b/packages/nextjs/components/modals/stark/MovePositionModal.tsx
@@ -13,7 +13,6 @@ import { tokenNameToLogo } from "~~/contracts/externalContracts";
 import { ERC20ABI } from "~~/contracts/externalContracts";
 import { useCollateralSupport } from "~~/hooks/scaffold-eth/useCollateralSupport";
 import { useCollaterals } from "~~/hooks/scaffold-eth/useCollaterals";
-import { useGasEstimate } from "~~/hooks/useGasEstimate";
 import {
   useDeployedContractInfo,
   useScaffoldMultiWriteContract,
@@ -105,7 +104,6 @@ export const MovePositionModal: FC<MovePositionModalProps> = ({
   const [loading, setLoading] = useState(false);
   const [step, setStep] = useState<MoveStep>("idle");
   const [error, setError] = useState<string | null>(null);
-  const gasCostUsd = useGasEstimate("stark");
 
   const { data: routerGateway } = useDeployedContractInfo("RouterGateway");
   const { getAuthorizations, isReady: isAuthReady } = useLendingAuthorizations();
@@ -1169,7 +1167,7 @@ export const MovePositionModal: FC<MovePositionModalProps> = ({
                     {actionButtonText}
                   </span>
                   <span className="flex items-center gap-1 text-xs">
-                    <FaGasPump /> ${formatDisplayNumber(gasCostUsd)}
+                    <FaGasPump className="text-gray-400" />
                   </span>
                 </button>
               </div>


### PR DESCRIPTION
## Summary
- Remove unused gas estimation logic from TokenAction and MovePosition modals
- Show a greyed-out gas icon without displaying the placeholder $0.00 values

## Testing
- `yarn lint`
- `yarn next:check-types`
- `yarn test` *(fails: File @chainlink/contracts/src/v0.8/interfaces/FeedRegistryInterface.sol not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bfd3db10588320b45add7cf0f13370