### PR TITLE
Fix Vesu market utilization bar color

### DIFF
--- a/packages/nextjs/components/markets/MarketCard.tsx
+++ b/packages/nextjs/components/markets/MarketCard.tsx
@@ -62,7 +62,11 @@ export const MarketCard: FC<MarketCardProps> = ({
               <span>Utilization</span>
               <span>{utilization}%</span>
             </div>
-            <progress className="progress w-full progress-info" value={utilization} max="100"></progress>
+            <progress
+              className="progress w-full progress-info"
+              value={parseFloat(utilization)}
+              max={100}
+            ></progress>
           </div>
         </div>
       </div>

--- a/packages/nextjs/components/specific/vesu/MarketCard.tsx
+++ b/packages/nextjs/components/specific/vesu/MarketCard.tsx
@@ -58,7 +58,11 @@ export const MarketCard: FC<MarketCardProps> = ({
               <span>Utilization</span>
               <span>{utilization}%</span>
             </div>
-            <progress className="progress w-full progress-info" value={utilization} max="100"></progress>
+            <progress
+              className="progress w-full progress-info"
+              value={parseFloat(utilization)}
+              max={100}
+            ></progress>
           </div>
         </div>
       </div>

--- a/packages/nextjs/utils/protocols.ts
+++ b/packages/nextjs/utils/protocols.ts
@@ -80,10 +80,8 @@ export const formatPrice = (price: bigint): string => {
 export const formatUtilization = (utilization: bigint): string => {
   // Convert utilization to percentage with 2 decimal places
   const utilizationNum = (Number(utilization) / 1e18) * 100; // Assuming utilization is in wei
-  return utilizationNum.toLocaleString(undefined, {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  });
+  // Use toFixed to avoid locale-specific separators which break progress bars
+  return utilizationNum.toFixed(2);
 };
 
 // Common types


### PR DESCRIPTION
## Summary
- ensure utilization values use numeric formatting
- parse utilization string for progress bar rendering

## Testing
- `yarn next:lint`

------
https://chatgpt.com/codex/tasks/task_e_68bfe073b4a083209fb8037b21395acb