### PR TITLE
feat: default dark mode theme

### DIFF
--- a/packages/nextjs/components/SwitchTheme.tsx
+++ b/packages/nextjs/components/SwitchTheme.tsx
@@ -18,8 +18,8 @@ export const SwitchTheme = ({ className }: { className?: string }) => {
       : "light";
   const darkTheme =
     typeof window !== "undefined"
-      ? localStorage.getItem("darkTheme") ?? "synthwave"
-      : "synthwave";
+      ? localStorage.getItem("darkTheme") ?? "dark"
+      : "dark";
 
   useEffect(() => {
     if (mounted && theme === "system" && resolvedTheme) {

--- a/packages/nextjs/components/ThemeSettings.tsx
+++ b/packages/nextjs/components/ThemeSettings.tsx
@@ -10,11 +10,11 @@ export const ThemeSettings = ({ className }: { className?: string }) => {
   const { theme, setTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
   const [lightTheme, setLightTheme] = useState("light");
-  const [darkTheme, setDarkTheme] = useState("synthwave");
+  const [darkTheme, setDarkTheme] = useState("dark");
 
   useEffect(() => {
     const storedLight = localStorage.getItem("lightTheme") ?? "light";
-    const storedDark = localStorage.getItem("darkTheme") ?? "synthwave";
+    const storedDark = localStorage.getItem("darkTheme") ?? "dark";
     setLightTheme(storedLight);
     setDarkTheme(storedDark);
     setMounted(true);


### PR DESCRIPTION
## Summary
- default to dark theme when enabling dark mode

## Testing
- `yarn test` *(fails: File @chainlink/contracts/src/v0.8/interfaces/FeedRegistryInterface.sol not found)*
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68c306ac90f083209b8b6869c1dd7618