### PR TITLE
Fix Vesu positions spinner stuck on loaded data

### DIFF
--- a/packages/nextjs/components/specific/vesu/VesuProtocolView.tsx
+++ b/packages/nextjs/components/specific/vesu/VesuProtocolView.tsx
@@ -91,11 +91,14 @@ export const VesuProtocolView: FC = () => {
       setCachedPositions([]);
       return;
     }
-    if (!isUpdating) {
+
+    const hasPositionData = userPositionsPart1 !== undefined || userPositionsPart2 !== undefined;
+
+    if (hasPositionData) {
       setCachedPositions(mergedUserPositions);
       setHasLoadedOnce(true);
     }
-  }, [mergedUserPositions, isUpdating, userAddress]);
+  }, [mergedUserPositions, userAddress, userPositionsPart1, userPositionsPart2]);
 
   useEffect(() => {
     const handler = () => refetchPositions();


### PR DESCRIPTION
## Summary
- mark the Vesu positions list as loaded once any paginated reads resolve
- keep cached positions in sync after successful reads without waiting for fetch status

## Testing
- yarn workspace @se-2/nextjs exec node ./node_modules/next/dist/bin/next lint

------
https://chatgpt.com/codex/tasks/task_e_68ca899f7a3483208b812dd332760f29