### PR TITLE
chore: lower vesu positions refetch interval

### DIFF
--- a/packages/nextjs/components/specific/vesu/VesuProtocolView.tsx
+++ b/packages/nextjs/components/specific/vesu/VesuProtocolView.tsx
@@ -72,7 +72,7 @@ export const VesuProtocolView: FC = () => {
     if (!userAddress) return;
     refetchCounter.current += 1;
     if (refetchCounter.current >= 3) {
-      setPositionsRefetchInterval(15000);
+      setPositionsRefetchInterval(5000);
     }
   }, [mergedUserPositions, userAddress]);
 


### PR DESCRIPTION
## Summary
- lower Vesu positions refetch interval to 5 seconds

## Testing
- `yarn next:lint`
- `yarn next:check-types`

------
https://chatgpt.com/codex/tasks/task_e_68c07484db648320be8c144962308214