### PR TITLE
feat(vesu): restore header net balance display

### DIFF
--- a/packages/nextjs/components/specific/vesu/VesuProtocolView.tsx
+++ b/packages/nextjs/components/specific/vesu/VesuProtocolView.tsx
@@ -505,6 +505,35 @@ export const VesuProtocolView: FC = () => {
     });
   }, [assetMap, cachedPositions, poolId]);
 
+  const netBalanceUsd = useMemo(() => {
+    if (vesuRows.length === 0) {
+      return 0;
+    }
+
+    let totalSupply = 0;
+    let totalDebt = 0;
+
+    vesuRows.forEach(row => {
+      totalSupply += row.supply.balance;
+      if (row.borrow) {
+        totalDebt += Math.abs(row.borrow.balance);
+      }
+    });
+
+    return totalSupply - totalDebt;
+  }, [vesuRows]);
+
+  const formatCurrency = useCallback((amount: number) => {
+    const formatter = new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    });
+
+    return formatter.format(amount);
+  }, []);
+
   const hasPositions = vesuRows.length > 0;
 
   useEffect(() => {
@@ -547,6 +576,16 @@ export const VesuProtocolView: FC = () => {
               <div className="flex flex-col">
                 <div className="text-xl font-bold tracking-tight">Vesu</div>
                 <div className="text-xs text-base-content/70">Manage your Starknet lending positions</div>
+                {userAddress && (
+                  <div className="text-xs text-base-content/70 flex items-center gap-1 mt-1">
+                    <span>Balance:</span>
+                    <span
+                      className={`font-semibold ${netBalanceUsd >= 0 ? "text-success" : "text-error"}`}
+                    >
+                      {formatCurrency(netBalanceUsd)}
+                    </span>
+                  </div>
+                )}
               </div>
             </div>
 


### PR DESCRIPTION
## Summary
- compute the net USD balance of Vesu positions from current supply and debt rows
- show the formatted balance in the Vesu protocol header for connected Starknet users

## Testing
- yarn workspace @se-2/nextjs lint

------
https://chatgpt.com/codex/tasks/task_e_68ca870422a4832080644b1d4ee48347