### PR TITLE
Disable market dropdowns in Vesu protocol view

### DIFF
--- a/packages/nextjs/components/BorrowPosition.tsx
+++ b/packages/nextjs/components/BorrowPosition.tsx
@@ -32,6 +32,7 @@ export type BorrowPositionProps = ProtocolPosition & {
   onBorrow?: () => void;
   borrowCtaLabel?: string;
   showNoDebtLabel?: boolean;
+  showInfoDropdown?: boolean;
 };
 
 export const BorrowPosition: FC<BorrowPositionProps> = ({
@@ -59,6 +60,7 @@ export const BorrowPosition: FC<BorrowPositionProps> = ({
   onBorrow,
   borrowCtaLabel,
   showNoDebtLabel = false,
+  showInfoDropdown = true,
 }) => {
   const moveModal = useModal();
   const repayModal = useModal();
@@ -153,7 +155,9 @@ export const BorrowPosition: FC<BorrowPositionProps> = ({
       <div
         className={`w-full p-3 rounded-md ${
           isExpanded ? "bg-base-300" : "bg-base-200"
-        } cursor-pointer transition-all duration-200 hover:bg-primary/10 hover:shadow-md ${containerClassName ?? ""}`}
+        } ${hasAnyActions ? "cursor-pointer hover:bg-primary/10 hover:shadow-md" : "cursor-default"} transition-all duration-200 ${
+          containerClassName ?? ""
+        }`}
         onClick={toggleExpanded}
       >
         <div className="grid grid-cols-1 lg:grid-cols-12 relative">
@@ -163,54 +167,56 @@ export const BorrowPosition: FC<BorrowPositionProps> = ({
               <Image src={icon} alt={`${name} icon`} layout="fill" className="rounded-full" />
             </div>
             <span className="ml-2 font-semibold text-lg truncate">{name}</span>
-            <div
-              className="dropdown dropdown-end dropdown-bottom flex-shrink-0 ml-1"
-              onClick={e => e.stopPropagation()}
-            >
-              <div tabIndex={0} role="button" className="cursor-pointer flex items-center justify-center h-[1.125em]">
-                <FiInfo
-                  className="w-4 h-4 text-base-content/50 hover:text-base-content/80 transition-colors"
-                  aria-hidden="true"
-                />
-              </div>
+            {showInfoDropdown && (
               <div
-                tabIndex={0}
-                className="dropdown-content z-[1] card card-compact p-2 shadow bg-base-100 w-64 max-w-[90vw]"
-                style={{
-                  right: "auto",
-                  transform: "translateX(-50%)",
-                  left: "50%",
-                  borderRadius: "4px",
-                }}
+                className="dropdown dropdown-end dropdown-bottom flex-shrink-0 ml-1"
+                onClick={e => e.stopPropagation()}
               >
-                <div className="card-body p-3">
-                  <h3 className="card-title text-sm">{name} Details</h3>
-                  <div className="text-xs space-y-1">
-                    <p className="text-base-content/70">Contract Address:</p>
-                    <p className="font-mono break-all">{tokenAddress}</p>
-                    <p className="text-base-content/70">Protocol:</p>
-                    <p>{protocolName}</p>
-                    <p className="text-base-content/70">Type:</p>
-                    <p className="capitalize">Borrow Position</p>
-                    {collateralValue && (
-                      <>
-                        <p className="text-base-content/70">Collateral Value:</p>
-                        <p>
-                          <FiatBalance
-                            tokenAddress={tokenAddress}
-                            rawValue={BigInt(Math.round(collateralValue * 10 ** 8))}
-                            price={BigInt(10 ** 8)}
-                            decimals={8}
-                            tokenSymbol={name}
-                            isNegative={false}
-                          />
-                        </p>
-                      </>
-                    )}
+                <div tabIndex={0} role="button" className="cursor-pointer flex items-center justify-center h-[1.125em]">
+                  <FiInfo
+                    className="w-4 h-4 text-base-content/50 hover:text-base-content/80 transition-colors"
+                    aria-hidden="true"
+                  />
+                </div>
+                <div
+                  tabIndex={0}
+                  className="dropdown-content z-[1] card card-compact p-2 shadow bg-base-100 w-64 max-w-[90vw]"
+                  style={{
+                    right: "auto",
+                    transform: "translateX(-50%)",
+                    left: "50%",
+                    borderRadius: "4px",
+                  }}
+                >
+                  <div className="card-body p-3">
+                    <h3 className="card-title text-sm">{name} Details</h3>
+                    <div className="text-xs space-y-1">
+                      <p className="text-base-content/70">Contract Address:</p>
+                      <p className="font-mono break-all">{tokenAddress}</p>
+                      <p className="text-base-content/70">Protocol:</p>
+                      <p>{protocolName}</p>
+                      <p className="text-base-content/70">Type:</p>
+                      <p className="capitalize">Borrow Position</p>
+                      {collateralValue && (
+                        <>
+                          <p className="text-base-content/70">Collateral Value:</p>
+                          <p>
+                            <FiatBalance
+                              tokenAddress={tokenAddress}
+                              rawValue={BigInt(Math.round(collateralValue * 10 ** 8))}
+                              price={BigInt(10 ** 8)}
+                              decimals={8}
+                              tokenSymbol={name}
+                              isNegative={false}
+                            />
+                          </p>
+                        </>
+                      )}
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
+            )}
           </div>
 
           {/* Stats: Rates */}

--- a/packages/nextjs/components/SupplyPosition.tsx
+++ b/packages/nextjs/components/SupplyPosition.tsx
@@ -32,6 +32,7 @@ export type SupplyPositionProps = ProtocolPosition & {
   onWithdraw?: () => void;
   onMove?: () => void;
   showQuickDepositButton?: boolean;
+  showInfoDropdown?: boolean;
 };
 
 export const SupplyPosition: FC<SupplyPositionProps> = ({
@@ -58,6 +59,7 @@ export const SupplyPosition: FC<SupplyPositionProps> = ({
   onWithdraw,
   onMove,
   showQuickDepositButton = false,
+  showInfoDropdown = true,
 }) => {
   const moveModal = useModal();
   const depositModal = useModal();
@@ -134,7 +136,9 @@ export const SupplyPosition: FC<SupplyPositionProps> = ({
       <div
         className={`w-full p-3 rounded-md ${
           isExpanded ? "bg-base-300" : "bg-base-200"
-        } cursor-pointer transition-all duration-200 hover:bg-primary/10 hover:shadow-md ${containerClassName ?? ""}`}
+        } ${hasAnyActions ? "cursor-pointer hover:bg-primary/10 hover:shadow-md" : "cursor-default"} transition-all duration-200 ${
+          containerClassName ?? ""
+        }`}
         onClick={toggleExpanded}
       >
         <div className="grid grid-cols-1 lg:grid-cols-12 relative">
@@ -144,39 +148,41 @@ export const SupplyPosition: FC<SupplyPositionProps> = ({
               <Image src={icon} alt={`${name} icon`} layout="fill" className="rounded-full" />
             </div>
             <span className="ml-2 font-semibold text-lg truncate">{name}</span>
-            <div
-              className="dropdown dropdown-end dropdown-bottom flex-shrink-0 ml-1"
-              onClick={e => e.stopPropagation()}
-            >
-              <div tabIndex={0} role="button" className="cursor-pointer flex items-center justify-center h-[1.125em]">
-                <FiInfo
-                  className="w-4 h-4 text-base-content/50 hover:text-base-content/80 transition-colors"
-                  aria-hidden="true"
-                />
-              </div>
+            {showInfoDropdown && (
               <div
-                tabIndex={0}
-                className="dropdown-content z-[1] card card-compact p-2 shadow bg-base-100 w-64 max-w-[90vw]"
-                style={{
-                  right: "auto",
-                  transform: "translateX(-50%)",
-                  left: "50%",
-                  borderRadius: "4px",
-                }}
+                className="dropdown dropdown-end dropdown-bottom flex-shrink-0 ml-1"
+                onClick={e => e.stopPropagation()}
               >
-                <div className="card-body p-3">
-                  <h3 className="card-title text-sm">{name} Details</h3>
-                  <div className="text-xs space-y-1">
-                    <p className="text-base-content/70">Contract Address:</p>
-                    <p className="font-mono break-all">{tokenAddress}</p>
-                    <p className="text-base-content/70">Protocol:</p>
-                    <p>{protocolName}</p>
-                    <p className="text-base-content/70">Type:</p>
-                    <p className="capitalize">Supply Position</p>
+                <div tabIndex={0} role="button" className="cursor-pointer flex items-center justify-center h-[1.125em]">
+                  <FiInfo
+                    className="w-4 h-4 text-base-content/50 hover:text-base-content/80 transition-colors"
+                    aria-hidden="true"
+                  />
+                </div>
+                <div
+                  tabIndex={0}
+                  className="dropdown-content z-[1] card card-compact p-2 shadow bg-base-100 w-64 max-w-[90vw]"
+                  style={{
+                    right: "auto",
+                    transform: "translateX(-50%)",
+                    left: "50%",
+                    borderRadius: "4px",
+                  }}
+                >
+                  <div className="card-body p-3">
+                    <h3 className="card-title text-sm">{name} Details</h3>
+                    <div className="text-xs space-y-1">
+                      <p className="text-base-content/70">Contract Address:</p>
+                      <p className="font-mono break-all">{tokenAddress}</p>
+                      <p className="text-base-content/70">Protocol:</p>
+                      <p>{protocolName}</p>
+                      <p className="text-base-content/70">Type:</p>
+                      <p className="capitalize">Supply Position</p>
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
+            )}
 
             {/* Render additional content after the info button if provided */}
             {afterInfoContent && <div onClick={e => e.stopPropagation()}>{afterInfoContent}</div>}

--- a/packages/nextjs/components/specific/vesu/VesuProtocolView.tsx
+++ b/packages/nextjs/components/specific/vesu/VesuProtocolView.tsx
@@ -647,6 +647,7 @@ export const VesuProtocolView: FC = () => {
                           disableMove
                           hideBalanceColumn
                           availableActions={{ deposit: false, withdraw: false, move: false }}
+                          showInfoDropdown={false}
                         />
                       ))
                     ) : (
@@ -669,6 +670,7 @@ export const VesuProtocolView: FC = () => {
                           networkType="starknet"
                           hideBalanceColumn
                           availableActions={{ borrow: false, repay: false, move: false }}
+                          showInfoDropdown={false}
                         />
                       ))
                     ) : (


### PR DESCRIPTION
## Summary
- add a toggle to SupplyPosition and BorrowPosition components to hide their info dropdowns when displaying read-only markets
- ensure vesu market rows render as non-interactive by disabling pointer hover states while leaving active positions unchanged

## Testing
- `yarn next:lint`


------
https://chatgpt.com/codex/tasks/task_e_68ca88d51aa0832098d80edf61468da3