### PR TITLE
feat: add network selector for deployed contracts

### DIFF
--- a/packages/nextjs/app/components/StarknetDeployedContractsList.tsx
+++ b/packages/nextjs/app/components/StarknetDeployedContractsList.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import { ArrowTopRightOnSquareIcon } from "@heroicons/react/24/outline";
+import contracts, { SNContract } from "~~/contracts/snfoundry/deployedContracts";
+
+export const StarknetDeployedContractsList = () => {
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  if (!isMounted) {
+    return <div className="py-8 text-center">Loading deployed contracts...</div>;
+  }
+
+  const networkKey = Object.keys(contracts)[0] as keyof typeof contracts;
+  const contractsData = contracts[networkKey];
+
+  if (!contractsData || Object.keys(contractsData).length === 0) {
+    return (
+      <div className="text-center py-5">
+        <p>No contracts deployed on the current network (Starknet).</p>
+      </div>
+    );
+  }
+
+  const explorerBaseUrl = "https://voyager.online/contract";
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="table w-full">
+        <thead>
+          <tr>
+            <th>Contract Name</th>
+            <th>Address</th>
+            <th>Network</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {(Object.entries(contractsData) as [string, SNContract][]).map(([contractName, contractData]) => (
+            <tr key={contractName}>
+              <td className="font-medium">{contractName}</td>
+              <td>
+                <div className="flex items-center gap-1">
+                  <span className="font-mono text-xs truncate max-w-[150px] md:max-w-[200px] lg:max-w-[300px]">
+                    {contractData.address}
+                  </span>
+                  <button
+                    className="btn btn-xs btn-ghost"
+                    onClick={() => {
+                      navigator.clipboard.writeText(contractData.address);
+                    }}
+                  >
+                    📋
+                  </button>
+                </div>
+              </td>
+              <td>Starknet</td>
+              <td>
+                <Link
+                  href={`${explorerBaseUrl}/${contractData.address}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="btn btn-xs btn-primary"
+                >
+                  <ArrowTopRightOnSquareIcon className="h-4 w-4 mr-1" />
+                  View
+                </Link>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default StarknetDeployedContractsList;
+

--- a/packages/nextjs/components/info/ContractsSection.tsx
+++ b/packages/nextjs/components/info/ContractsSection.tsx
@@ -1,16 +1,35 @@
-import React from "react";
+"use client";
+
+import React, { useState } from "react";
 import { motion } from "framer-motion";
 import { CodeBracketIcon } from "@heroicons/react/24/outline";
 import { DeployedContractsList } from "~~/app/components/DeployedContractsList";
+import { NetworkFilter, NetworkOption } from "~~/components/NetworkFilter";
+import { StarknetDeployedContractsList } from "~~/app/components/StarknetDeployedContractsList";
+
+const networkOptions: NetworkOption[] = [
+  {
+    id: "starknet",
+    name: "Starknet",
+    logo: "/logos/starknet.svg",
+  },
+  {
+    id: "arbitrum",
+    name: "Arbitrum",
+    logo: "/logos/arb.svg",
+  },
+];
 
 const ContractsSection = () => {
+  const [selectedNetwork, setSelectedNetwork] = useState<string>("starknet");
+
   return (
     <section className="py-16 relative">
       {/* Background decoration */}
       <div className="absolute top-0 right-0 w-64 h-64 bg-primary/5 -z-10 rounded-full"></div>
       <div className="absolute bottom-0 left-0 w-48 h-48 bg-accent/5 -z-10 rounded-full"></div>
-      
-      <motion.div 
+
+      <motion.div
         initial={{ opacity: 0, y: 20 }}
         whileInView={{ opacity: 1, y: 0 }}
         viewport={{ once: true }}
@@ -21,15 +40,15 @@ const ContractsSection = () => {
           <CodeBracketIcon className="w-5 h-5 text-accent" />
           <h2 className="text-3xl font-bold">Deployed Smart Contracts</h2>
         </div>
-        
+
         <div className="w-24 h-1 bg-accent mx-auto rounded-full mb-4"></div>
-        
+
         <p className="text-base-content/80 max-w-2xl mx-auto">
-          Kapan Finance&apos;s atomic debt migration functionality is powered by the following smart contracts, 
+          Kapan Finance&apos;s atomic debt migration functionality is powered by the following smart contracts,
           enabling secure cross-protocol interactions for Web3 lending refinancing.
         </p>
       </motion.div>
-      
+
       <motion.div
         initial={{ opacity: 0, y: 30 }}
         whileInView={{ opacity: 1, y: 0 }}
@@ -39,17 +58,26 @@ const ContractsSection = () => {
       >
         <div className="card bg-base-100 shadow-sm overflow-hidden border border-base-300/50">
           <div className="card-body">
-            <div className="bg-base-200/50 -mx-6 -mt-6 px-6 py-3 mb-4 border-b border-base-300/50">
+            <div className="bg-base-200/50 -mx-6 -mt-6 px-6 py-3 mb-4 border-b border-base-300/50 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
               <h3 className="font-medium text-base-content flex items-center gap-2">
                 <CodeBracketIcon className="w-4 h-4 text-accent" />
                 <span>Smart Contract Deployments</span>
               </h3>
+              <NetworkFilter
+                networks={networkOptions}
+                defaultNetwork="starknet"
+                onNetworkChange={setSelectedNetwork}
+              />
             </div>
-            <DeployedContractsList />
+            {selectedNetwork === "arbitrum" ? (
+              <DeployedContractsList />
+            ) : (
+              <StarknetDeployedContractsList />
+            )}
           </div>
         </div>
       </motion.div>
-      
+
       <motion.div
         initial={{ opacity: 0 }}
         whileInView={{ opacity: 1 }}
@@ -58,12 +86,13 @@ const ContractsSection = () => {
         className="mt-8 text-center"
       >
         <p className="text-sm text-base-content/70 max-w-2xl mx-auto">
-          All contracts are verified on Etherscan. View contract source code and interactions
-          by clicking on the contract addresses above.
+          All contracts are verified on their respective explorers. View contract source code and
+          interactions by clicking on the contract addresses above.
         </p>
       </motion.div>
     </section>
   );
 };
 
-export default ContractsSection; 
+export default ContractsSection;
+


### PR DESCRIPTION
## Summary
- allow switching between Starknet and Arbitrum contract lists on the Info page
- list Starknet deployments with Voyager links

## Testing
- `yarn next:lint`
- `yarn next:check-types`


------
https://chatgpt.com/codex/tasks/task_e_68c1dc7f209c8320b3e677b19d3c917b