### PR TITLE
fix: correct Nostra interest rate scaling

### DIFF
--- a/packages/nextjs/components/markets/MarketsGrouped.tsx
+++ b/packages/nextjs/components/markets/MarketsGrouped.tsx
@@ -167,9 +167,9 @@ const useNostraData = (): MarketData[] => {
       const address = `0x${info[0].toString(16).padStart(64, "0")}`;
       const symbol = feltToString(info[1]);
       const rate = rates[idx];
-      // Rates are provided in RAY (1e27); divide by 1e25 to obtain percentage values
-      const supplyAPY = Number(rate.lending_rate) / 1e25;
-      const borrowAPR = Number(rate.borrowing_rate) / 1e25;
+      // Rates are provided in WAD (1e18); divide by 1e16 to obtain percentage values
+      const supplyAPY = Number(rate.lending_rate) / 1e16;
+      const borrowAPR = Number(rate.borrowing_rate) / 1e16;
       const utilization = borrowAPR > 0 ? (supplyAPY / borrowAPR) * 100 : 0;
       const price = priceArr[idx] ? formatPrice(priceArr[idx]) : "0.00";
       return {

--- a/packages/nextjs/components/specific/nostra/NostraMarkets.tsx
+++ b/packages/nextjs/components/specific/nostra/NostraMarkets.tsx
@@ -47,9 +47,9 @@ export const NostraMarkets: FC<NostraMarketsProps> = ({ viewMode, search }) => {
       const address = `0x${info[0].toString(16).padStart(64, "0")}`;
       const symbol = feltToString(info[1]);
       const rate = rates[idx];
-      // Rates are returned in RAY (1e27); divide by 1e25 to get percentage values
-      const supplyAPY = Number(rate.lending_rate) / 1e25;
-      const borrowAPR = Number(rate.borrowing_rate) / 1e25;
+      // Rates are returned in WAD (1e18); divide by 1e16 to get percentage values
+      const supplyAPY = Number(rate.lending_rate) / 1e16;
+      const borrowAPR = Number(rate.borrowing_rate) / 1e16;
       const utilization = borrowAPR > 0 ? (supplyAPY / borrowAPR) * 100 : 0;
       const price = priceArr[idx] ? formatPrice(priceArr[idx]) : "0.00";
       return {

--- a/packages/nextjs/components/specific/nostra/NostraProtocolView.tsx
+++ b/packages/nextjs/components/specific/nostra/NostraProtocolView.tsx
@@ -127,10 +127,10 @@ export const NostraProtocolView: FC = () => {
       const symbol = symbolMap[underlying];
       const interestRate = rates?.[index];
 
-      // Convert rates from RAY (1e27) to percentage values
-      // Divide by 1e25 to account for the 1e2 factor when converting to percent
-      const supplyAPY = interestRate ? Number(interestRate.lending_rate) / 1e25 : 0;
-      const borrowAPR = interestRate ? Number(interestRate.borrowing_rate) / 1e25 : 0;
+      // Convert rates from WAD (1e18) to percentage values
+      // Divide by 1e16 to account for the 1e2 factor when converting to percent
+      const supplyAPY = interestRate ? Number(interestRate.lending_rate) / 1e16 : 0;
+      const borrowAPR = interestRate ? Number(interestRate.borrowing_rate) / 1e16 : 0;
 
       // Convert token amounts to numbers and multiply by USD price to get fiat value
       const decimals = tokenToDecimals[underlying];


### PR DESCRIPTION
## Summary
- fix Nostra supply and borrow rate calculations to use 1e16 scaling
- update market and protocol views to reflect WAD-based rates

## Testing
- `yarn lint`
- `yarn test` *(fails: HH404: File @chainlink/contracts/src/v0.8/Denominations.sol not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c26e56ad4083208771e0982fcd192d