### PR TITLE
Refactor Vesu protocol view and enable Vesu modal contexts

### DIFF
--- a/packages/nextjs/components/BorrowPosition.tsx
+++ b/packages/nextjs/components/BorrowPosition.tsx
@@ -39,6 +39,9 @@ export const BorrowPosition: FC<BorrowPositionProps> = ({
   collateralValue,
   networkType,
   position,
+  vesuContext,
+  actionsDisabled = false,
+  actionsDisabledReason,
 }) => {
   const moveModal = useModal();
   const repayModal = useModal();
@@ -51,11 +54,16 @@ export const BorrowPosition: FC<BorrowPositionProps> = ({
 
   // Get wallet connection status for both networks
   const { evm, starknet } = useWalletConnection();
-  const address = networkType === "evm" ? evm.address : starknet.address;
   const isWalletConnected = networkType === "evm" ? evm.isConnected : starknet.isConnected;
 
   // Check if position has a balance (debt)
   const hasBalance = tokenBalance > 0;
+
+  const disabledMessage =
+    actionsDisabledReason ||
+    (networkType === "starknet"
+      ? "Action unavailable for this market"
+      : "Action unavailable");
 
   // Fetch optimal rate
   const { protocol: optimalProtocol, rate: optimalRateDisplay } = useOptimalRate({
@@ -210,9 +218,15 @@ export const BorrowPosition: FC<BorrowPositionProps> = ({
                   e.stopPropagation();
                   moveModal.open();
                 }}
-                disabled={!isWalletConnected}
+                disabled={!isWalletConnected || actionsDisabled}
                 aria-label="Move"
-                title="Move debt to another protocol"
+                title={
+                  !isWalletConnected
+                    ? "Connect wallet to move debt"
+                    : actionsDisabled
+                      ? disabledMessage
+                      : "Move debt to another protocol"
+                }
               >
                 Move
               </button>
@@ -237,9 +251,15 @@ export const BorrowPosition: FC<BorrowPositionProps> = ({
               <button
                 className="btn btn-sm btn-primary w-full flex justify-center items-center"
                 onClick={repayModal.open}
-                disabled={!hasBalance || !isWalletConnected}
+                disabled={!hasBalance || !isWalletConnected || actionsDisabled}
                 aria-label="Repay"
-                title={!isWalletConnected ? "Connect wallet to repay" : "Repay debt"}
+                title={
+                  !isWalletConnected
+                    ? "Connect wallet to repay"
+                    : actionsDisabled
+                      ? disabledMessage
+                      : "Repay debt"
+                }
               >
                 <div className="flex items-center justify-center">
                   <FiMinus className="w-4 h-4 mr-1" />
@@ -250,9 +270,15 @@ export const BorrowPosition: FC<BorrowPositionProps> = ({
               <button
                 className={`btn btn-sm w-full flex justify-center items-center ${hasBetterRate ? "btn-secondary" : "btn-outline"}`}
                 onClick={moveModal.open}
-                disabled={!hasBalance || !isWalletConnected}
+                disabled={!hasBalance || !isWalletConnected || actionsDisabled}
                 aria-label="Move"
-                title={!isWalletConnected ? "Connect wallet to move debt" : "Move debt to another protocol"}
+                title={
+                  !isWalletConnected
+                    ? "Connect wallet to move debt"
+                    : actionsDisabled
+                      ? disabledMessage
+                      : "Move debt to another protocol"
+                }
               >
                 <div className="flex items-center justify-center">
                   <FiRepeat className="w-4 h-4 mr-1" />
@@ -263,9 +289,15 @@ export const BorrowPosition: FC<BorrowPositionProps> = ({
               <button
                 className="btn btn-sm btn-primary w-full flex justify-center items-center"
                 onClick={borrowModal.open}
-                disabled={!isWalletConnected}
+                disabled={!isWalletConnected || actionsDisabled}
                 aria-label="Borrow"
-                title={!isWalletConnected ? "Connect wallet to borrow" : "Borrow more tokens"}
+                title={
+                  !isWalletConnected
+                    ? "Connect wallet to borrow"
+                    : actionsDisabled
+                      ? disabledMessage
+                      : "Borrow more tokens"
+                }
               >
                 <div className="flex items-center justify-center">
                   <FiPlus className="w-4 h-4 mr-1" />
@@ -279,9 +311,15 @@ export const BorrowPosition: FC<BorrowPositionProps> = ({
               <button
                 className="btn btn-sm btn-primary flex justify-center items-center"
                 onClick={repayModal.open}
-                disabled={!hasBalance || !isWalletConnected}
+                disabled={!hasBalance || !isWalletConnected || actionsDisabled}
                 aria-label="Repay"
-                title={!isWalletConnected ? "Connect wallet to repay" : "Repay debt"}
+                title={
+                  !isWalletConnected
+                    ? "Connect wallet to repay"
+                    : actionsDisabled
+                      ? disabledMessage
+                      : "Repay debt"
+                }
               >
                 <div className="flex items-center justify-center">
                   <FiMinus className="w-4 h-4 mr-1" />
@@ -292,9 +330,15 @@ export const BorrowPosition: FC<BorrowPositionProps> = ({
               <button
                 className={`btn btn-sm flex justify-center items-center ${hasBetterRate ? "btn-secondary" : "btn-outline"}`}
                 onClick={moveModal.open}
-                disabled={!hasBalance || !isWalletConnected}
+                disabled={!hasBalance || !isWalletConnected || actionsDisabled}
                 aria-label="Move"
-                title={!isWalletConnected ? "Connect wallet to move debt" : "Move debt to another protocol"}
+                title={
+                  !isWalletConnected
+                    ? "Connect wallet to move debt"
+                    : actionsDisabled
+                      ? disabledMessage
+                      : "Move debt to another protocol"
+                }
               >
                 <div className="flex items-center justify-center">
                   <FiRepeat className="w-4 h-4 mr-1" />
@@ -305,9 +349,15 @@ export const BorrowPosition: FC<BorrowPositionProps> = ({
               <button
                 className="btn btn-sm btn-primary flex justify-center items-center"
                 onClick={borrowModal.open}
-                disabled={!isWalletConnected}
+                disabled={!isWalletConnected || actionsDisabled}
                 aria-label="Borrow"
-                title={!isWalletConnected ? "Connect wallet to borrow" : "Borrow more tokens"}
+                title={
+                  !isWalletConnected
+                    ? "Connect wallet to borrow"
+                    : actionsDisabled
+                      ? disabledMessage
+                      : "Borrow more tokens"
+                }
               >
                 <div className="flex items-center justify-center">
                   <FiPlus className="w-4 h-4 mr-1" />
@@ -315,6 +365,12 @@ export const BorrowPosition: FC<BorrowPositionProps> = ({
                 </div>
               </button>
             </div>
+
+            {actionsDisabled && (
+              <div className="mt-3 text-sm text-base-content/70">
+                {disabledMessage}
+              </div>
+            )}
           </div>
         )}
       </div>
@@ -343,6 +399,7 @@ export const BorrowPosition: FC<BorrowPositionProps> = ({
             protocolName={protocolName}
             currentDebt={debtAmount}
             position={position}
+            vesuContext={vesuContext?.borrow}
           />
           <RepayModalStark
             isOpen={repayModal.isOpen}
@@ -358,6 +415,7 @@ export const BorrowPosition: FC<BorrowPositionProps> = ({
             protocolName={protocolName}
             debtBalance={typeof tokenBalance === "bigint" ? tokenBalance : BigInt(tokenBalance || 0)}
             position={position}
+            vesuContext={vesuContext?.repay}
           />
           <MovePositionModalStark
             isOpen={moveModal.isOpen}

--- a/packages/nextjs/components/SupplyPosition.tsx
+++ b/packages/nextjs/components/SupplyPosition.tsx
@@ -37,6 +37,9 @@ export const SupplyPosition: FC<SupplyPositionProps> = ({
   networkType,
   position,
   disableMove = false,
+  vesuContext,
+  actionsDisabled = false,
+  actionsDisabledReason,
 }) => {
   const moveModal = useModal();
   const depositModal = useModal();
@@ -49,11 +52,16 @@ export const SupplyPosition: FC<SupplyPositionProps> = ({
 
   // Get wallet connection status for both networks
   const { evm, starknet } = useWalletConnection();
-  const address = networkType === "evm" ? evm.address : starknet.address;
   const isWalletConnected = networkType === "evm" ? evm.isConnected : starknet.isConnected;
 
   // Check if position has a balance
   const hasBalance = tokenBalance > 0;
+
+  const disabledMessage =
+    actionsDisabledReason ||
+    (networkType === "starknet"
+      ? "Action unavailable for this market"
+      : "Action unavailable");
 
   // Fetch optimal rate
   const { protocol: optimalProtocol, rate: optimalRateDisplay } = useOptimalRate({
@@ -191,8 +199,14 @@ export const SupplyPosition: FC<SupplyPositionProps> = ({
               <button
                 className="btn btn-sm btn-primary w-full flex justify-center items-center"
                 onClick={depositModal.open}
-                disabled={!isWalletConnected}
-                title={!isWalletConnected ? "Connect wallet to deposit" : "Deposit tokens"}
+                disabled={!isWalletConnected || actionsDisabled}
+                title={
+                  !isWalletConnected
+                    ? "Connect wallet to deposit"
+                    : actionsDisabled
+                      ? disabledMessage
+                      : "Deposit tokens"
+                }
               >
                 <div className="flex items-center justify-center">
                   <span>Deposit</span>
@@ -201,11 +215,13 @@ export const SupplyPosition: FC<SupplyPositionProps> = ({
               <button
                 className="btn btn-sm btn-outline w-full flex justify-center items-center"
                 onClick={withdrawModal.open}
-                disabled={!isWalletConnected || !hasBalance}
+                disabled={!isWalletConnected || !hasBalance || actionsDisabled}
                 title={
                   !isWalletConnected
                     ? "Connect wallet to withdraw"
-                    : !hasBalance
+                    : actionsDisabled
+                      ? disabledMessage
+                      : !hasBalance
                       ? "No balance to withdraw"
                       : "Withdraw tokens"
                 }
@@ -218,11 +234,13 @@ export const SupplyPosition: FC<SupplyPositionProps> = ({
                 <button
                   className="btn btn-sm btn-outline w-full flex justify-center items-center"
                   onClick={moveModal.open}
-                  disabled={!isWalletConnected || !hasBalance}
+                  disabled={!isWalletConnected || !hasBalance || actionsDisabled}
                   title={
                     !isWalletConnected
                       ? "Connect wallet to move supply"
-                      : !hasBalance
+                      : actionsDisabled
+                        ? disabledMessage
+                        : !hasBalance
                         ? "No balance to move"
                         : "Move supply to another protocol"
                   }
@@ -239,8 +257,14 @@ export const SupplyPosition: FC<SupplyPositionProps> = ({
               <button
                 className="btn btn-sm btn-primary flex justify-center items-center"
                 onClick={depositModal.open}
-                disabled={!isWalletConnected}
-                title={!isWalletConnected ? "Connect wallet to deposit" : "Deposit tokens"}
+                disabled={!isWalletConnected || actionsDisabled}
+                title={
+                  !isWalletConnected
+                    ? "Connect wallet to deposit"
+                    : actionsDisabled
+                      ? disabledMessage
+                      : "Deposit tokens"
+                }
               >
                 <div className="flex items-center justify-center">
                   <span>Deposit</span>
@@ -249,11 +273,13 @@ export const SupplyPosition: FC<SupplyPositionProps> = ({
               <button
                 className="btn btn-sm btn-outline flex justify-center items-center"
                 onClick={withdrawModal.open}
-                disabled={!isWalletConnected || !hasBalance}
+                disabled={!isWalletConnected || !hasBalance || actionsDisabled}
                 title={
                   !isWalletConnected
                     ? "Connect wallet to withdraw"
-                    : !hasBalance
+                    : actionsDisabled
+                      ? disabledMessage
+                      : !hasBalance
                       ? "No balance to withdraw"
                       : "Withdraw tokens"
                 }
@@ -266,11 +292,13 @@ export const SupplyPosition: FC<SupplyPositionProps> = ({
                 <button
                   className="btn btn-sm btn-outline flex justify-center items-center"
                   onClick={moveModal.open}
-                  disabled={!isWalletConnected || !hasBalance}
+                  disabled={!isWalletConnected || !hasBalance || actionsDisabled}
                   title={
                     !isWalletConnected
                       ? "Connect wallet to move supply"
-                      : !hasBalance
+                      : actionsDisabled
+                        ? disabledMessage
+                        : !hasBalance
                         ? "No balance to move"
                         : "Move supply to another protocol"
                   }
@@ -281,6 +309,12 @@ export const SupplyPosition: FC<SupplyPositionProps> = ({
                 </button>
               )}
             </div>
+          </div>
+        )}
+
+        {isExpanded && actionsDisabled && (
+          <div className="mt-3 text-sm text-base-content/70" onClick={e => e.stopPropagation()}>
+            {disabledMessage}
           </div>
         )}
       </div>
@@ -301,6 +335,7 @@ export const SupplyPosition: FC<SupplyPositionProps> = ({
             }}
             protocolName={protocolName}
             position={position}
+            vesuContext={vesuContext?.deposit}
           />
           <WithdrawModalStark
             isOpen={withdrawModal.isOpen}
@@ -316,6 +351,7 @@ export const SupplyPosition: FC<SupplyPositionProps> = ({
             protocolName={protocolName}
             supplyBalance={typeof tokenBalance === "bigint" ? tokenBalance : BigInt(tokenBalance || 0)}
             position={position}
+            vesuContext={vesuContext?.withdraw}
           />
         </>
       ) : (

--- a/packages/nextjs/components/specific/vesu/VesuProtocolView.tsx
+++ b/packages/nextjs/components/specific/vesu/VesuProtocolView.tsx
@@ -1,14 +1,51 @@
 import { FC, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ContractResponse, POOL_IDS, VesuMarkets } from "./VesuMarkets";
-import { VesuPosition } from "./VesuPosition";
+import { ProtocolPosition, ProtocolView } from "../../ProtocolView";
+import { SupplyPosition } from "../../SupplyPosition";
+import { BorrowPosition } from "../../BorrowPosition";
 import { useScaffoldReadContract } from "~~/hooks/scaffold-stark";
 import { useAccount } from "~~/hooks/useAccount";
-import { PositionData, TokenMetadata, formatTokenAmount, toAnnualRates } from "~~/utils/protocols";
+import { tokenNameToLogo } from "~~/contracts/externalContracts";
+import { PositionManager } from "~~/utils/position";
+import { feltToString, toAnnualRates } from "~~/utils/protocols";
+import type { ContractResponse } from "./VesuMarkets";
+import { POOL_IDS } from "./VesuMarkets";
+import { formatUnits } from "viem";
+
+const toHexAddress = (value: bigint) => `0x${value.toString(16).padStart(64, "0")}`;
+
+const normalizePrice = (price: { value: bigint; is_valid: boolean }) => (price.is_valid ? price.value / 10n ** 10n : 0n);
+
+const computeUsdValue = (amount: bigint, decimals: number, price: bigint): number => {
+  if (amount === 0n || price === 0n) {
+    return 0;
+  }
+
+  const amountAsNumber = Number(formatUnits(amount, decimals));
+  const priceAsNumber = Number(price) / 1e8;
+
+  return amountAsNumber * priceAsNumber;
+};
 
 type PositionTuple = {
-  0: bigint; // collateral_asset
-  1: bigint; // debt_asset
-  2: PositionData;
+  0: bigint; // collateral asset
+  1: bigint; // debt asset
+  2: {
+    collateral_shares: bigint;
+    collateral_amount: bigint;
+    nominal_debt: bigint;
+    is_vtoken: boolean;
+  };
+};
+
+type AssetWithRates = ContractResponse[number] & { borrowAPR: number; supplyAPY: number };
+
+type VesuPositionRow = {
+  key: string;
+  supply: ProtocolPosition;
+  borrow?: ProtocolPosition;
+  isVtoken: boolean;
+  collateralSymbol: string;
+  debtSymbol?: string;
 };
 
 export const VesuProtocolView: FC = () => {
@@ -29,7 +66,6 @@ export const VesuProtocolView: FC = () => {
     console.error("Error fetching supported assets:", assetsError);
   }
 
-  // Paginated user positions reads
   const {
     data: userPositionsPart1,
     error: positionsError1,
@@ -42,6 +78,7 @@ export const VesuProtocolView: FC = () => {
     watch: true,
     refetchInterval: positionsRefetchInterval,
   });
+
   const {
     data: userPositionsPart2,
     error: positionsError2,
@@ -84,7 +121,6 @@ export const VesuProtocolView: FC = () => {
     refetchPositionsPart2();
   }, [userAddress, refetchPositionsPart1, refetchPositionsPart2]);
 
-  // Keep previous positions while new data is loading to avoid UI flicker
   const [cachedPositions, setCachedPositions] = useState<PositionTuple[]>([]);
   const [hasLoadedOnce, setHasLoadedOnce] = useState(false);
 
@@ -117,118 +153,250 @@ export const VesuProtocolView: FC = () => {
     };
   }, [refetchPositions]);
 
-  const positionRows = useMemo(() => {
-    if (!supportedAssets) return null;
-    const positions = cachedPositions as unknown as PositionTuple[];
+  const assetsWithRates = useMemo<AssetWithRates[]>(() => {
+    if (!supportedAssets) return [];
 
-    return positions?.map((position, index) => {
-      const collateralAsset = `0x${position[0].toString(16).padStart(64, "0")}`;
-      const debtAsset = `0x${position[1].toString(16).padStart(64, "0")}`;
-      const positionData = position[2];
+    return (supportedAssets as ContractResponse).map(asset => {
+      if (asset.scale === 0n) {
+        return { ...asset, borrowAPR: 0, supplyAPY: 0 };
+      }
 
-      const assetsWithRates = (supportedAssets as unknown as ContractResponse).map(asset => {
-        if (asset.scale == 0n) {
-          return { ...asset, borrowAPR: 0, supplyAPY: 0 };
-        }
-        const { borrowAPR, supplyAPY } = toAnnualRates(
-          asset.fee_rate,
-          asset.total_nominal_debt,
-          asset.last_rate_accumulator,
-          asset.reserve,
-          asset.scale,
-        );
-        return { ...asset, borrowAPR, supplyAPY };
-      });
-
-      return (
-        <VesuPosition
-          key={`${collateralAsset}-${debtAsset}-${index}`}
-          collateralAsset={collateralAsset}
-          debtAsset={debtAsset}
-          collateralShares={positionData.collateral_shares.toString()}
-          collateralAmount={positionData.collateral_amount.toString()}
-          nominalDebt={positionData.nominal_debt.toString()}
-          isVtoken={positionData.is_vtoken}
-          supportedAssets={assetsWithRates as unknown as TokenMetadata[]}
-          poolId={poolId}
-        />
+      const { borrowAPR, supplyAPY } = toAnnualRates(
+        asset.fee_rate,
+        asset.total_nominal_debt,
+        asset.last_rate_accumulator,
+        asset.reserve,
+        asset.scale,
       );
+
+      return { ...asset, borrowAPR, supplyAPY };
     });
-  }, [cachedPositions, supportedAssets, poolId]);
+  }, [supportedAssets]);
+
+  const assetMap = useMemo(() => {
+    const map = new Map<string, AssetWithRates>();
+    assetsWithRates.forEach(asset => {
+      map.set(toHexAddress(asset.address), asset);
+    });
+    return map;
+  }, [assetsWithRates]);
+
+  const suppliablePositions = useMemo<ProtocolPosition[]>(() => {
+    return assetsWithRates.map(asset => {
+      const address = toHexAddress(asset.address);
+      const symbol = feltToString(asset.symbol);
+      const price = normalizePrice(asset.price);
+
+      return {
+        icon: tokenNameToLogo(symbol.toLowerCase()),
+        name: symbol,
+        balance: 0,
+        tokenBalance: 0n,
+        currentRate: (asset.supplyAPY ?? 0) * 100,
+        tokenAddress: address,
+        tokenDecimals: asset.decimals,
+        tokenPrice: price,
+        tokenSymbol: symbol,
+      };
+    });
+  }, [assetsWithRates]);
+
+  const borrowablePositions = useMemo<ProtocolPosition[]>(() => {
+    return assetsWithRates.map(asset => {
+      const address = toHexAddress(asset.address);
+      const symbol = feltToString(asset.symbol);
+      const price = normalizePrice(asset.price);
+
+      return {
+        icon: tokenNameToLogo(symbol.toLowerCase()),
+        name: symbol,
+        balance: 0,
+        tokenBalance: 0n,
+        currentRate: (asset.borrowAPR ?? 0) * 100,
+        tokenAddress: address,
+        tokenDecimals: asset.decimals,
+        tokenPrice: price,
+        tokenSymbol: symbol,
+      };
+    });
+  }, [assetsWithRates]);
+
+  const vesuRows = useMemo<VesuPositionRow[]>(() => {
+    if (assetMap.size === 0) return [];
+
+    return cachedPositions
+      .map((position, index) => {
+        const collateralAddress = toHexAddress(position[0]);
+        const debtAddress = toHexAddress(position[1]);
+        const positionData = position[2];
+
+        const collateralMetadata = assetMap.get(collateralAddress);
+        if (!collateralMetadata) return null;
+
+        const collateralSymbol = feltToString(collateralMetadata.symbol);
+        const collateralPrice = normalizePrice(collateralMetadata.price);
+        const collateralUsd = computeUsdValue(positionData.collateral_amount, collateralMetadata.decimals, collateralPrice);
+
+        const disabledReason = positionData.is_vtoken ? "Managing vToken positions is not supported" : undefined;
+
+        const supplyPosition: ProtocolPosition = {
+          icon: tokenNameToLogo(collateralSymbol.toLowerCase()),
+          name: collateralSymbol,
+          balance: collateralUsd,
+          tokenBalance: positionData.collateral_amount,
+          currentRate: (collateralMetadata.supplyAPY ?? 0) * 100,
+          tokenAddress: collateralAddress,
+          tokenDecimals: collateralMetadata.decimals,
+          tokenPrice: collateralPrice,
+          tokenSymbol: collateralSymbol,
+          vesuContext: {
+            deposit: positionData.nominal_debt > 0n ? { poolId, counterpartToken: debtAddress } : undefined,
+            withdraw: { poolId, counterpartToken: debtAddress },
+          },
+          actionsDisabled: positionData.is_vtoken,
+          actionsDisabledReason: disabledReason,
+        };
+
+        const debtMetadata = assetMap.get(debtAddress);
+        let borrowPosition: ProtocolPosition | undefined;
+        let debtSymbol: string | undefined;
+
+        if (positionData.nominal_debt > 0n && debtMetadata) {
+          debtSymbol = feltToString(debtMetadata.symbol);
+          const debtPrice = normalizePrice(debtMetadata.price);
+          const debtUsd = computeUsdValue(positionData.nominal_debt, debtMetadata.decimals, debtPrice);
+
+          borrowPosition = {
+            icon: tokenNameToLogo(debtSymbol.toLowerCase()),
+            name: debtSymbol,
+            balance: -debtUsd,
+            tokenBalance: positionData.nominal_debt,
+            currentRate: (debtMetadata.borrowAPR ?? 0) * 100,
+            tokenAddress: debtAddress,
+            tokenDecimals: debtMetadata.decimals,
+            tokenPrice: debtPrice,
+            tokenSymbol: debtSymbol,
+            collateralValue: collateralUsd,
+            vesuContext: {
+              borrow: { poolId, counterpartToken: collateralAddress },
+              repay: { poolId, counterpartToken: collateralAddress },
+            },
+            actionsDisabled: positionData.is_vtoken,
+            actionsDisabledReason: disabledReason,
+          };
+        } else if (debtMetadata) {
+          debtSymbol = feltToString(debtMetadata.symbol);
+        }
+
+        return {
+          key: `${collateralAddress}-${debtAddress}-${index}`,
+          supply: supplyPosition,
+          borrow: borrowPosition,
+          isVtoken: positionData.is_vtoken,
+          collateralSymbol,
+          debtSymbol,
+        };
+      })
+      .filter((row): row is VesuPositionRow => row !== null);
+  }, [assetMap, cachedPositions, poolId]);
+
+  const totalNetBalance = useMemo(() => {
+    return vesuRows.reduce((total, row) => total + row.supply.balance + (row.borrow ? row.borrow.balance : 0), 0);
+  }, [vesuRows]);
 
   if (assetsError) {
-    console.error("Error fetching supported assets:", assetsError);
+    console.error("Error loading markets:", assetsError);
     return <div>Error loading markets</div>;
   }
 
+  const formatCurrency = (value: number) =>
+    new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(value);
+
   return (
-    <div className="w-full flex flex-col p-4 space-y-4">
-      <VesuMarkets
-        supportedAssets={supportedAssets as ContractResponse | undefined}
-        viewMode="grid"
-        search=""
-        allowDeposit
+    <div className="w-full flex flex-col p-4 space-y-6">
+      <ProtocolView
+        protocolName="Vesu"
+        protocolIcon="/logos/vesu.svg"
+        ltv={75}
+        maxLtv={90}
+        suppliedPositions={suppliablePositions}
+        borrowedPositions={borrowablePositions}
+        forceShowAll={!userAddress}
+        networkType="starknet"
+        disableMoveSupply
       />
 
       <div className="card bg-base-100 shadow-md">
-        <div className="card-body p-4">
-          <div className="flex justify-between items-center mb-4">
-            <h2 className="card-title text-lg">Your Positions</h2>
-            {userAddress && positionRows?.length ? (
-              <div className="text-right">
-                <div className="text-sm text-gray-500">Total Net Balance</div>
-                <div className="text-xl font-bold">
-                  $
-                  {positionRows
-                    .reduce((total, position) => {
-                      const collateralMetadata = position.props.supportedAssets.find(
-                        (asset: TokenMetadata) =>
-                          `0x${BigInt(asset.address).toString(16).padStart(64, "0")}` ===
-                          position.props.collateralAsset,
-                      );
-                      const debtMetadata = position.props.supportedAssets.find(
-                        (asset: TokenMetadata) =>
-                          `0x${BigInt(asset.address).toString(16).padStart(64, "0")}` === position.props.debtAsset,
-                      );
-
-                      if (!collateralMetadata) return total;
-
-                      const collateralAmtNum = parseFloat(
-                        formatTokenAmount(position.props.collateralAmount, collateralMetadata.decimals),
-                      );
-                      const collateralPriceNum = parseFloat(
-                        formatTokenAmount(collateralMetadata.price.value.toString(), 18),
-                      );
-                      const collateralValue = collateralAmtNum * collateralPriceNum;
-
-                      let debtValue = 0;
-                      if (position.props.nominalDebt !== "0" && debtMetadata) {
-                        const debtAmtNum = parseFloat(formatTokenAmount(position.props.nominalDebt, 18));
-                        const debtPriceNum = parseFloat(formatTokenAmount(debtMetadata.price.value.toString(), 18));
-                        debtValue = debtAmtNum * debtPriceNum;
-                      }
-
-                      return total + (collateralValue - debtValue);
-                    }, 0)
-                    .toLocaleString("en-US", {
-                      minimumFractionDigits: 2,
-                      maximumFractionDigits: 2,
-                    })}
+        <div className="card-body p-4 space-y-4">
+          <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+            <h2 className="card-title text-lg">Your Vesu Positions</h2>
+            <div className="flex items-center gap-4">
+              {isUpdating && userAddress && (
+                <div className="flex items-center text-xs text-base-content/60">
+                  <span className="loading loading-spinner loading-xs mr-1" /> Updating
                 </div>
-              </div>
-            ) : null}
+              )}
+              {userAddress && vesuRows.length > 0 && (
+                <div className="text-right">
+                  <div className="text-sm text-base-content/70">Total Net Balance</div>
+                  <div className="text-xl font-bold">{formatCurrency(totalNetBalance)}</div>
+                </div>
+              )}
+            </div>
           </div>
-          <div className={`flex flex-wrap gap-4 justify-start ${isUpdating ? "" : ""}`}>
+
+          <div className="space-y-4">
             {status === "connecting" || (userAddress && !hasLoadedOnce) ? (
-              <div className="text-center py-4 w-full">
-                <span className="loading loading-spinner" />
+              <div className="flex justify-center py-6">
+                <span className="loading loading-spinner loading-md" />
               </div>
             ) : !userAddress ? (
-              <div className="text-center py-4 text-gray-500 w-full">Connect your Starknet wallet to view</div>
-            ) : positionRows?.length ? (
-              positionRows
+              <div className="rounded-md bg-base-200/60 p-4 text-center text-sm text-base-content/70">
+                Connect your Starknet wallet to view your Vesu positions
+              </div>
+            ) : vesuRows.length > 0 ? (
+              vesuRows.map(row => {
+                const positionManager = PositionManager.fromPositions(
+                  [row.supply],
+                  row.borrow ? [row.borrow] : [],
+                );
+
+                return (
+                  <div key={row.key} className="grid gap-4 md:grid-cols-2">
+                    <SupplyPosition
+                      {...row.supply}
+                      protocolName="Vesu"
+                      networkType="starknet"
+                      position={positionManager}
+                      disableMove
+                      afterInfoContent={
+                        row.isVtoken ? <span className="badge badge-xs badge-primary ml-2">vToken</span> : undefined
+                      }
+                    />
+                    {row.borrow ? (
+                      <BorrowPosition
+                        {...row.borrow}
+                        protocolName="Vesu"
+                        networkType="starknet"
+                        position={positionManager}
+                      />
+                    ) : (
+                      <div className="flex items-center justify-center rounded-md bg-base-200/60 p-4 text-sm text-base-content/70">
+                        No active debt for {row.collateralSymbol}
+                      </div>
+                    )}
+                  </div>
+                );
+              })
             ) : (
-              <div className="text-center py-4 text-gray-500 w-full">No positions found</div>
+              <div className="rounded-md bg-base-200/60 p-4 text-center text-sm text-base-content/70">
+                No positions found
+              </div>
             )}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add Vesu-aware action disabling and context plumbing to shared SupplyPosition and BorrowPosition components
- extend the shared protocol view to carry modal context metadata for Starknet flows
- rebuild the Vesu protocol screen to reuse the shared protocol view for market rates and render paired supply/borrow rows per position

## Testing
- yarn lint *(warnings only; existing lint warnings remain)*

------
https://chatgpt.com/codex/tasks/task_e_68c9b34ec67883209cf47aca23b78ada