### PR TITLE
Add Kapan paymaster wrapper hook

### DIFF
--- a/packages/nextjs/__tests__/useKapanPaymasterSendTransaction.test.ts
+++ b/packages/nextjs/__tests__/useKapanPaymasterSendTransaction.test.ts
@@ -1,0 +1,166 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import type { Call } from "starknet";
+import { num } from "starknet";
+import {
+  DEFAULT_GAS_TOKEN_MAP,
+  normalizeExtendedPaymasterDetails,
+  parseAuthorizationResult,
+  useKapanPaymasterSendTransaction,
+  type ExtendedPaymasterDetails,
+} from "../hooks/useKapanPaymasterSendTransaction";
+
+let capturedArgs: any = null;
+const sendAsyncSpy = vi.fn();
+const usePaymasterSendTransactionMock = vi.fn((args: any) => ({
+  send: vi.fn(),
+  sendAsync: sendAsyncSpy,
+  data: null,
+  error: null,
+  status: "idle",
+}));
+
+vi.mock("@starknet-react/core", () => ({
+  usePaymasterSendTransaction: (args: any) => {
+    capturedArgs = args;
+    return usePaymasterSendTransactionMock(args);
+  },
+}));
+
+vi.mock("~~/hooks/useAccount", () => ({
+  useAccount: () => ({
+    account: { address: "0xabc" },
+    address: "0xabc",
+  }),
+}));
+
+vi.mock("~~/hooks/scaffold-stark", () => ({
+  useDeployedContractInfo: () => ({
+    data: { address: "0xrouter", abi: [] as any },
+  }),
+}));
+
+describe("useKapanPaymasterSendTransaction helpers", () => {
+  beforeEach(() => {
+    capturedArgs = null;
+    sendAsyncSpy.mockReset();
+    sendAsyncSpy.mockResolvedValue({ transaction_hash: "0x0" });
+    usePaymasterSendTransactionMock.mockClear();
+  });
+
+  it("merges default token map", () => {
+    expect(DEFAULT_GAS_TOKEN_MAP.strk).toBeDefined();
+    expect(DEFAULT_GAS_TOKEN_MAP.eth).toBeDefined();
+  });
+
+  it("normalizes default fee mode without modifications", () => {
+    const details: ExtendedPaymasterDetails = {
+      feeMode: { mode: "default", gasToken: "0x123" },
+    };
+    const { options, kapanMode } = normalizeExtendedPaymasterDetails(details, undefined, undefined);
+    expect(options).toEqual(details);
+    expect(kapanMode).toBeNull();
+  });
+
+  it("normalizes collateral mode with alias resolution", () => {
+    const details: ExtendedPaymasterDetails = {
+      feeMode: {
+        mode: "collateral",
+        protocol: "kapan",
+        lendingProtocol: "Vesu",
+        gasToken: "USDC",
+        amount: 500n,
+        withdrawAll: true,
+      },
+    };
+    const { options, kapanMode } = normalizeExtendedPaymasterDetails(details, { usdc: "0xusdc" }, undefined);
+    expect(options.feeMode).toEqual({ mode: "default", gasToken: "0xusdc" });
+    expect(kapanMode).not.toBeNull();
+    expect(kapanMode?.gasTokenAddress).toBe("0xusdc");
+    expect(kapanMode?.withdrawAll).toBe(true);
+    expect(kapanMode?.amount).toBe(500n);
+    expect(kapanMode?.aggregatorType).toBe("kapan");
+  });
+
+  it("parses authorization results into calls", () => {
+    const entryFelt = BigInt("0x7769746864726177"); // "withdraw"
+    const calls = parseAuthorizationResult([[1n, entryFelt, [2n, 3n]]]);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual({
+      contractAddress: num.toHexString(1n),
+      entrypoint: "withdraw",
+      calldata: [num.toHexString(2n), num.toHexString(3n)],
+    });
+  });
+});
+
+describe("useKapanPaymasterSendTransaction hook", () => {
+  beforeEach(() => {
+    capturedArgs = null;
+    sendAsyncSpy.mockReset();
+    sendAsyncSpy.mockResolvedValue({ transaction_hash: "0xfeed" });
+    usePaymasterSendTransactionMock.mockClear();
+  });
+
+  it("appends custom builder calls and normalizes fee mode", async () => {
+    const builderCalls: Call[] = [
+      { contractAddress: "0xrouter", entrypoint: "withdraw", calldata: ["0x1"] },
+    ];
+    const builderSpy = vi.fn().mockResolvedValue(builderCalls);
+    const baseCalls: Call[] = [
+      { contractAddress: "0xbase", entrypoint: "do", calldata: [] },
+    ];
+
+    const { result } = renderHook(() =>
+      useKapanPaymasterSendTransaction({
+        calls: baseCalls,
+        options: {
+          feeMode: {
+            mode: "collateral",
+            protocol: "kapan",
+            lendingProtocol: "Vesu",
+            gasToken: "USDC",
+            amount: 1000n,
+            buildAdditionalCalls: builderSpy,
+          },
+        },
+        tokenAddressMap: { usdc: "0xUSDC" },
+      }),
+    );
+
+    await act(async () => {
+      await result.current.sendAsync();
+    });
+
+    expect(builderSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountAddress: "0xabc",
+        gasTokenAddress: "0xUSDC",
+        mode: "collateral",
+        protocolName: "Vesu",
+      }),
+    );
+    expect(sendAsyncSpy).toHaveBeenCalledWith([...baseCalls, ...builderCalls]);
+    expect(capturedArgs?.options?.feeMode).toEqual({ mode: "default", gasToken: "0xUSDC" });
+  });
+
+  it("behaves like base hook for default mode", async () => {
+    const baseCalls: Call[] = [
+      { contractAddress: "0xbase", entrypoint: "operate", calldata: [] },
+    ];
+
+    const { result } = renderHook(() =>
+      useKapanPaymasterSendTransaction({
+        calls: baseCalls,
+        options: { feeMode: { mode: "default", gasToken: "0x123" } },
+      }),
+    );
+
+    await act(async () => {
+      await result.current.sendAsync();
+    });
+
+    expect(sendAsyncSpy).toHaveBeenCalledWith(baseCalls);
+    expect(capturedArgs?.options?.feeMode).toEqual({ mode: "default", gasToken: "0x123" });
+  });
+});

