### PR TITLE
Fix Vesu positions spinner reset

### DIFF
--- a/packages/nextjs/components/specific/vesu/VesuProtocolView.tsx
+++ b/packages/nextjs/components/specific/vesu/VesuProtocolView.tsx
@@ -280,6 +280,12 @@ export const VesuProtocolView: FC = () => {
     refetchPositionsPart2();
   }, [userAddress, refetchPositionsPart1, refetchPositionsPart2]);
 
+  const refetchPositionsRef = useRef(refetchPositions);
+
+  useEffect(() => {
+    refetchPositionsRef.current = refetchPositions;
+  }, [refetchPositions]);
+
   const [cachedPositions, setCachedPositions] = useState<PositionTuple[]>([]);
   const [hasLoadedOnce, setHasLoadedOnce] = useState(false);
   const [borrowSelection, setBorrowSelection] = useState<{
@@ -300,9 +306,9 @@ export const VesuProtocolView: FC = () => {
     setCachedPositions([]);
     setHasLoadedOnce(false);
     if (userAddress) {
-      refetchPositions();
+      refetchPositionsRef.current?.();
     }
-  }, [userAddress, refetchPositions]);
+  }, [userAddress]);
 
   useEffect(() => {
     if (!userAddress) {


### PR DESCRIPTION
## Summary
- prevent the Vesu positions view from endlessly resetting its loading state when refetch callbacks change
- cache the latest refetch handler in a ref and trigger it only when the connected address actually changes

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68ca7f9dac908320921331276b83bcd7