### PR TITLE
feat: refine deposit actions for market cards

### DIFF
--- a/packages/nextjs/components/markets/MarketCard.tsx
+++ b/packages/nextjs/components/markets/MarketCard.tsx
@@ -13,6 +13,7 @@ export type MarketCardProps = {
   address: string;
   networkType: "evm" | "starknet";
   protocol: string;
+  allowDeposit?: boolean;
 };
 
 export const MarketCard: FC<MarketCardProps> = ({
@@ -25,6 +26,7 @@ export const MarketCard: FC<MarketCardProps> = ({
   address,
   networkType,
   protocol,
+  allowDeposit = false,
 }) => {
   const [isDepositModalOpen, setIsDepositModalOpen] = useState(false);
 
@@ -38,13 +40,12 @@ export const MarketCard: FC<MarketCardProps> = ({
               <h3 className="text-lg font-semibold">{name}</h3>
               <span className="text-sm text-base-content/70">${price}</span>
             </div>
-            {networkType === "starknet" && (
+            {allowDeposit && networkType === "starknet" && (
               <button
-                className="btn btn-sm btn-primary btn-circle ml-auto"
+                className="btn btn-sm btn-primary ml-auto"
                 onClick={() => setIsDepositModalOpen(true)}
-                aria-label="Deposit"
               >
-                +
+                Deposit
               </button>
             )}
           </div>
@@ -71,7 +72,7 @@ export const MarketCard: FC<MarketCardProps> = ({
         </div>
       </div>
 
-      {networkType === "starknet" && (
+      {allowDeposit && networkType === "starknet" && (
         <DepositModalStark
           isOpen={isDepositModalOpen}
           onClose={() => setIsDepositModalOpen(false)}

--- a/packages/nextjs/components/markets/MarketRow.tsx
+++ b/packages/nextjs/components/markets/MarketRow.tsx
@@ -13,6 +13,7 @@ type MarketRowProps = {
   address: string;
   networkType: "evm" | "starknet";
   protocol: string;
+  allowDeposit?: boolean;
 };
 
 export const MarketRow: FC<MarketRowProps> = ({
@@ -25,6 +26,7 @@ export const MarketRow: FC<MarketRowProps> = ({
   address,
   networkType,
   protocol,
+  allowDeposit = false,
 }) => {
   const [isDepositModalOpen, setIsDepositModalOpen] = useState(false);
 
@@ -56,7 +58,7 @@ export const MarketRow: FC<MarketRowProps> = ({
                 labels="center"
               />
             </div>
-            {networkType === "starknet" && (
+            {allowDeposit && networkType === "starknet" && (
               <button
                 className="btn btn-sm btn-primary ml-auto"
                 onClick={() => setIsDepositModalOpen(true)}
@@ -74,7 +76,7 @@ export const MarketRow: FC<MarketRowProps> = ({
               <Image src={icon} alt={name} width={24} height={24} className="rounded-full" />
               <span className="font-medium">{name}</span>
             </div>
-            {networkType === "starknet" && (
+            {allowDeposit && networkType === "starknet" && (
               <button
                 className="btn btn-sm btn-primary"
                 onClick={() => setIsDepositModalOpen(true)}
@@ -111,7 +113,7 @@ export const MarketRow: FC<MarketRowProps> = ({
               <Image src={icon} alt={name} width={24} height={24} className="rounded-full" />
               <span className="font-medium">{name}</span>
             </div>
-            {networkType === "starknet" && (
+            {allowDeposit && networkType === "starknet" && (
               <button
                 className="btn btn-xs btn-primary"
                 onClick={() => setIsDepositModalOpen(true)}
@@ -142,7 +144,7 @@ export const MarketRow: FC<MarketRowProps> = ({
         </div>
       </div>
 
-      {networkType === "starknet" && (
+      {allowDeposit && networkType === "starknet" && (
         <DepositModalStark
           isOpen={isDepositModalOpen}
           onClose={() => setIsDepositModalOpen(false)}

--- a/packages/nextjs/components/markets/MarketsSection.tsx
+++ b/packages/nextjs/components/markets/MarketsSection.tsx
@@ -12,6 +12,7 @@ export interface MarketData {
   address: string;
   networkType: "evm" | "starknet";
   protocol: "aave" | "nostra" | "venus" | "vesu" | "compound";
+  allowDeposit?: boolean;
 }
 
 interface MarketsSectionProps {

--- a/packages/nextjs/components/specific/vesu/VesuMarkets.tsx
+++ b/packages/nextjs/components/specific/vesu/VesuMarkets.tsx
@@ -31,9 +31,10 @@ interface VesuMarketsProps {
   supportedAssets?: ContractResponse;
   viewMode: "list" | "grid";
   search: string;
+  allowDeposit?: boolean;
 }
 
-export const VesuMarkets: FC<VesuMarketsProps> = ({ supportedAssets, viewMode, search }) => {
+export const VesuMarkets: FC<VesuMarketsProps> = ({ supportedAssets, viewMode, search, allowDeposit = false }) => {
 
   const markets: MarketData[] = useMemo(() => {
     if (!supportedAssets) return [];
@@ -57,9 +58,10 @@ export const VesuMarkets: FC<VesuMarketsProps> = ({ supportedAssets, viewMode, s
         address,
         networkType: "starknet",
         protocol: "vesu",
+        allowDeposit,
       } as MarketData;
     });
-  }, [supportedAssets]);
+  }, [supportedAssets, allowDeposit]);
 
   return <MarketsSection title="Vesu Markets" markets={markets} viewMode={viewMode} search={search} />;
 };

--- a/packages/nextjs/components/specific/vesu/VesuProtocolView.tsx
+++ b/packages/nextjs/components/specific/vesu/VesuProtocolView.tsx
@@ -163,7 +163,12 @@ export const VesuProtocolView: FC = () => {
 
   return (
     <div className="w-full flex flex-col p-4 space-y-4">
-      <VesuMarkets supportedAssets={supportedAssets as ContractResponse | undefined} viewMode="grid" search="" />
+      <VesuMarkets
+        supportedAssets={supportedAssets as ContractResponse | undefined}
+        viewMode="grid"
+        search=""
+        allowDeposit
+      />
 
       <div className="card bg-base-100 shadow-md">
         <div className="card-body p-4">


### PR DESCRIPTION
## Summary
- remove deposit controls from market listing cards
- show a "Deposit" button on Vesu market cards when viewing positions
- allow toggling deposit availability via `allowDeposit` flag

## Testing
- `yarn next:lint`
- `yarn next:check-types`
- `yarn test` *(fails: Error HH404: File @chainlink/contracts/src/v0.8/interfaces/FeedRegistryInterface.sol, imported from contracts/gateways/CompoundGateway.sol, not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c306f44aa88320af39b69c9f7278d2