### PR TITLE
fix: correct debt display when selecting borrow token

### DIFF
--- a/packages/nextjs/components/modals/stark/TokenSelectModalStark.tsx
+++ b/packages/nextjs/components/modals/stark/TokenSelectModalStark.tsx
@@ -168,14 +168,7 @@ export const TokenSelectModalStark: FC<TokenSelectModalStarkProps> = ({
               selectedToken.price && selectedToken.price.is_valid ? Number(selectedToken.price.value) / 1e18 : 0,
           }}
           protocolName={protocolName}
-          currentDebt={
-            selectedToken.total_nominal_debt
-              ? Number(
-                  selectedToken.total_nominal_debt /
-                    10n ** BigInt(selectedToken.decimals),
-                )
-              : 0
-          }
+          currentDebt={0}
           vesuContext={vesuContext}
           position={position}
         />


### PR DESCRIPTION
## Summary
- avoid showing protocol-wide debt when selecting a borrow token

## Testing
- `yarn next:lint`
- `yarn next:check-types`
- `yarn test` *(fails: Error HH404: File @chainlink/contracts/src/v0.8/interfaces/FeedRegistryInterface.sol, imported from contracts/gateways/CompoundGateway.sol, not found.)*

------
https://chatgpt.com/codex/tasks/task_e_68c06c2ae85c8320960d357aa93cd945