### PR TITLE
feat: display utilization percentage across market views

### DIFF
--- a/packages/nextjs/components/markets/MarketRow.tsx
+++ b/packages/nextjs/components/markets/MarketRow.tsx
@@ -43,8 +43,8 @@ export const MarketRow: FC<MarketRowProps> = ({
               <div className="font-medium">${price}</div>
             </div>
             <div className="flex flex-col items-center w-1/5">
-              <div className="text-sm text-base-content/70">Utilization</div>
-              <div className="font-medium">{utilization}%</div>
+              <div className="text-sm text-base-content/70 mb-1">Utilization</div>
+              <span className="font-medium">{utilization}%</span>
             </div>
             <div className="w-2/5">
               <InterestPillRow
@@ -98,8 +98,8 @@ export const MarketRow: FC<MarketRowProps> = ({
               <div className="font-medium">${price}</div>
             </div>
             <div className="bg-base-200/50 p-2 rounded-md flex-1 min-w-[140px]">
-              <div className="text-sm text-base-content/70">Utilization</div>
-              <div className="font-medium">{utilization}%</div>
+              <div className="text-sm text-base-content/70 mb-1">Utilization</div>
+              <span className="font-medium">{utilization}%</span>
             </div>
           </div>
         </div>
@@ -135,8 +135,8 @@ export const MarketRow: FC<MarketRowProps> = ({
               <div className="font-medium text-sm">${price}</div>
             </div>
             <div className="bg-base-200/50 p-2 rounded-md">
-              <div className="text-xs text-base-content/70">Utilization</div>
-              <div className="font-medium text-sm">{utilization}%</div>
+              <div className="text-xs text-base-content/70 mb-1">Utilization</div>
+              <span className="font-medium text-sm">{utilization}%</span>
             </div>
           </div>
         </div>

--- a/packages/nextjs/components/markets/MarketsGrouped.tsx
+++ b/packages/nextjs/components/markets/MarketsGrouped.tsx
@@ -325,6 +325,23 @@ export const MarketsGrouped: FC<{ search: string }> = ({ search }) => {
     return sorted.filter(g => g.name.toLowerCase().includes(lower) || g.name.toLowerCase().includes(canon));
   }, [sorted, search]);
 
+  const [groupSorts, setGroupSorts] = useState<
+    Record<string, { column: "supply" | "borrow"; direction: "asc" | "desc" }>
+  >({});
+
+  const toggleGroupSort = (name: string, column: "supply" | "borrow") => {
+    setGroupSorts(prev => {
+      const current = prev[name] || { column: "borrow", direction: "asc" };
+      return {
+        ...prev,
+        [name]:
+          current.column === column
+            ? { column, direction: current.direction === "asc" ? "desc" : "asc" }
+            : { column, direction: "asc" },
+      };
+    });
+  };
+
   const networkIcons: Record<"evm" | "starknet", string> = {
     evm: "/logos/arb.svg",
     starknet: "/logos/starknet.svg",
@@ -370,69 +387,80 @@ export const MarketsGrouped: FC<{ search: string }> = ({ search }) => {
         </div>
       </div>
       <div className="space-y-4">
-        {filtered.map(group => (
-          <details key={group.name} className="collapse collapse-arrow rounded-lg">
-            <summary className="collapse-title p-0 list-none">
-              <div className="flex items-center gap-4 p-4 rounded-lg bg-base-100 border border-base-300 hover:bg-base-200 cursor-pointer">
-                <Image src={group.icon} alt={group.name} width={24} height={24} className="rounded-full" />
-                <span className="font-medium">{group.name}</span>
-                <div className="ml-auto mr-8 flex gap-4">
-                  <RatePill
-                    variant="supply"
-                    label="Supply Rate"
-                    rate={group.bestSupply.supplyRate}
-                    networkType={group.bestSupply.networkType}
-                    protocol={group.bestSupply.protocol}
-                  />
-                  <RatePill
-                    variant="borrow"
-                    label="Borrow Rate"
-                    rate={group.bestBorrow.borrowRate}
-                    networkType={group.bestBorrow.networkType}
-                    protocol={group.bestBorrow.protocol}
-                  />
-                </div>
-              </div>
-            </summary>
-            <div className="collapse-content p-0 mt-2 space-y-2">
-              {group.markets.map(m => (
-                <div
-                  key={m.protocol + m.address}
-                  className="grid grid-cols-4 items-center gap-4 p-3 rounded-lg bg-base-100"
-                >
-                  <div className="flex items-center gap-2">
-                    <Image src={networkIcons[m.networkType]} alt={m.networkType} width={16} height={16} />
-                    <span>{networkNames[m.networkType]}</span>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <Image src={protocolIcons[m.protocol]} alt={m.protocol} width={16} height={16} />
-                    <span className="capitalize">{protocolNames[m.protocol]}</span>
-                  </div>
-                  <div className="justify-self-center">
+        {filtered.map(group => {
+          const sortInfo = groupSorts[group.name] || { column: "borrow", direction: "asc" };
+          const sortedMarkets = [...group.markets].sort((a, b) => {
+            const key = sortInfo.column === "supply" ? "supplyRate" : "borrowRate";
+            const aVal = parseFloat(a[key]);
+            const bVal = parseFloat(b[key]);
+            return sortInfo.direction === "asc" ? aVal - bVal : bVal - aVal;
+          });
+          return (
+            <details key={group.name} className="collapse collapse-arrow rounded-lg">
+              <summary className="collapse-title p-0 list-none">
+                <div className="flex items-center gap-4 p-4 rounded-lg bg-base-100 border border-base-300 hover:bg-base-200 cursor-pointer">
+                  <Image src={group.icon} alt={group.name} width={24} height={24} className="rounded-full" />
+                  <span className="font-medium">{group.name}</span>
+                  <div className="ml-auto mr-8 flex gap-4">
                     <RatePill
                       variant="supply"
                       label="Supply Rate"
-                      rate={m.supplyRate}
-                      networkType={m.networkType}
-                      protocol={m.protocol}
-                      showIcons={false}
+                      rate={group.bestSupply.supplyRate}
+                      networkType={group.bestSupply.networkType}
+                      protocol={group.bestSupply.protocol}
                     />
-                  </div>
-                  <div className="justify-self-center">
                     <RatePill
                       variant="borrow"
                       label="Borrow Rate"
-                      rate={m.borrowRate}
-                      networkType={m.networkType}
-                      protocol={m.protocol}
-                      showIcons={false}
+                      rate={group.bestBorrow.borrowRate}
+                      networkType={group.bestBorrow.networkType}
+                      protocol={group.bestBorrow.protocol}
                     />
                   </div>
                 </div>
-              ))}
-            </div>
-          </details>
-        ))}
+              </summary>
+              <div className="collapse-content p-0 mt-2 space-y-2">
+                <div className="grid grid-cols-5 gap-4 p-3 text-xs font-medium uppercase text-base-content/60">
+                  <span>Network</span>
+                  <span>Protocol</span>
+                  <span className="justify-self-center">Utilization</span>
+                  <button
+                    type="button"
+                    className="justify-self-center underline cursor-pointer"
+                    onClick={() => toggleGroupSort(group.name, "supply")}
+                  >
+                    Supply Rate
+                  </button>
+                  <button
+                    type="button"
+                    className="justify-self-center underline cursor-pointer"
+                    onClick={() => toggleGroupSort(group.name, "borrow")}
+                  >
+                    Borrow Rate
+                  </button>
+                </div>
+                {sortedMarkets.map((m, idx) => (
+                  <div
+                    key={m.protocol + m.address}
+                    className={`grid grid-cols-5 items-center gap-4 p-3 rounded-lg ${idx === 0 ? "bg-base-200" : "bg-base-100"}`}
+                  >
+                    <div className="flex items-center gap-2">
+                      <Image src={networkIcons[m.networkType]} alt={m.networkType} width={16} height={16} />
+                      <span>{networkNames[m.networkType]}</span>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <Image src={protocolIcons[m.protocol]} alt={m.protocol} width={16} height={16} />
+                      <span className="capitalize">{protocolNames[m.protocol]}</span>
+                    </div>
+                    <div className="justify-self-center font-medium">{m.utilization}%</div>
+                    <div className="justify-self-center">{m.supplyRate}</div>
+                    <div className="justify-self-center">{m.borrowRate}</div>
+                  </div>
+                ))}
+              </div>
+            </details>
+          );
+        })}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- replace utilization progress bars with plain percentage text in market list
- include utilization percentage in token-grouped market dropdown
- add headers and text-based rates in grouped dropdown
- sort grouped dropdown markets by clickable supply and borrow rate headers, defaulting to lowest borrow rate
- highlight first sorted market row for quick reference

## Testing
- `yarn next:lint` *(fails: No such file or directory)*
- `yarn workspace @se-2/nextjs test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c27eb39b808320b8f496adc75696c7