### PR TITLE
Eliminate sidebar spacing

### DIFF
--- a/packages/nextjs/app/app/page.tsx
+++ b/packages/nextjs/app/app/page.tsx
@@ -67,7 +67,7 @@ const App: NextPage = () => {
   ];
 
   return (
-    <div className="container mx-auto px-5 flex">
+    <div className="container mx-auto flex p-0">
       <div className="hidden lg:block">
         <LendingSidebar />
       </div>

--- a/packages/nextjs/components/LendingSidebar.tsx
+++ b/packages/nextjs/components/LendingSidebar.tsx
@@ -12,7 +12,7 @@ export const LendingSidebar = () => {
   ];
 
   return (
-    <aside className="group sticky top-[4.5rem] min-h-[calc(100vh-4.5rem)] self-start flex-shrink-0 w-16 hover:w-40 transition-all duration-300 overflow-hidden mr-4">
+    <aside className="group sticky top-[4.5rem] min-h-[calc(100vh-4.5rem)] self-start flex-shrink-0 w-16 hover:w-40 transition-all duration-300 overflow-hidden">
       <ul className="menu bg-base-200 rounded-box py-2 pr-2 pl-0 min-h-full">
         {links.map(({ href, label, icon: Icon }) => (
           <li key={href}>


### PR DESCRIPTION
## Summary
- remove right margin from `LendingSidebar` to remove gap next to content
- strip horizontal padding from the app container to align sidebar flush with protocol views

## Testing
- `yarn lint`
- `yarn test` *(fails: HardhatError: File @chainlink/contracts/src/v0.8/interfaces/FeedRegistryInterface.sol not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c064eff75083209331e2c7c5706cc9