--- a/packages/nextjs/hooks/scaffold-stark/usePaymasterTransactor.tsx
+++ b/packages/nextjs/hooks/scaffold-stark/usePaymasterTransactor.tsx
@@ -3,8 +3,9 @@ import { AccountInterface, InvokeFunctionResponse, constants, RpcProvider, Call 
 import { useAccount } from "~~/hooks/useAccount";
 import { getBlockExplorerTxLink, notification } from "~~/utils/scaffold-stark";
 import { useSelectedGasToken } from "~~/contexts/SelectedGasTokenContext";
-import { usePaymasterSendTransaction, usePaymasterGasTokens } from "@starknet-react/core";
+import { usePaymasterGasTokens } from "@starknet-react/core";
 import { universalStrkAddress } from "~~/utils/Constants";
+import { useKapanPaymasterSendTransaction } from "~~/hooks/useKapanPaymasterSendTransaction";
 
 type TransactionFunc = (
   tx: () => Promise<InvokeFunctionResponse> | Promise<string> | Call | Call[],
@@ -54,7 +55,7 @@ export const usePaymasterTransactor = (_walletClient?: AccountInterface): Transa
   const shouldUsePaymaster = !isSelectedStrk && isSupportedPaymasterToken;
 
   // Setup paymaster transaction hook
-  const { sendAsync: sendPaymasterTransaction } = usePaymasterSendTransaction({
+  const { sendAsync: sendPaymasterTransaction } = useKapanPaymasterSendTransaction({
     calls: [], // Will be overridden in execution
     options: {
       feeMode: shouldUsePaymaster

--- a/packages/nextjs/hooks/useKapanPaymasterSendTransaction.ts
+++ b/packages/nextjs/hooks/useKapanPaymasterSendTransaction.ts
@@ -1,0 +1,426 @@
+"use client";
+
+import { useCallback, useMemo } from "react";
+import {
+  type AccountInterface,
+  type Abi,
+  type BigNumberish,
+  type Call,
+  CairoCustomEnum,
+  CairoOption,
+  CairoOptionVariant,
+  CallData,
+  Contract,
+  num,
+  uint256,
+  type PaymasterDetails,
+} from "starknet";
+import {
+  usePaymasterSendTransaction,
+  type UsePaymasterSendTransactionArgs,
+  type UsePaymasterSendTransactionResult,
+} from "@starknet-react/core";
+import { useAccount } from "~~/hooks/useAccount";
+import { useDeployedContractInfo } from "~~/hooks/scaffold-stark";
+import { feltToString } from "~~/utils/protocols";
+import { universalEthAddress, universalStrkAddress } from "~~/utils/Constants";
+
+const HEX_PREFIX = "0x";
+
+export const DEFAULT_GAS_TOKEN_MAP: Record<string, string> = {
+  strk: universalStrkAddress,
+  eth: universalEthAddress,
+};
+
+export type GasTokenResolver = (tokenId: string) => string | undefined;
+
+export interface KapanInstructionContext {
+  values?: Array<BigNumberish | string>;
+  poolId?: BigNumberish;
+  counterpartToken?: string;
+}
+
+export interface KapanCallBuilderArgs {
+  account?: AccountInterface;
+  accountAddress: string;
+  routerAddress?: string;
+  routerAbi?: Abi;
+  gasTokenAddress: string;
+  amount: bigint;
+  withdrawAll: boolean;
+  protocolName: string;
+  contextValues?: Array<BigNumberish | string>;
+  userCalls: Call[];
+  mode: "collateral" | "borrow";
+}
+
+export type KapanCallBuilder = (args: KapanCallBuilderArgs) => Promise<Call[]>;
+
+interface KapanModeBase {
+  protocol?: string;
+  lendingProtocol: string;
+  gasToken: string;
+  amount: BigNumberish;
+  context?: KapanInstructionContext;
+  accountAddress?: string;
+  routerAddress?: string;
+  tokenAddressMap?: Record<string, string>;
+  buildAdditionalCalls?: KapanCallBuilder;
+}
+
+export interface KapanCollateralFeeMode extends KapanModeBase {
+  mode: "collateral";
+  withdrawAll?: boolean;
+}
+
+export interface KapanBorrowFeeMode extends KapanModeBase {
+  mode: "borrow";
+}
+
+export type ExtendedFeeMode =
+  | PaymasterDetails["feeMode"]
+  | KapanCollateralFeeMode
+  | KapanBorrowFeeMode;
+
+export type ExtendedPaymasterDetails = Omit<PaymasterDetails, "feeMode"> & {
+  feeMode: ExtendedFeeMode;
+};
+
+export type UseKapanPaymasterSendTransactionArgs = Omit<UsePaymasterSendTransactionArgs, "options"> & {
+  options: ExtendedPaymasterDetails;
+  tokenAddressMap?: Record<string, string>;
+  resolveGasTokenAddress?: GasTokenResolver;
+};
+
+interface NormalizedKapanMode {
+  mode: "collateral" | "borrow";
+  aggregatorType: string;
+  lendingProtocol: string;
+  gasTokenAddress: string;
+  amount: bigint;
+  withdrawAll: boolean;
+  contextValues?: Array<BigNumberish | string>;
+  accountAddress?: string;
+  routerAddress?: string;
+  buildAdditionalCalls?: KapanCallBuilder;
+}
+
+interface NormalizedPaymasterConfig {
+  options: PaymasterDetails;
+  kapanMode: NormalizedKapanMode | null;
+}
+
+function mergeTokenMaps(
+  ...maps: Array<Record<string, string> | undefined>
+): Record<string, string> {
+  const merged: Record<string, string> = {};
+  for (const map of maps) {
+    if (!map) continue;
+    for (const [key, value] of Object.entries(map)) {
+      if (!value) continue;
+      merged[key.toLowerCase()] = value;
+    }
+  }
+  return merged;
+}
+
+export function resolveGasToken(
+  tokenId: string,
+  resolver: GasTokenResolver | undefined,
+  maps: Array<Record<string, string> | undefined>,
+): string {
+  if (!tokenId) throw new Error("Gas token identifier is required");
+  const direct = resolver?.(tokenId);
+  if (direct) return direct;
+  if (tokenId.toLowerCase().startsWith(HEX_PREFIX)) {
+    return tokenId;
+  }
+  const lower = tokenId.toLowerCase();
+  for (const map of maps) {
+    if (!map) continue;
+    const found = map[lower];
+    if (found) return found;
+  }
+  throw new Error(`Unable to resolve gas token identifier: ${tokenId}`);
+}
+
+function resolveContextValues(
+  context?: KapanInstructionContext,
+): Array<BigNumberish | string> | undefined {
+  if (!context) return undefined;
+  if (Array.isArray(context.values) && context.values.length > 0) {
+    return context.values;
+  }
+  if (context.poolId !== undefined && context.counterpartToken !== undefined) {
+    return [context.poolId, context.counterpartToken];
+  }
+  return undefined;
+}
+
+export function toBigInt(value: BigNumberish | undefined): bigint {
+  if (value === undefined || value === null) {
+    throw new Error("Amount is required for Kapan paymaster mode");
+  }
+  if (typeof value === "bigint") return value;
+  if (typeof value === "number") return BigInt(Math.trunc(value));
+  if (typeof value === "string") return BigInt(value);
+  if (Array.isArray(value)) {
+    if (value.length === 2) {
+      const low = toBigInt(value[0] as BigNumberish);
+      const high = toBigInt(value[1] as BigNumberish);
+      return (high << 128n) + low;
+    }
+    throw new Error("Unsupported array format for BigNumberish value");
+  }
+  if (typeof value === "object") {
+    if ("low" in value && "high" in value) {
+      const low = toBigInt((value as any).low);
+      const high = toBigInt((value as any).high);
+      return (high << 128n) + low;
+    }
+  }
+  throw new Error("Unsupported BigNumberish value");
+}
+
+export function normalizeExtendedPaymasterDetails(
+  details: ExtendedPaymasterDetails,
+  tokenAddressMap: Record<string, string> | undefined,
+  resolver: GasTokenResolver | undefined,
+): NormalizedPaymasterConfig {
+  const { feeMode, ...rest } = details;
+
+  if (feeMode.mode === "default" || feeMode.mode === "sponsored") {
+    return {
+      options: details as PaymasterDetails,
+      kapanMode: null,
+    };
+  }
+
+  if (feeMode.mode !== "collateral" && feeMode.mode !== "borrow") {
+    throw new Error(`Unsupported paymaster mode: ${String((feeMode as any).mode)}`);
+  }
+
+  const maps = mergeTokenMaps(DEFAULT_GAS_TOKEN_MAP, tokenAddressMap, feeMode.tokenAddressMap);
+  const gasTokenAddress = resolveGasToken(feeMode.gasToken, resolver, [maps]);
+  const amount = toBigInt(feeMode.amount);
+  const withdrawAll = feeMode.mode === "collateral" ? Boolean(feeMode.withdrawAll) : false;
+  const aggregatorType = (feeMode.protocol ?? "kapan").toLowerCase();
+  const contextValues = resolveContextValues(feeMode.context);
+
+  const normalizedMode: NormalizedKapanMode = {
+    mode: feeMode.mode,
+    aggregatorType,
+    lendingProtocol: feeMode.lendingProtocol,
+    gasTokenAddress,
+    amount,
+    withdrawAll,
+    contextValues,
+    accountAddress: feeMode.accountAddress,
+    routerAddress: feeMode.routerAddress,
+    buildAdditionalCalls: feeMode.buildAdditionalCalls,
+  };
+
+  const normalizedOptions: PaymasterDetails = {
+    ...(rest as Omit<PaymasterDetails, "feeMode">),
+    feeMode: {
+      mode: "default",
+      gasToken: gasTokenAddress,
+    },
+  };
+
+  return {
+    options: normalizedOptions,
+    kapanMode: normalizedMode,
+  };
+}
+
+function normalizeCallInput(calls?: Call | Call[]): Call[] {
+  if (!calls) return [];
+  return Array.isArray(calls) ? calls : [calls];
+}
+
+export function parseAuthorizationResult(result: unknown): Call[] {
+  const calls: Call[] = [];
+  if (!Array.isArray(result)) return calls;
+  for (const item of result as any[]) {
+    if (!Array.isArray(item) || item.length < 3) continue;
+    const [addrRaw, entryRaw, dataRaw] = item;
+    const contractAddress = num.toHexString(addrRaw);
+    const entrypoint =
+      typeof entryRaw === "string"
+        ? entryRaw
+        : typeof entryRaw === "bigint"
+        ? feltToString(entryRaw)
+        : feltToString(BigInt(entryRaw ?? 0));
+    const calldataArray = Array.isArray(dataRaw) ? dataRaw : [];
+    const calldata = calldataArray.map(arg => num.toHexString(arg));
+    calls.push({ contractAddress, entrypoint, calldata });
+  }
+  return calls;
+}
+
+async function defaultKapanCallBuilder({
+  account,
+  accountAddress,
+  routerAddress,
+  routerAbi,
+  gasTokenAddress,
+  amount,
+  withdrawAll,
+  protocolName,
+  contextValues,
+  mode,
+}: KapanCallBuilderArgs): Promise<Call[]> {
+  if (!account) throw new Error("Starknet account is required for Kapan paymaster mode");
+  if (!routerAddress || !routerAbi) {
+    throw new Error("Router gateway contract is required for Kapan paymaster mode");
+  }
+
+  const contract = new Contract(routerAbi, routerAddress, account);
+  const basic = {
+    token: gasTokenAddress,
+    amount: uint256.bnToUint256(amount),
+    user: accountAddress,
+  };
+
+  const option = contextValues && contextValues.length > 0
+    ? new CairoOption(CairoOptionVariant.Some, contextValues)
+    : new CairoOption(CairoOptionVariant.None);
+
+  const lendingInstruction = new CairoCustomEnum({
+    Deposit: undefined,
+    Borrow: mode === "borrow" ? { basic, context: option } : undefined,
+    Repay: undefined,
+    Withdraw:
+      mode === "collateral"
+        ? { basic, withdraw_all: withdrawAll, context: option }
+        : undefined,
+  });
+
+  const protocolInstruction = {
+    protocol_name: protocolName.toLowerCase(),
+    instructions: [lendingInstruction],
+  };
+
+  const fullInstruction = CallData.compile({ instructions: [protocolInstruction] });
+  const authInstruction = CallData.compile({ instructions: [protocolInstruction], rawSelectors: false });
+
+  const rawAuthorizations = await contract.call(
+    "get_authorizations_for_instructions",
+    authInstruction,
+  );
+  const authorizationCalls = parseAuthorizationResult(rawAuthorizations);
+
+  authorizationCalls.push({
+    contractAddress: routerAddress,
+    entrypoint: "process_protocol_instructions",
+    calldata: fullInstruction,
+  });
+
+  return authorizationCalls;
+}
+
+async function buildKapanModeCalls(
+  normalized: NormalizedKapanMode,
+  account: AccountInterface | undefined,
+  accountAddress: string | undefined,
+  routerContract: { address: string; abi: Abi } | undefined,
+  userCalls: Call[],
+): Promise<Call[]> {
+  const resolvedAddress = normalized.accountAddress ?? accountAddress;
+  if (!resolvedAddress) {
+    throw new Error("Account address is required for Kapan paymaster mode");
+  }
+
+  const builder = normalized.buildAdditionalCalls;
+  if (builder) {
+    return builder({
+      account,
+      accountAddress: resolvedAddress,
+      routerAddress: normalized.routerAddress ?? routerContract?.address,
+      routerAbi: routerContract?.abi,
+      gasTokenAddress: normalized.gasTokenAddress,
+      amount: normalized.amount,
+      withdrawAll: normalized.withdrawAll,
+      protocolName: normalized.lendingProtocol,
+      contextValues: normalized.contextValues,
+      userCalls,
+      mode: normalized.mode,
+    });
+  }
+
+  if (normalized.aggregatorType !== "kapan") {
+    return [];
+  }
+
+  const routerAddress = normalized.routerAddress ?? routerContract?.address;
+  const routerAbi = routerContract?.abi;
+  return defaultKapanCallBuilder({
+    account,
+    accountAddress: resolvedAddress,
+    routerAddress,
+    routerAbi,
+    gasTokenAddress: normalized.gasTokenAddress,
+    amount: normalized.amount,
+    withdrawAll: normalized.withdrawAll,
+    protocolName: normalized.lendingProtocol,
+    contextValues: normalized.contextValues,
+    userCalls,
+    mode: normalized.mode,
+  });
+}
+
+export function useKapanPaymasterSendTransaction(
+  props: UseKapanPaymasterSendTransactionArgs,
+): UsePaymasterSendTransactionResult {
+  const { account, address } = useAccount();
+  const { data: routerContract } = useDeployedContractInfo("RouterGateway");
+
+  const { tokenAddressMap, resolveGasTokenAddress, options: extendedOptions, ...restProps } = props;
+
+  const { options, kapanMode } = useMemo(() => {
+    return normalizeExtendedPaymasterDetails(extendedOptions, tokenAddressMap, resolveGasTokenAddress);
+  }, [extendedOptions, tokenAddressMap, resolveGasTokenAddress]);
+
+  const { sendAsync: baseSendAsync, ...baseResult } = usePaymasterSendTransaction({
+    ...restProps,
+    options,
+  });
+
+  const buildFullCalls = useCallback(
+    async (override?: Call | Call[]): Promise<Call[]> => {
+      const baseCalls = normalizeCallInput(override ?? restProps.calls);
+      if (baseCalls.length === 0) {
+        throw new Error("calls are required");
+      }
+      const extraCalls = kapanMode
+        ? await buildKapanModeCalls(kapanMode, account as AccountInterface | undefined, address, routerContract, baseCalls)
+        : [];
+      return [...baseCalls, ...extraCalls];
+    },
+    [account, address, restProps.calls, routerContract, kapanMode],
+  );
+
+  const sendAsync = useCallback(
+    async (override?: Call | Call[]) => {
+      const finalCalls = await buildFullCalls(override);
+      return baseSendAsync(finalCalls);
+    },
+    [baseSendAsync, buildFullCalls],
+  );
+
+  const send = useCallback(
+    (override?: Call | Call[]) => {
+      void sendAsync(override);
+    },
+    [sendAsync],
+  );
+
+  return {
+    ...baseResult,
+    send,
+    sendAsync,
+  };
+}
+
+export default useKapanPaymasterSendTransaction;

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -81,6 +81,7 @@
     "autoprefixer": "~10.4.20",
     "eslint": "~8.57.1",
     "eslint-config-next": "^15.2.3",
+    "jsdom": "^27.0.0",
     "postcss": "~8.4.45",
     "prettier": "~3.3.3",
     "tailwindcss": "~3.4.11",

--- a/packages/nextjs/vitest.config.ts
+++ b/packages/nextjs/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+import path from "node:path";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "~~": path.resolve(__dirname),
+    },
+  },
+  test: {
+    environment: "jsdom",
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -135,6 +135,38 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@asamuzakjp/css-color@npm:^4.0.3":
+  version: 4.0.4
+  resolution: "@asamuzakjp/css-color@npm:4.0.4"
+  dependencies:
+    "@csstools/css-calc": ^2.1.4
+    "@csstools/css-color-parser": ^3.0.10
+    "@csstools/css-parser-algorithms": ^3.0.5
+    "@csstools/css-tokenizer": ^3.0.4
+    lru-cache: ^11.1.0
+  checksum: e864136c5a2f8120c6b3ac0c759a869478c24ed319c42c98b0f851d9bb8c07f4bcd077ebf82309e1024100bde5808497fd5e1669317e1deac374b400303a99e6
+  languageName: node
+  linkType: hard
+
+"@asamuzakjp/dom-selector@npm:^6.5.4":
+  version: 6.5.4
+  resolution: "@asamuzakjp/dom-selector@npm:6.5.4"
+  dependencies:
+    "@asamuzakjp/nwsapi": ^2.3.9
+    bidi-js: ^1.0.3
+    css-tree: ^3.1.0
+    is-potential-custom-element-name: ^1.0.1
+  checksum: 9df02ac54a6d556c075bfe78739e1e07df210566cf28ab756c6464e8299218195f0ac0018aba6ebfafa9f03e6114f9588928844ce48bc173f029be494f95650a
+  languageName: node
+  linkType: hard
+
+"@asamuzakjp/nwsapi@npm:^2.3.9":
+  version: 2.3.9
+  resolution: "@asamuzakjp/nwsapi@npm:2.3.9"
+  checksum: 5fe839eb5cdc231176a671f8723b40a2f3f29f2fee5bf76120732819dbbd4ecda0e8d7464135aafb16731eea4b0e85a998bece983aae8612fe00e73433bc2cf4
+  languageName: node
+  linkType: hard
+
 "@aws-crypto/sha256-js@npm:1.2.2":
   version: 1.2.2
   resolution: "@aws-crypto/sha256-js@npm:1.2.2"
@@ -786,6 +818,61 @@ __metadata:
   dependencies:
     "@jridgewell/trace-mapping": 0.3.9
   checksum: 5718f267085ed8edb3e7ef210137241775e607ee18b77d95aa5bd7514f47f5019aa2d82d96b3bf342ef7aa890a346fa1044532ff7cc3009e7d24fce3ce6200fa
+  languageName: node
+  linkType: hard
+
+"@csstools/color-helpers@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "@csstools/color-helpers@npm:5.1.0"
+  checksum: 2b1cef009309c30c6e6e904d259e809761a8482fe262b000dacc159d94bcd982d59d85baea449de0fd57afc98b7fc19561ffe756d2b679d56a39c48c2b9c556a
+  languageName: node
+  linkType: hard
+
+"@csstools/css-calc@npm:^2.1.4":
+  version: 2.1.4
+  resolution: "@csstools/css-calc@npm:2.1.4"
+  peerDependencies:
+    "@csstools/css-parser-algorithms": ^3.0.5
+    "@csstools/css-tokenizer": ^3.0.4
+  checksum: b833d1a031dfb3e3268655aa384121b864fce9bad05f111a3cf2a343eed69ba5d723f3f7cd0793fd7b7a28de2f8141f94568828f48de41d86cefa452eee06390
+  languageName: node
+  linkType: hard
+
+"@csstools/css-color-parser@npm:^3.0.10":
+  version: 3.1.0
+  resolution: "@csstools/css-color-parser@npm:3.1.0"
+  dependencies:
+    "@csstools/color-helpers": ^5.1.0
+    "@csstools/css-calc": ^2.1.4
+  peerDependencies:
+    "@csstools/css-parser-algorithms": ^3.0.5
+    "@csstools/css-tokenizer": ^3.0.4
+  checksum: 615d825fc7b231e9ba048b4688f15f721423caf2a7be282d910445de30b558efb0f0294557e5a1a7401eefdfcc6c01c89b842fa7835d6872a3e06967dbaabc49
+  languageName: node
+  linkType: hard
+
+"@csstools/css-parser-algorithms@npm:^3.0.5":
+  version: 3.0.5
+  resolution: "@csstools/css-parser-algorithms@npm:3.0.5"
+  peerDependencies:
+    "@csstools/css-tokenizer": ^3.0.4
+  checksum: 80647139574431071e4664ad3c3e141deef4368f0ca536a63b3872487db68cf0d908fb76000f967deb1866963a90e6357fc6b9b00fdfa032f3321cebfcc66cd7
+  languageName: node
+  linkType: hard
+
+"@csstools/css-syntax-patches-for-csstree@npm:^1.0.14":
+  version: 1.0.14
+  resolution: "@csstools/css-syntax-patches-for-csstree@npm:1.0.14"
+  peerDependencies:
+    postcss: ^8.4
+  checksum: 383dc9e0f7567eac5e222cfa69ec3172c05365af1ddb6c58aaad4caa350abfe9c7c44990aa567551939f3389597edac8361c5c1b097c1425fb3cde28cb7fb640
+  languageName: node
+  linkType: hard
+
+"@csstools/css-tokenizer@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "@csstools/css-tokenizer@npm:3.0.4"
+  checksum: adc6681d3a0d7a75dc8e5ee0488c99ad4509e4810ae45dd6549a2e64a996e8d75512e70bb244778dc0c6ee85723e20eaeea8c083bf65b51eb19034e182554243
   languageName: node
   linkType: hard
 
@@ -4616,6 +4703,7 @@ __metadata:
     framer-motion: ^12.4.10
     gray-matter: ^4.0.3
     heatmap.js: ^2.0.5
+    jsdom: ^27.0.0
     lodash.merge: ^4.6.2
     next: ^15.2.4
     next-mdx-remote: ^5.0.0
@@ -8494,6 +8582,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bidi-js@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "bidi-js@npm:1.0.3"
+  dependencies:
+    require-from-string: ^2.0.2
+  checksum: 877c5dcfd69a35fd30fee9e49a03faf205a7a4cd04a38af7648974a659cab7b1cd51fa881d7957c07bd1fc5adf22b90a56da3617bb0885ee69d58ff41117658c
+  languageName: node
+  linkType: hard
+
 "big.js@npm:6.2.2":
   version: 6.2.2
   resolution: "big.js@npm:6.2.2"
@@ -9819,6 +9916,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"css-tree@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "css-tree@npm:3.1.0"
+  dependencies:
+    mdn-data: 2.12.2
+    source-map-js: ^1.0.1
+  checksum: 6b8c713c22b7223c0e71179575c3bbf421a13a61641204645d6c3b560bdc4ffed8d676220bbcb83777e07b46a934ec3b1c629aa61d57422c196c8e2e7417ee1a
+  languageName: node
+  linkType: hard
+
 "css-what@npm:^6.1.0":
   version: 6.2.2
   resolution: "css-what@npm:6.2.2"
@@ -9839,6 +9946,17 @@ __metadata:
   bin:
     cssesc: bin/cssesc
   checksum: f8c4ababffbc5e2ddf2fa9957dda1ee4af6048e22aeda1869d0d00843223c1b13ad3f5d88b51caa46c994225eacb636b764eb807a8883e2fb6f99b4f4e8c48b2
+  languageName: node
+  linkType: hard
+
+"cssstyle@npm:^5.3.0":
+  version: 5.3.0
+  resolution: "cssstyle@npm:5.3.0"
+  dependencies:
+    "@asamuzakjp/css-color": ^4.0.3
+    "@csstools/css-syntax-patches-for-csstree": ^1.0.14
+    css-tree: ^3.1.0
+  checksum: e29804f65785c1b804d04e0b3ea92fe9513eab8a7a53734712a57e82eb43859d69f3d303853186d0dbc5bf68a92225e709a99c0a8db6ce8b8e0b3f00b65fde10
   languageName: node
   linkType: hard
 
@@ -9994,6 +10112,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"data-urls@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "data-urls@npm:6.0.0"
+  dependencies:
+    whatwg-mimetype: ^4.0.0
+    whatwg-url: ^15.0.0
+  checksum: a47f0dde184337c4f168d455aedf0b486fed87b6ca583b4b9ad55d1515f4836b418d4bdc5b5b6fc55e321feb826029586a0d47e1c9a9e7ac4d52a78faceb7fb0
+  languageName: node
+  linkType: hard
+
 "data-view-buffer@npm:^1.0.2":
   version: 1.0.2
   resolution: "data-view-buffer@npm:1.0.2"
@@ -10124,6 +10252,13 @@ __metadata:
   version: 2.5.1
   resolution: "decimal.js-light@npm:2.5.1"
   checksum: f5a2c7eac1c4541c8ab8a5c8abea64fc1761cefc7794bd5f8afd57a8a78d1b51785e0c4e4f85f4895a043eaa90ddca1edc3981d1263eb6ddce60f32bf5fe66c9
+  languageName: node
+  linkType: hard
+
+"decimal.js@npm:^10.5.0":
+  version: 10.6.0
+  resolution: "decimal.js@npm:10.6.0"
+  checksum: 9302b990cd6f4da1c7602200002e40e15d15660374432963421d3cd6d81cc6e27e0a488356b030fee64650947e32e78bdbea245d596dadfeeeb02e146d485999
   languageName: node
   linkType: hard
 
@@ -10644,6 +10779,13 @@ __metadata:
     ansi-colors: ^4.1.1
     strip-ansi: ^6.0.1
   checksum: f080f11a74209647dbf347a7c6a83c8a47ae1ebf1e75073a808bc1088eb780aa54075bfecd1bcdb3e3c724520edb8e6ee05da031529436b421b71066fcc48cb5
+  languageName: node
+  linkType: hard
+
+"entities@npm:^6.0.0":
+  version: 6.0.1
+  resolution: "entities@npm:6.0.1"
+  checksum: 937b952e81aca641660a6a07f70001c6821973dea3ae7f6a5013eadce94620f3ed2e9c745832d503c8811ce6e97704d8a0396159580c0e567d815234de7fdecf
   languageName: node
   linkType: hard
 
@@ -13877,6 +14019,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"html-encoding-sniffer@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "html-encoding-sniffer@npm:4.0.0"
+  dependencies:
+    whatwg-encoding: ^3.1.1
+  checksum: 3339b71dab2723f3159a56acf541ae90a408ce2d11169f00fe7e0c4663d31d6398c8a4408b504b4eec157444e47b084df09b3cb039c816660f0dd04846b8957d
+  languageName: node
+  linkType: hard
+
 "http-basic@npm:^8.1.1":
   version: 8.1.3
   resolution: "http-basic@npm:8.1.3"
@@ -13932,7 +14083,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-proxy-agent@npm:^7.0.0":
+"http-proxy-agent@npm:^7.0.0, http-proxy-agent@npm:^7.0.2":
   version: 7.0.2
   resolution: "http-proxy-agent@npm:7.0.2"
   dependencies:
@@ -13961,7 +14112,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"https-proxy-agent@npm:^7.0.1":
+"https-proxy-agent@npm:^7.0.1, https-proxy-agent@npm:^7.0.6":
   version: 7.0.6
   resolution: "https-proxy-agent@npm:7.0.6"
   dependencies:
@@ -14522,6 +14673,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-potential-custom-element-name@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "is-potential-custom-element-name@npm:1.0.1"
+  checksum: ced7bbbb6433a5b684af581872afe0e1767e2d1146b2207ca0068a648fb5cab9d898495d1ac0583524faaf24ca98176a7d9876363097c2d14fee6dd324f3a1ab
+  languageName: node
+  linkType: hard
+
 "is-promise@npm:^4.0.0":
   version: 4.0.0
   resolution: "is-promise@npm:4.0.0"
@@ -14892,6 +15050,39 @@ __metadata:
   version: 3.1.4
   resolution: "jschardet@npm:3.1.4"
   checksum: 30a1dfe2d0bbdfa4e641827ac31173e8b25c533d519d45edfe15091db8ec4737715de2daa13bc49037b74b3812778b7a43b6f6c94bf081df3566b133a43e98ec
+  languageName: node
+  linkType: hard
+
+"jsdom@npm:^27.0.0":
+  version: 27.0.0
+  resolution: "jsdom@npm:27.0.0"
+  dependencies:
+    "@asamuzakjp/dom-selector": ^6.5.4
+    cssstyle: ^5.3.0
+    data-urls: ^6.0.0
+    decimal.js: ^10.5.0
+    html-encoding-sniffer: ^4.0.0
+    http-proxy-agent: ^7.0.2
+    https-proxy-agent: ^7.0.6
+    is-potential-custom-element-name: ^1.0.1
+    parse5: ^7.3.0
+    rrweb-cssom: ^0.8.0
+    saxes: ^6.0.0
+    symbol-tree: ^3.2.4
+    tough-cookie: ^6.0.0
+    w3c-xmlserializer: ^5.0.0
+    webidl-conversions: ^8.0.0
+    whatwg-encoding: ^3.1.1
+    whatwg-mimetype: ^4.0.0
+    whatwg-url: ^15.0.0
+    ws: ^8.18.2
+    xml-name-validator: ^5.0.0
+  peerDependencies:
+    canvas: ^3.0.0
+  peerDependenciesMeta:
+    canvas:
+      optional: true
+  checksum: a908333c5202b782aa4b989184143786250d4806485a3c0e0cad8dc1fe2fd33600133b3fc947e9fedf0dfdee767f6ad89df710e79fb345279a911fd89fcbd8f2
   languageName: node
   linkType: hard
 
@@ -15454,6 +15645,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lru-cache@npm:^11.1.0":
+  version: 11.2.1
+  resolution: "lru-cache@npm:11.2.1"
+  checksum: d54584b6f03e6de64c9e9f01e48abce5a9bc04318874d5204cee9e4275719544624d51eea6a167672576794af8bba3a7cfc23455d28b270a278cc387d1965131
+  languageName: node
+  linkType: hard
+
 "lru-cache@npm:^6.0.0":
   version: 6.0.0
   resolution: "lru-cache@npm:6.0.0"
@@ -15798,6 +15996,13 @@ __metadata:
   dependencies:
     "@types/mdast": ^4.0.0
   checksum: 35489fb5710d58cbc2d6c8b6547df161a3f81e0f28f320dfb3548a9393555daf07c310c0c497708e67ed4dfea4a06e5655799e7d631ca91420c288b4525d6c29
+  languageName: node
+  linkType: hard
+
+"mdn-data@npm:2.12.2":
+  version: 2.12.2
+  resolution: "mdn-data@npm:2.12.2"
+  checksum: 77f38c180292cfbbd41c06641a27940cc293c08f47faa98f80bf64f98bb1b2a804df371e864e31a1ea97bdf181c0b0f85a2d96d1a6261f43c427b32222f33f1f
   languageName: node
   linkType: hard
 
@@ -17674,6 +17879,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"parse5@npm:^7.3.0":
+  version: 7.3.0
+  resolution: "parse5@npm:7.3.0"
+  dependencies:
+    entities: ^6.0.0
+  checksum: ffd040c4695d93f0bc370e3d6d75c1b352178514af41be7afa212475ea5cead1d6e377cd9d4cec6a5e2bcf497ca50daf9e0088eadaa37dbc271f60def08fdfcd
+  languageName: node
+  linkType: hard
+
 "parseurl@npm:^1.3.3":
   version: 1.3.3
   resolution: "parseurl@npm:1.3.3"
@@ -19449,6 +19663,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rrweb-cssom@npm:^0.8.0":
+  version: 0.8.0
+  resolution: "rrweb-cssom@npm:0.8.0"
+  checksum: b84912cd1fbab9c972bf3fd5ca27b492efb442cacb23b6fd5a5ef6508572a91e411d325692609bf758865bc38a01b876e343c552d0e2ae87d0ff9907d96ef622
+  languageName: node
+  linkType: hard
+
 "run-parallel@npm:^1.1.9":
   version: 1.2.0
   resolution: "run-parallel@npm:1.2.0"
@@ -19526,6 +19747,15 @@ __metadata:
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
   checksum: cab8f25ae6f1434abee8d80023d7e72b598cf1327164ddab31003c51215526801e40b66c5e65d658a0af1e9d6478cadcb4c745f4bd6751f97d8644786c0978b0
+  languageName: node
+  linkType: hard
+
+"saxes@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "saxes@npm:6.0.0"
+  dependencies:
+    xmlchars: ^2.2.0
+  checksum: d3fa3e2aaf6c65ed52ee993aff1891fc47d5e47d515164b5449cbf5da2cbdc396137e55590472e64c5c436c14ae64a8a03c29b9e7389fc6f14035cf4e982ef3b
   languageName: node
   linkType: hard
 
@@ -20198,7 +20428,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map-js@npm:^1.0.2, source-map-js@npm:^1.2.1":
+"source-map-js@npm:^1.0.1, source-map-js@npm:^1.0.2, source-map-js@npm:^1.2.1":
   version: 1.2.1
   resolution: "source-map-js@npm:1.2.1"
   checksum: 4eb0cd997cdf228bc253bcaff9340afeb706176e64868ecd20efbe6efea931465f43955612346d6b7318789e5265bdc419bc7669c1cebe3db0eb255f57efa76b
@@ -20852,6 +21082,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"symbol-tree@npm:^3.2.4":
+  version: 3.2.4
+  resolution: "symbol-tree@npm:3.2.4"
+  checksum: 6e8fc7e1486b8b54bea91199d9535bb72f10842e40c79e882fc94fb7b14b89866adf2fd79efa5ebb5b658bc07fb459ccce5ac0e99ef3d72f474e74aaf284029d
+  languageName: node
+  linkType: hard
+
 "sync-request@npm:^6.0.0":
   version: 6.1.0
   resolution: "sync-request@npm:6.1.0"
@@ -21131,6 +21368,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tldts-core@npm:^7.0.14":
+  version: 7.0.14
+  resolution: "tldts-core@npm:7.0.14"
+  checksum: bc13d721605fb66dab2baaf3ae665a8a48722f5b86e2b8a9b299cdbdc34c2a3b7167a08566afe52eed3064a3a0fc08680c456aa170fa9a50d85b9421f787c6db
+  languageName: node
+  linkType: hard
+
+"tldts@npm:^7.0.5":
+  version: 7.0.14
+  resolution: "tldts@npm:7.0.14"
+  dependencies:
+    tldts-core: ^7.0.14
+  bin:
+    tldts: bin/cli.js
+  checksum: dfd07fe27f2d4bfb7219391dcf666e60ca5041c17e037a7eee3171d4a809e003f71abd73295ab846586c1b589f4aa727439038810e19ef86a8e74ac780deb421
+  languageName: node
+  linkType: hard
+
 "tmp@npm:0.0.33, tmp@npm:^0.0.33":
   version: 0.0.33
   resolution: "tmp@npm:0.0.33"
@@ -21199,6 +21454,24 @@ __metadata:
   version: 3.0.0
   resolution: "toml@npm:3.0.0"
   checksum: 5d7f1d8413ad7780e9bdecce8ea4c3f5130dd53b0a4f2e90b93340979a137739879d7b9ce2ce05c938b8cc828897fe9e95085197342a1377dd8850bf5125f15f
+  languageName: node
+  linkType: hard
+
+"tough-cookie@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "tough-cookie@npm:6.0.0"
+  dependencies:
+    tldts: ^7.0.5
+  checksum: 66d32ee40e1c6c61be5388e1c124674871dae0a684c30853f1628a4da2c5ad4199a825d1b0a7ba424dadfba7b5a9b37e8c761eafbf48f1b9f75a4629e73b14bc
+  languageName: node
+  linkType: hard
+
+"tr46@npm:^5.1.1":
+  version: 5.1.1
+  resolution: "tr46@npm:5.1.1"
+  dependencies:
+    punycode: ^2.3.1
+  checksum: da7a04bd3f77e641abdabe948bb84f24e6ee73e81c8c96c36fe79796c889ba97daf3dbacae778f8581ff60307a4136ee14c9540a5f85ebe44f99c6cc39a97690
   languageName: node
   linkType: hard
 
@@ -22615,6 +22888,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"w3c-xmlserializer@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "w3c-xmlserializer@npm:5.0.0"
+  dependencies:
+    xml-name-validator: ^5.0.0
+  checksum: 593acc1fdab3f3207ec39d851e6df0f3fa41a36b5809b0ace364c7a6d92e351938c53424a7618ce8e0fbaffee8be2e8e070a5734d05ee54666a8bdf1a376cc40
+  languageName: node
+  linkType: hard
+
 "wagmi@npm:^2.14.16":
   version: 2.16.9
   resolution: "wagmi@npm:2.16.9"
@@ -22689,6 +22971,39 @@ __metadata:
   version: 3.0.1
   resolution: "webidl-conversions@npm:3.0.1"
   checksum: c92a0a6ab95314bde9c32e1d0a6dfac83b578f8fa5f21e675bc2706ed6981bc26b7eb7e6a1fab158e5ce4adf9caa4a0aee49a52505d4d13c7be545f15021b17c
+  languageName: node
+  linkType: hard
+
+"webidl-conversions@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "webidl-conversions@npm:8.0.0"
+  checksum: bcae2572af98793b150c2f1878796e9c416aa9527859b5e11b56d0ec4cbad2d2ccb3cbd575f5579a111c1e5ba335c7ad762466e93740bbc7fa7e6a03ec472a21
+  languageName: node
+  linkType: hard
+
+"whatwg-encoding@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "whatwg-encoding@npm:3.1.1"
+  dependencies:
+    iconv-lite: 0.6.3
+  checksum: f75a61422421d991e4aec775645705beaf99a16a88294d68404866f65e92441698a4f5b9fa11dd609017b132d7b286c3c1534e2de5b3e800333856325b549e3c
+  languageName: node
+  linkType: hard
+
+"whatwg-mimetype@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "whatwg-mimetype@npm:4.0.0"
+  checksum: f97edd4b4ee7e46a379f3fb0e745de29fe8b839307cc774300fd49059fcdd560d38cb8fe21eae5575b8f39b022f23477cc66e40b0355c2851ce84760339cef30
+  languageName: node
+  linkType: hard
+
+"whatwg-url@npm:^15.0.0":
+  version: 15.0.0
+  resolution: "whatwg-url@npm:15.0.0"
+  dependencies:
+    tr46: ^5.1.1
+    webidl-conversions: ^8.0.0
+  checksum: b640d935167124e1f07e09cac5e9d1ca79b73313d712959adcb721a4651412540ff6d4379058658f759d0ac3a8827cc8e81b3c9ff98e346db0c5500f48e9989f
   languageName: node
   linkType: hard
 
@@ -22990,7 +23305,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:8.18.3, ws@npm:^8.18.0":
+"ws@npm:8.18.3, ws@npm:^8.18.0, ws@npm:^8.18.2":
   version: 8.18.3
   resolution: "ws@npm:8.18.3"
   peerDependencies:
@@ -23035,6 +23350,20 @@ __metadata:
   dependencies:
     os-paths: ^4.0.1
   checksum: e228ec6486e143d58d2e151bbb5899107bddbd57f92841e52598ba9515373fc095a570d4e974b009afd9b94bd9b98d4a4e5ebac66736cc02d30d178c7182bf6b
+  languageName: node
+  linkType: hard
+
+"xml-name-validator@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "xml-name-validator@npm:5.0.0"
+  checksum: 86effcc7026f437701252fcc308b877b4bc045989049cfc79b0cc112cb365cf7b009f4041fab9fb7cd1795498722c3e9fe9651afc66dfa794c16628a639a4c45
+  languageName: node
+  linkType: hard
+
+"xmlchars@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "xmlchars@npm:2.2.0"
+  checksum: 8c70ac94070ccca03f47a81fcce3b271bd1f37a591bf5424e787ae313fcb9c212f5f6786e1fa82076a2c632c0141552babcd85698c437506dfa6ae2d58723062
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- add a reusable `useKapanPaymasterSendTransaction` hook that maps extended fee modes into Avnu-compatible calls and supports Kapan-specific call injection
- switch the scaffold-stark paymaster transactor to consume the new wrapper hook
- add dedicated Vitest config, jsdom dev dependency, and unit tests for the wrapper behaviour

## Testing
- yarn workspace @se-2/nextjs vitest run __tests__/useKapanPaymasterSendTransaction.test.ts
- yarn workspace @se-2/nextjs lint

------
https://chatgpt.com/codex/tasks/task_e_68c9bfced6288320b3ab42627ff1b6a8