### PR TITLE
fix: hide move button when current borrow rate is optimal

### DIFF
--- a/packages/nextjs/components/BorrowPosition.tsx
+++ b/packages/nextjs/components/BorrowPosition.tsx
@@ -15,6 +15,7 @@ import { useOptimalRate } from "~~/hooks/useOptimalRate";
 import { useWalletConnection } from "~~/hooks/useWalletConnection";
 import formatPercentage from "~~/utils/formatPercentage";
 import { PositionManager } from "~~/utils/position";
+import { normalizeProtocolName } from "~~/utils/protocol";
 
 // BorrowPositionProps extends ProtocolPosition but can add borrow-specific props
 export type BorrowPositionProps = ProtocolPosition & {
@@ -67,7 +68,7 @@ export const BorrowPosition: FC<BorrowPositionProps> = ({
   const hasBetterRate =
     hasBalance &&
     optimalProtocol &&
-    optimalProtocol !== protocolName &&
+    normalizeProtocolName(optimalProtocol) !== normalizeProtocolName(protocolName) &&
     optimalRateDisplay < currentRate;
 
   const formatNumber = (num: number) =>

--- a/packages/nextjs/components/BorrowPosition.tsx
+++ b/packages/nextjs/components/BorrowPosition.tsx
@@ -65,9 +65,11 @@ export const BorrowPosition: FC<BorrowPositionProps> = ({
   });
 
   // Determine if there's a better rate available on another protocol
+  const ratesAreSame = Math.abs(currentRate - optimalRateDisplay) < 0.000001;
   const hasBetterRate =
     hasBalance &&
     optimalProtocol &&
+    !ratesAreSame &&
     normalizeProtocolName(optimalProtocol) !== normalizeProtocolName(protocolName) &&
     optimalRateDisplay < currentRate;
 

--- a/packages/nextjs/utils/protocol.ts
+++ b/packages/nextjs/utils/protocol.ts
@@ -11,4 +11,11 @@ export const getProtocolLogo = (protocolName: string): string => {
   };
   
   return protocolLogos[protocolName] || tokenNameToLogo(protocolName);
-}; 
+};
+
+/**
+ * Normalize protocol names for comparison purposes.
+ * Removes spaces, hyphens and underscores and lowercases the result.
+ */
+export const normalizeProtocolName = (name: string): string =>
+  name.toLowerCase().replace(/[\s-_]/g, "");


### PR DESCRIPTION
## Summary
- normalize protocol names before comparing optimal borrow rates
- hide move button when current protocol already provides the best rate

## Testing
- `yarn next:lint`
- `yarn next:check-types`

------
https://chatgpt.com/codex/tasks/task_e_68c72038464c83209b0be1e02a0b64b5