### PR TITLE
Show all Nostra positions when wallet disconnected

### DIFF
--- a/packages/nextjs/components/specific/nostra/NostraProtocolView.tsx
+++ b/packages/nextjs/components/specific/nostra/NostraProtocolView.tsx
@@ -172,6 +172,7 @@ export const NostraProtocolView: FC = () => {
       maxLtv={90}
       suppliedPositions={suppliedPositions}
       borrowedPositions={borrowedPositions}
+      forceShowAll={!connectedAddress}
       networkType="starknet"
       disableMoveSupply
     />


### PR DESCRIPTION
## Summary
- show all Nostra assets when no wallet is connected

## Testing
- `yarn lint`
- `yarn next:check-types`
- `yarn test` *(fails: File @chainlink/contracts/src/v0.8/interfaces/FeedRegistryInterface.sol, imported from contracts/gateways/CompoundGateway.sol, not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bfeae25d348320851079e032208944