### PR TITLE
feat: add exact-in swaps to ekubo gateway

### DIFF
--- a/packages/snfoundry/contracts/src/interfaces/IGateway.cairo
+++ b/packages/snfoundry/contracts/src/interfaces/IGateway.cairo
@@ -80,6 +80,18 @@ pub struct Swap {
 }
 
 #[derive(Drop, Serde, Copy)]
+pub struct SwapExactIn {
+    pub token_in: ContractAddress,
+    pub token_out: ContractAddress,
+    pub exact_in: u256,
+    pub min_out: u256,
+    pub user: ContractAddress,
+    pub should_pay_out: bool,
+    pub should_pay_in: bool,
+    pub context: Option<Span<felt252>>,
+}
+
+#[derive(Drop, Serde, Copy)]
 pub enum LendingInstruction {
     Deposit: Deposit,
     Borrow: Borrow,
@@ -88,6 +100,7 @@ pub enum LendingInstruction {
     Redeposit: Redeposit,
     Reborrow: Reborrow,
     Swap: Swap,
+    SwapExactIn: SwapExactIn,
     Reswap: Reswap,
 }
 


### PR DESCRIPTION
## Summary
- add SwapExactIn instruction in shared gateway interface
- extend Ekubo gateway and router to process exact-in swaps
- cover gateway with a new exact-in swap test

## Testing
- `scarb build` *(fails: command not found)*
- `snforge test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e869a8408320a80a32bedeaf3069