### PR TITLE
Fix Nostra borrow rate and debt calculations

### DIFF
--- a/packages/nextjs/components/ProtocolView.tsx
+++ b/packages/nextjs/components/ProtocolView.tsx
@@ -433,7 +433,9 @@ export const ProtocolView: FC<ProtocolViewProps> = ({
               decimals: pos.tokenDecimals || 18,
               rate_accumulator: BigInt(0),
               utilization: BigInt(0),
-              fee_rate: BigInt(Math.floor(pos.currentRate * 1e18 / (365 * 24 * 60 * 60))), // Convert APR to per-second rate
+              fee_rate: BigInt(
+                Math.floor((pos.currentRate / 100) * 1e18 / (365 * 24 * 60 * 60)),
+              ), // Convert APR percentage to per-second rate
               price: {
                 value: BigInt(pos.tokenPrice || 0),
                 is_valid: true

--- a/packages/nextjs/components/markets/MarketsGrouped.tsx
+++ b/packages/nextjs/components/markets/MarketsGrouped.tsx
@@ -167,8 +167,9 @@ const useNostraData = (): MarketData[] => {
       const address = `0x${info[0].toString(16).padStart(64, "0")}`;
       const symbol = feltToString(info[1]);
       const rate = rates[idx];
-      const supplyAPY = Number(rate.lending_rate) / 1e16;
-      const borrowAPR = Number(rate.borrowing_rate) / 1e16;
+      // Rates are provided in RAY (1e27); divide by 1e25 to obtain percentage values
+      const supplyAPY = Number(rate.lending_rate) / 1e25;
+      const borrowAPR = Number(rate.borrowing_rate) / 1e25;
       const utilization = borrowAPR > 0 ? (supplyAPY / borrowAPR) * 100 : 0;
       const price = priceArr[idx] ? formatPrice(priceArr[idx]) : "0.00";
       return {

--- a/packages/nextjs/components/modals/stark/TokenSelectModalStark.tsx
+++ b/packages/nextjs/components/modals/stark/TokenSelectModalStark.tsx
@@ -109,7 +109,7 @@ export const TokenSelectModalStark: FC<TokenSelectModalStarkProps> = ({
                       <div
                         className={`badge ${hoveredToken === address ? "badge-primary" : "badge-outline"} p-3 font-medium`}
                       >
-                        {token.borrowAPR ? (token.borrowAPR * 100).toFixed(2) : "0.00"}% APR
+                        {token.borrowAPR !== undefined ? token.borrowAPR.toFixed(2) : "0.00"}% APR
                       </div>
                     </div>
                   );
@@ -163,9 +163,9 @@ export const TokenSelectModalStark: FC<TokenSelectModalStarkProps> = ({
             name: feltToString(selectedToken.symbol),
             icon: tokenNameToLogo(feltToString(selectedToken.symbol).toLowerCase()),
             address: `0x${BigInt(selectedToken.address).toString(16).padStart(64, "0")}`,
-            currentRate: selectedToken.borrowAPR ? selectedToken.borrowAPR * 100 : 0,
+            currentRate: selectedToken.borrowAPR ?? 0,
             usdPrice:
-              selectedToken.price && selectedToken.price.is_valid ? Number(selectedToken.price.value) / 1e18 : 0,
+              selectedToken.price && selectedToken.price.is_valid ? Number(selectedToken.price.value) / 1e8 : 0,
           }}
           protocolName={protocolName}
           currentDebt={0}

--- a/packages/nextjs/components/specific/nostra/NostraMarkets.tsx
+++ b/packages/nextjs/components/specific/nostra/NostraMarkets.tsx
@@ -47,8 +47,9 @@ export const NostraMarkets: FC<NostraMarketsProps> = ({ viewMode, search }) => {
       const address = `0x${info[0].toString(16).padStart(64, "0")}`;
       const symbol = feltToString(info[1]);
       const rate = rates[idx];
-      const supplyAPY = Number(rate.lending_rate) / 1e16;
-      const borrowAPR = Number(rate.borrowing_rate) / 1e16;
+      // Rates are returned in RAY (1e27); divide by 1e25 to get percentage values
+      const supplyAPY = Number(rate.lending_rate) / 1e25;
+      const borrowAPR = Number(rate.borrowing_rate) / 1e25;
       const utilization = borrowAPR > 0 ? (supplyAPY / borrowAPR) * 100 : 0;
       const price = priceArr[idx] ? formatPrice(priceArr[idx]) : "0.00";
       return {

--- a/packages/nextjs/components/specific/nostra/NostraProtocolView.tsx
+++ b/packages/nextjs/components/specific/nostra/NostraProtocolView.tsx
@@ -127,9 +127,10 @@ export const NostraProtocolView: FC = () => {
       const symbol = symbolMap[underlying];
       const interestRate = rates?.[index];
 
-      // Convert rates to APY/APR (rates are in RAY format - 1e27)
-      const supplyAPY = interestRate ? Number(interestRate.lending_rate) / 1e16 : 0;
-      const borrowAPR = interestRate ? Number(interestRate.borrowing_rate) / 1e16 : 0;
+      // Convert rates from RAY (1e27) to percentage values
+      // Divide by 1e25 to account for the 1e2 factor when converting to percent
+      const supplyAPY = interestRate ? Number(interestRate.lending_rate) / 1e25 : 0;
+      const borrowAPR = interestRate ? Number(interestRate.borrowing_rate) / 1e25 : 0;
 
       // Convert token amounts to numbers and multiply by USD price to get fiat value
       const decimals = tokenToDecimals[underlying];


### PR DESCRIPTION
## Summary
- Correctly convert Nostra interest rates from RAY to percentages
- Fix borrow token modal to display proper borrow APR and USD pricing
- Adjust fee rate calculation when preparing borrow token data

## Testing
- `npm test` *(fails: HardhatError HH404: File @chainlink/contracts/src/v0.8/interfaces/FeedRegistryInterface.sol not found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c18acbe2848320b338c13d9e0c4c7a