### PR TITLE
Preserve Vesu collateral inputs

### DIFF
--- a/packages/nextjs/components/modals/stark/MovePositionModal.tsx
+++ b/packages/nextjs/components/modals/stark/MovePositionModal.tsx
@@ -741,9 +741,21 @@ export const MovePositionModal: FC<MovePositionModalProps> = ({
   // Initialize selected collaterals when preselected ones are provided
   useEffect(() => {
     if (isOpen && preSelectedCollaterals && preSelectedCollaterals.length > 0) {
-      setSelectedCollateralsWithAmounts(
-        preSelectedCollaterals.map(c => ({ ...c, amount: 0n, inputValue: "" })),
-      );
+      setSelectedCollateralsWithAmounts(prev => {
+        if (prev.length === 0) {
+          return preSelectedCollaterals.map(c => ({ ...c, amount: 0n, inputValue: "" }));
+        }
+
+        const existing = new Map(prev.map(c => [c.token.toLowerCase(), c]));
+        const merged = preSelectedCollaterals.map(c => {
+          const key = c.token.toLowerCase();
+          return existing.get(key) || { ...c, amount: 0n, inputValue: "" };
+        });
+        const others = prev.filter(
+          c => !preSelectedCollaterals.some(p => p.token.toLowerCase() === c.token.toLowerCase()),
+        );
+        return [...merged, ...others];
+      });
     }
   }, [isOpen, preSelectedCollaterals]);
 
@@ -923,6 +935,7 @@ export const MovePositionModal: FC<MovePositionModalProps> = ({
                     marketToken={position.tokenAddress}
                     onMaxClick={handleCollateralMaxClick}
                     hideAmounts
+                    initialSelectedCollaterals={selectedCollateralsWithAmounts}
                   />
                 )
               )}

--- a/packages/nextjs/components/specific/collateral/CollateralSelector.tsx
+++ b/packages/nextjs/components/specific/collateral/CollateralSelector.tsx
@@ -205,6 +205,7 @@ interface CollateralSelectorProps {
   onCollateralSelectionChange: (collaterals: CollateralWithAmount[]) => void;
   onMaxClick?: (collateralToken: string, maxAmount: bigint, formattedMaxAmount: string) => void;
   hideAmounts?: boolean;
+  initialSelectedCollaterals?: CollateralWithAmount[];
 }
 
 export const CollateralSelector: FC<CollateralSelectorProps> = ({
@@ -215,9 +216,21 @@ export const CollateralSelector: FC<CollateralSelectorProps> = ({
   onCollateralSelectionChange,
   onMaxClick,
   hideAmounts = false,
+  initialSelectedCollaterals,
 }) => {
   // Store selected collaterals with amounts
   const [selectedCollaterals, setSelectedCollaterals] = useState<CollateralWithAmount[]>([]);
+
+  useEffect(() => {
+    if (
+      initialSelectedCollaterals &&
+      initialSelectedCollaterals.length > 0 &&
+      selectedCollaterals.length === 0
+    ) {
+      setSelectedCollaterals(initialSelectedCollaterals);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialSelectedCollaterals]);
   
   // For the token switcher dropdown
   const [switcherOpen, setSwitcherOpen] = useState(false);


### PR DESCRIPTION
## Summary
- keep user-entered collateral amounts when Vesu collaterals refresh
- show pre-added Vesu collateral as selected in collateral selector

## Testing
- `yarn lint`
- `yarn check-types`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68bfd67226a48320a0b508cc219808bf