### PR TITLE
feat: add nostra debt and close modals

### DIFF
--- a/packages/nextjs/components/BorrowPosition.tsx
+++ b/packages/nextjs/components/BorrowPosition.tsx
@@ -35,6 +35,7 @@ export type BorrowPositionProps = ProtocolPosition & {
   borrowCtaLabel?: string;
   showNoDebtLabel?: boolean;
   infoButton?: React.ReactNode;
+  extraActions?: React.ReactNode;
 };
 
 export const BorrowPosition: FC<BorrowPositionProps> = ({
@@ -65,6 +66,7 @@ export const BorrowPosition: FC<BorrowPositionProps> = ({
   borrowCtaLabel,
   showNoDebtLabel = false,
   infoButton,
+  extraActions,
 }) => {
   const moveModal = useModal();
   const repayModal = useModal();
@@ -467,6 +469,8 @@ export const BorrowPosition: FC<BorrowPositionProps> = ({
                 {disabledMessage}
               </div>
             )}
+
+            {extraActions && <div className="mt-3">{extraActions}</div>}
           </div>
         )}
       </div>

--- a/packages/nextjs/components/SupplyPosition.tsx
+++ b/packages/nextjs/components/SupplyPosition.tsx
@@ -34,6 +34,7 @@ export type SupplyPositionProps = ProtocolPosition & {
   onWithdraw?: () => void;
   onMove?: () => void;
   showQuickDepositButton?: boolean;
+  extraActions?: React.ReactNode;
 };
 
 export const SupplyPosition: FC<SupplyPositionProps> = ({
@@ -62,6 +63,7 @@ export const SupplyPosition: FC<SupplyPositionProps> = ({
   onWithdraw,
   onMove,
   showQuickDepositButton = false,
+  extraActions,
 }) => {
   const moveModal = useModal();
   const depositModal = useModal();
@@ -392,6 +394,8 @@ export const SupplyPosition: FC<SupplyPositionProps> = ({
             {disabledMessage}
           </div>
         )}
+
+        {isExpanded && extraActions && <div className="mt-3" onClick={e => e.stopPropagation()}>{extraActions}</div>}
       </div>
 
       {showQuickDepositButton && (

--- a/packages/nextjs/components/modals/stark/NostraClosePositionModal.tsx
+++ b/packages/nextjs/components/modals/stark/NostraClosePositionModal.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import { FC, useMemo, useState } from "react";
+import Image from "next/image";
+import { BaseModal } from "../BaseModal";
+import { useAccount as useStarkAccount } from "~~/hooks/useAccount";
+import { useScaffoldMultiWriteContract } from "~~/hooks/scaffold-stark";
+import { notification } from "~~/utils/scaffold-stark";
+import { formatTokenAmount } from "~~/utils/protocols";
+import { useCollateral } from "~~/hooks/scaffold-stark/useCollateral";
+import { useNostraClosePosition, type CloseTokenInfo } from "~~/hooks/useNostraClosePosition";
+import type { CollateralToken } from "~~/components/specific/collateral/CollateralSelector";
+import { tokenNameToLogo } from "~~/contracts/externalContracts";
+
+const formatUsd = (value?: number) => {
+  if (value == null) return "-";
+  try {
+    return value.toLocaleString(undefined, { style: "currency", currency: "USD", maximumFractionDigits: 2 });
+  } catch {
+    return `$${value.toFixed(2)}`;
+  }
+};
+
+interface NostraClosePositionModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  debt: CloseTokenInfo | null;
+  debtBalance: bigint;
+}
+
+export const NostraClosePositionModal: FC<NostraClosePositionModalProps> = ({ isOpen, onClose, debt, debtBalance }) => {
+  const { address } = useStarkAccount();
+  const [selectedCollateral, setSelectedCollateral] = useState<CollateralToken | null>(null);
+
+  const { collaterals } = useCollateral({
+    protocolName: "Nostra",
+    userAddress: address || "0x0",
+    isOpen,
+  });
+
+  const collateralInfo: CloseTokenInfo | null = useMemo(() => {
+    if (!selectedCollateral) return null;
+    return {
+      name: selectedCollateral.symbol,
+      address: selectedCollateral.address,
+      decimals: selectedCollateral.decimals,
+      icon: tokenNameToLogo(selectedCollateral.symbol.toLowerCase()),
+    };
+  }, [selectedCollateral]);
+
+  const { loading, error, selectedQuote, swapSummary, calls } = useNostraClosePosition({
+    isOpen,
+    address,
+    debt,
+    collateral: collateralInfo,
+    debtBalance,
+    collateralBalance: selectedCollateral?.rawBalance ?? 0n,
+  });
+
+  const { sendAsync } = useScaffoldMultiWriteContract({ calls });
+  const [submitting, setSubmitting] = useState(false);
+
+  const disabled =
+    submitting ||
+    loading ||
+    !debt ||
+    !collateralInfo ||
+    !selectedQuote ||
+    !swapSummary ||
+    calls.length === 0;
+
+  const handleSubmit = async () => {
+    if (disabled) return;
+    try {
+      setSubmitting(true);
+      await sendAsync();
+      notification.success("Position closed");
+      onClose();
+    } catch (e) {
+      console.error(e);
+      notification.error("Failed to close position");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const sellToken = swapSummary?.sellToken ?? collateralInfo;
+  const buyToken = swapSummary?.buyToken ?? debt;
+
+  return (
+    <BaseModal isOpen={isOpen} onClose={onClose} maxWidthClass="max-w-md" boxClassName="p-4 rounded-none">
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold">Close position with collateral</h2>
+          {loading && <span className="loading loading-spinner loading-sm" />}
+        </div>
+
+        {!debt ? (
+          <div className="rounded-md bg-base-200/50 p-3 text-sm text-base-content/70">No debt position selected.</div>
+        ) : (
+          <>
+            <div className="space-y-3">
+              <div className="rounded-md border border-base-300 p-3">
+                <div className="text-xs uppercase tracking-wide text-base-content/60 mb-2">Debt token</div>
+                <div className="flex items-center gap-2">
+                  <Image src={debt.icon} alt={debt.name} width={28} height={28} className="rounded-full" />
+                  <div>
+                    <div className="font-medium">{debt.name}</div>
+                    <div className="text-xs text-base-content/60">{formatTokenAmount(debtBalance.toString(), debt.decimals)}</div>
+                  </div>
+                </div>
+              </div>
+
+              <div className="rounded-md border border-base-300 p-3">
+                <div className="text-xs uppercase tracking-wide text-base-content/60 mb-2">Select collateral</div>
+                <div className="space-y-2">
+                  {collaterals.length === 0 ? (
+                    <div className="text-sm text-base-content/60">No collateral balances found.</div>
+                  ) : (
+                    collaterals.map(collateral => {
+                      const isSelected = selectedCollateral?.address === collateral.address;
+                      return (
+                        <button
+                          key={collateral.address}
+                          type="button"
+                          className={`w-full rounded-md border p-3 text-left transition-colors ${
+                            isSelected ? "border-primary bg-primary/10" : "border-base-300 hover:border-primary"
+                          }`}
+                          onClick={() => setSelectedCollateral(collateral)}
+                        >
+                          <div className="flex items-center justify-between">
+                            <div className="flex items-center gap-2">
+                              <Image
+                                src={tokenNameToLogo(collateral.symbol.toLowerCase())}
+                                alt={collateral.symbol}
+                                width={24}
+                                height={24}
+                                className="rounded-full"
+                              />
+                              <div>
+                                <div className="font-medium">{collateral.symbol}</div>
+                                <div className="text-xs text-base-content/60">
+                                  Balance: {collateral.balance.toFixed(4)}
+                                </div>
+                              </div>
+                            </div>
+                            {isSelected && <span className="badge badge-primary badge-sm">Selected</span>}
+                          </div>
+                        </button>
+                      );
+                    })
+                  )}
+                </div>
+              </div>
+
+              {swapSummary && selectedQuote && sellToken && buyToken && (
+                <div className="rounded-md bg-base-200/60 p-3 space-y-2 text-sm">
+                  <div className="flex items-center justify-between">
+                    <span>Swap</span>
+                    <span className="font-medium flex items-center gap-2">
+                      <Image src={sellToken.icon} alt={sellToken.name} width={20} height={20} className="rounded-full" />
+                      {formatTokenAmount(swapSummary.sellAmount.toString(), sellToken.decimals)} {sellToken.name}
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span>Receive</span>
+                    <span className="font-medium flex items-center gap-2">
+                      <Image src={buyToken.icon} alt={buyToken.name} width={20} height={20} className="rounded-full" />
+                      {formatTokenAmount(swapSummary.buyAmount.toString(), buyToken.decimals)} {buyToken.name}
+                    </span>
+                  </div>
+                  <div className="pt-2 border-t border-base-300 space-y-1 text-xs text-base-content/70">
+                    <div className="flex justify-between">
+                      <span>AVNU fee</span>
+                      <span>{formatUsd(selectedQuote.avnuFeesInUsd)}</span>
+                    </div>
+                    {selectedQuote.integratorFees > 0n && (
+                      <div className="flex justify-between">
+                        <span>Integrator fee</span>
+                        <span>{formatUsd(selectedQuote.integratorFeesInUsd)}</span>
+                      </div>
+                    )}
+                    <div className="flex justify-between">
+                      <span>Network fee</span>
+                      <span>{formatUsd(selectedQuote.gasFeesInUsd)}</span>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {error && <div className="rounded-md bg-error/10 border border-error/40 p-2 text-xs text-error">{error}</div>}
+            </div>
+          </>
+        )}
+
+        <div className="flex justify-end gap-2">
+          <button className="btn btn-ghost btn-sm" onClick={onClose} disabled={submitting}>
+            Cancel
+          </button>
+          <button className="btn btn-primary btn-sm" onClick={handleSubmit} disabled={disabled}>
+            {submitting ? "Closing..." : "Close position"}
+          </button>
+        </div>
+      </div>
+    </BaseModal>
+  );
+};
+
+export default NostraClosePositionModal;
+

--- a/packages/nextjs/components/modals/stark/NostraSwitchDebtModal.tsx
+++ b/packages/nextjs/components/modals/stark/NostraSwitchDebtModal.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { FC, useMemo, useState } from "react";
+import Image from "next/image";
+import { BaseModal } from "../BaseModal";
+import { useAccount as useStarkAccount } from "~~/hooks/useAccount";
+import { useScaffoldMultiWriteContract } from "~~/hooks/scaffold-stark";
+import { notification } from "~~/utils/scaffold-stark";
+import { formatTokenAmount } from "~~/utils/protocols";
+import { useNostraDebtSwitch, type SwitchTokenInfo } from "~~/hooks/useNostraDebtSwitch";
+
+const formatUsd = (value?: number) => {
+  if (value == null) return "-";
+  try {
+    return value.toLocaleString(undefined, { style: "currency", currency: "USD", maximumFractionDigits: 2 });
+  } catch {
+    return `$${value.toFixed(2)}`;
+  }
+};
+
+interface NostraSwitchDebtModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  currentDebt: SwitchTokenInfo | null;
+  targetDebt: SwitchTokenInfo | null;
+  debtBalance: bigint;
+}
+
+export const NostraSwitchDebtModal: FC<NostraSwitchDebtModalProps> = ({
+  isOpen,
+  onClose,
+  currentDebt,
+  targetDebt,
+  debtBalance,
+}) => {
+  const { address } = useStarkAccount();
+  const [submitting, setSubmitting] = useState(false);
+
+  const { loading, error, selectedQuote, swapSummary, calls } = useNostraDebtSwitch({
+    isOpen,
+    address,
+    currentDebt,
+    targetDebt,
+    debtBalance,
+  });
+
+  const { sendAsync } = useScaffoldMultiWriteContract({ calls });
+
+  const disabled =
+    submitting ||
+    loading ||
+    !currentDebt ||
+    !targetDebt ||
+    !selectedQuote ||
+    !swapSummary ||
+    calls.length === 0;
+
+  const handleSubmit = async () => {
+    if (disabled) return;
+    try {
+      setSubmitting(true);
+      await sendAsync();
+      notification.success("Debt switched");
+      onClose();
+    } catch (e) {
+      console.error(e);
+      notification.error("Failed to switch debt");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const sellToken = swapSummary?.sellToken;
+  const buyToken = swapSummary?.buyToken;
+
+  const sellAmountFormatted = useMemo(
+    () =>
+      swapSummary
+        ? formatTokenAmount(swapSummary.sellAmount.toString(), sellToken?.decimals ?? targetDebt?.decimals ?? 18)
+        : "0",
+    [swapSummary, sellToken?.decimals, targetDebt?.decimals],
+  );
+
+  const buyAmountFormatted = useMemo(
+    () =>
+      swapSummary
+        ? formatTokenAmount(swapSummary.buyAmount.toString(), buyToken?.decimals ?? currentDebt?.decimals ?? 18)
+        : "0",
+    [swapSummary, buyToken?.decimals, currentDebt?.decimals],
+  );
+
+  return (
+    <BaseModal isOpen={isOpen} onClose={onClose} maxWidthClass="max-w-md" boxClassName="p-4 rounded-none">
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold">Switch debt token</h2>
+          {loading && <span className="loading loading-spinner loading-sm" />}
+        </div>
+
+        {!currentDebt || !targetDebt ? (
+          <div className="rounded-md bg-base-200/50 p-3 text-sm text-base-content/70">
+            Select a target debt asset to continue.
+          </div>
+        ) : (
+          <div className="space-y-3">
+            <div className="rounded-md border border-base-300 p-3">
+              <div className="text-xs uppercase tracking-wide text-base-content/60 mb-2">Current debt</div>
+              <div className="flex items-center gap-2">
+                <Image src={currentDebt.icon} alt={currentDebt.name} width={28} height={28} className="rounded-full" />
+                <div>
+                  <div className="font-medium">{currentDebt.name}</div>
+                  <div className="text-xs text-base-content/60">{formatTokenAmount(debtBalance.toString(), currentDebt.decimals)}</div>
+                </div>
+              </div>
+            </div>
+
+            <div className="rounded-md border border-base-300 p-3">
+              <div className="text-xs uppercase tracking-wide text-base-content/60 mb-2">Target debt</div>
+              <div className="flex items-center gap-2">
+                <Image src={targetDebt.icon} alt={targetDebt.name} width={28} height={28} className="rounded-full" />
+                <div>
+                  <div className="font-medium">{targetDebt.name}</div>
+                  <div className="text-xs text-base-content/60">APR adjustments handled automatically</div>
+                </div>
+              </div>
+            </div>
+
+            {swapSummary && selectedQuote && (
+              <div className="rounded-md bg-base-200/60 p-3 space-y-2 text-sm">
+                <div className="flex items-center justify-between">
+                  <span>You will borrow</span>
+                  <span className="font-medium flex items-center gap-2">
+                    <Image src={sellToken?.icon ?? targetDebt.icon} alt={sellToken?.name ?? targetDebt.name} width={20} height={20} className="rounded-full" />
+                    {sellAmountFormatted} {sellToken?.name ?? targetDebt.name}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span>To repay</span>
+                  <span className="font-medium flex items-center gap-2">
+                    <Image src={buyToken?.icon ?? currentDebt.icon} alt={buyToken?.name ?? currentDebt.name} width={20} height={20} className="rounded-full" />
+                    {buyAmountFormatted} {buyToken?.name ?? currentDebt.name}
+                  </span>
+                </div>
+                <div className="pt-2 border-t border-base-300 space-y-1 text-xs text-base-content/70">
+                  <div className="flex justify-between">
+                    <span>AVNU fee</span>
+                    <span>{formatUsd(selectedQuote.avnuFeesInUsd)}</span>
+                  </div>
+                  {selectedQuote.integratorFees > 0n && (
+                    <div className="flex justify-between">
+                      <span>Integrator fee</span>
+                      <span>{formatUsd(selectedQuote.integratorFeesInUsd)}</span>
+                    </div>
+                  )}
+                  <div className="flex justify-between">
+                    <span>Network fee</span>
+                    <span>{formatUsd(selectedQuote.gasFeesInUsd)}</span>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {error && <div className="rounded-md bg-error/10 border border-error/40 p-2 text-xs text-error">{error}</div>}
+          </div>
+        )}
+
+        <div className="flex justify-end gap-2">
+          <button className="btn btn-ghost btn-sm" onClick={onClose} disabled={submitting}>
+            Cancel
+          </button>
+          <button className="btn btn-primary btn-sm" onClick={handleSubmit} disabled={disabled}>
+            {submitting ? "Switching..." : "Switch debt"}
+          </button>
+        </div>
+      </div>
+    </BaseModal>
+  );
+};
+
+export default NostraSwitchDebtModal;
+

--- a/packages/nextjs/components/specific/nostra/NostraProtocolView.tsx
+++ b/packages/nextjs/components/specific/nostra/NostraProtocolView.tsx
@@ -1,10 +1,16 @@
-import { FC, useMemo } from "react";
+import { FC, useMemo, useState } from "react";
+import Image from "next/image";
 import { ProtocolPosition, ProtocolView } from "../../ProtocolView";
 import { formatUnits } from "viem";
 import { tokenNameToLogo } from "~~/contracts/externalContracts";
 import { useAccount } from "~~/hooks/useAccount";
 import { useNetworkAwareReadContract } from "~~/hooks/useNetworkAwareReadContract";
 import { feltToString } from "~~/utils/protocols";
+import { BaseModal } from "../../modals/BaseModal";
+import { NostraSwitchDebtModal } from "../../modals/stark/NostraSwitchDebtModal";
+import { NostraClosePositionModal } from "../../modals/stark/NostraClosePositionModal";
+import type { SwitchTokenInfo } from "~~/hooks/useNostraDebtSwitch";
+import type { CloseTokenInfo } from "~~/hooks/useNostraClosePosition";
 
 type UserPositionTuple = {
   0: bigint; // underlying token address
@@ -165,18 +171,223 @@ export const NostraProtocolView: FC = () => {
     return { suppliedPositions: supplied, borrowedPositions: borrowed };
   }, [tokenAddresses, userPositionMap, symbolMap, interestRates, tokenToDecimals, tokenToPrices]);
 
+  const [switchDebtSource, setSwitchDebtSource] = useState<ProtocolPosition | null>(null);
+  const [isSwitchTokenModalOpen, setIsSwitchTokenModalOpen] = useState(false);
+  const [switchTargetAddress, setSwitchTargetAddress] = useState<string | null>(null);
+  const [isSwitchModalOpen, setIsSwitchModalOpen] = useState(false);
+  const [closeDebtPosition, setCloseDebtPosition] = useState<ProtocolPosition | null>(null);
+  const [isCloseModalOpen, setIsCloseModalOpen] = useState(false);
+
+  const tokenMetadata = useMemo(
+    () =>
+      tokenAddresses.map(address => {
+        const symbol = symbolMap[address] ?? "";
+        const decimals = tokenToDecimals[address] ?? 18;
+        const borrowInfo = borrowedPositions.find(pos => pos.tokenAddress === address);
+        return {
+          address,
+          symbol,
+          decimals,
+          borrowAPR: borrowInfo?.currentRate ?? 0,
+          icon: tokenNameToLogo(symbol.toLowerCase()),
+        };
+      }),
+    [tokenAddresses, symbolMap, tokenToDecimals, borrowedPositions],
+  );
+
+  const selectableTargets = useMemo(
+    () => tokenMetadata.filter(meta => meta.address !== (switchDebtSource?.tokenAddress ?? "")),
+    [tokenMetadata, switchDebtSource?.tokenAddress],
+  );
+
+  const handleOpenSwitch = (position: ProtocolPosition) => {
+    setSwitchDebtSource(position);
+    setSwitchTargetAddress(null);
+    setIsSwitchTokenModalOpen(true);
+  };
+
+  const handleCloseSwitchPicker = () => {
+    setIsSwitchTokenModalOpen(false);
+    setSwitchTargetAddress(null);
+    setSwitchDebtSource(null);
+  };
+
+  const handleSelectTarget = (address: string) => {
+    setSwitchTargetAddress(address);
+    setIsSwitchTokenModalOpen(false);
+    setIsSwitchModalOpen(true);
+  };
+
+  const handleSwitchModalClose = () => {
+    setIsSwitchModalOpen(false);
+    setSwitchTargetAddress(null);
+    setSwitchDebtSource(null);
+  };
+
+  const handleOpenClosePosition = (position: ProtocolPosition) => {
+    setCloseDebtPosition(position);
+    setIsCloseModalOpen(true);
+  };
+
+  const handleClosePositionModal = () => {
+    setIsCloseModalOpen(false);
+    setCloseDebtPosition(null);
+  };
+
+  const currentDebtInfo: SwitchTokenInfo | null = useMemo(() => {
+    if (!switchDebtSource) return null;
+    return {
+      name: switchDebtSource.name,
+      address: switchDebtSource.tokenAddress,
+      decimals: switchDebtSource.tokenDecimals ?? 18,
+      icon: switchDebtSource.icon,
+    };
+  }, [switchDebtSource]);
+
+  const targetDebtInfo: SwitchTokenInfo | null = useMemo(() => {
+    if (!switchTargetAddress) return null;
+    const meta = tokenMetadata.find(token => token.address === switchTargetAddress);
+    if (!meta) return null;
+    return {
+      name: meta.symbol,
+      address: meta.address,
+      decimals: meta.decimals,
+      icon: meta.icon,
+    };
+  }, [switchTargetAddress, tokenMetadata]);
+
+  const closeDebtInfo: CloseTokenInfo | null = useMemo(() => {
+    if (!closeDebtPosition) return null;
+    return {
+      name: closeDebtPosition.name,
+      address: closeDebtPosition.tokenAddress,
+      decimals: closeDebtPosition.tokenDecimals ?? 18,
+      icon: closeDebtPosition.icon,
+    };
+  }, [closeDebtPosition]);
+
+  const switchDebtBalance = switchDebtSource?.tokenBalance ?? 0n;
+  const closeDebtBalance = closeDebtPosition?.tokenBalance ?? 0n;
+
+  const enhancedSuppliedPositions = useMemo(
+    () =>
+      suppliedPositions.map(position => ({
+        ...position,
+        extraActions: (
+          <button
+            type="button"
+            className="btn btn-sm btn-outline btn-block"
+            disabled
+            title="Collateral switching coming soon"
+          >
+            Switch collateral (coming soon)
+          </button>
+        ),
+      })),
+    [suppliedPositions],
+  );
+
+  const enhancedBorrowedPositions = useMemo(
+    () =>
+      borrowedPositions.map(position => ({
+        ...position,
+        availableActions: { ...position.availableActions, move: false },
+        extraActions: (
+          <div className="grid gap-2 sm:grid-cols-2">
+            <button
+              type="button"
+              className="btn btn-sm btn-outline"
+              onClick={event => {
+                event.stopPropagation();
+                handleOpenSwitch(position);
+              }}
+            >
+              Switch debt
+            </button>
+            <button
+              type="button"
+              className="btn btn-sm btn-outline btn-error"
+              onClick={event => {
+                event.stopPropagation();
+                handleOpenClosePosition(position);
+              }}
+            >
+              Close position
+            </button>
+          </div>
+        ),
+      })),
+    [borrowedPositions],
+  );
+
   return (
-    <ProtocolView
-      protocolName="Nostra"
-      protocolIcon="/logos/nostra.svg"
-      ltv={75}
-      maxLtv={90}
-      suppliedPositions={suppliedPositions}
-      borrowedPositions={borrowedPositions}
-      forceShowAll={!connectedAddress}
-      networkType="starknet"
-      disableMoveSupply
-    />
+    <>
+      <ProtocolView
+        protocolName="Nostra"
+        protocolIcon="/logos/nostra.svg"
+        ltv={75}
+        maxLtv={90}
+        suppliedPositions={enhancedSuppliedPositions}
+        borrowedPositions={enhancedBorrowedPositions}
+        forceShowAll={!connectedAddress}
+        networkType="starknet"
+        disableMoveSupply
+      />
+
+      <BaseModal
+        isOpen={isSwitchTokenModalOpen}
+        onClose={handleCloseSwitchPicker}
+        maxWidthClass="max-w-md"
+        boxClassName="p-4"
+      >
+        <div className="space-y-4">
+          <div className="flex items-center justify-between">
+            <h3 className="text-lg font-semibold">Select new debt token</h3>
+            <button className="btn btn-ghost btn-sm" onClick={handleCloseSwitchPicker}>
+              Cancel
+            </button>
+          </div>
+
+          <div className="space-y-2 max-h-[60vh] overflow-y-auto">
+            {selectableTargets.length === 0 ? (
+              <div className="text-sm text-base-content/60">No other assets available.</div>
+            ) : (
+              selectableTargets.map(meta => (
+                <button
+                  key={meta.address}
+                  type="button"
+                  className="w-full rounded-md border border-base-300 p-3 flex items-center justify-between hover:border-primary transition-colors"
+                  onClick={() => handleSelectTarget(meta.address)}
+                >
+                  <div className="flex items-center gap-2">
+                    <Image src={meta.icon} alt={meta.symbol} width={28} height={28} className="rounded-full" />
+                    <div>
+                      <div className="font-medium">{meta.symbol}</div>
+                      <div className="text-xs text-base-content/60">{meta.borrowAPR.toFixed(2)}% APR</div>
+                    </div>
+                  </div>
+                </button>
+              ))
+            )}
+          </div>
+        </div>
+      </BaseModal>
+
+      <NostraSwitchDebtModal
+        isOpen={isSwitchModalOpen}
+        onClose={handleSwitchModalClose}
+        currentDebt={currentDebtInfo}
+        targetDebt={targetDebtInfo}
+        debtBalance={switchDebtBalance}
+      />
+
+      <NostraClosePositionModal
+        isOpen={isCloseModalOpen}
+        onClose={handleClosePositionModal}
+        debt={closeDebtInfo}
+        debtBalance={closeDebtBalance}
+      />
+    </>
   );
 };
 

--- a/packages/nextjs/hooks/useNostraClosePosition.ts
+++ b/packages/nextjs/hooks/useNostraClosePosition.ts
@@ -1,0 +1,223 @@
+import { useEffect, useMemo, useState } from "react";
+import { CairoCustomEnum, CairoOption, CairoOptionVariant, CallData, uint256 } from "starknet";
+import { fetchBuildExecuteTransaction, fetchQuotes, type Quote } from "@avnu/avnu-sdk";
+import { useLendingAuthorizations, type BaseProtocolInstruction } from "~~/hooks/useLendingAuthorizations";
+
+const SLIPPAGE = 0.05;
+const BUFFER_BPS = 300n;
+
+const withBuffer = (amount: bigint, bufferBps: bigint = BUFFER_BPS) => {
+  if (amount === 0n) return 0n;
+  return (amount * (10_000n + bufferBps)) / 10_000n;
+};
+
+const toOutputPointer = (instructionIndex: number, outputIndex = 0) => ({
+  instruction_index: BigInt(instructionIndex),
+  output_index: BigInt(outputIndex),
+});
+
+export interface CloseTokenInfo {
+  name: string;
+  address: string;
+  decimals: number;
+  icon: string;
+}
+
+interface UseNostraClosePositionArgs {
+  isOpen: boolean;
+  address?: string;
+  debt: CloseTokenInfo | null;
+  collateral: CloseTokenInfo | null;
+  debtBalance: bigint;
+  collateralBalance: bigint;
+}
+
+export const useNostraClosePosition = ({
+  isOpen,
+  address,
+  debt,
+  collateral,
+  debtBalance,
+  collateralBalance,
+}: UseNostraClosePositionArgs) => {
+  const { getAuthorizations, isReady: isAuthReady } = useLendingAuthorizations();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedQuote, setSelectedQuote] = useState<Quote | null>(null);
+  const [protocolInstructions, setProtocolInstructions] = useState<BaseProtocolInstruction[]>([]);
+  const [fetchedAuthorizations, setFetchedAuthorizations] = useState<any[]>([]);
+
+  useEffect(() => {
+    setSelectedQuote(null);
+    setProtocolInstructions([]);
+    setFetchedAuthorizations([]);
+    setError(null);
+  }, [isOpen, debt?.address, collateral?.address]);
+
+  useEffect(() => {
+    if (!isOpen || !address || !debt || !collateral || debtBalance === 0n || collateralBalance === 0n) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const run = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const repayAmount = debtBalance > 0n ? debtBalance : 1n;
+        const quoteRequest = {
+          sellTokenAddress: collateral.address,
+          buyTokenAddress: debt.address,
+          buyAmount: repayAmount,
+          takerAddress: address,
+        } as const;
+
+        const quotes = await fetchQuotes(quoteRequest as any);
+        if (quotes.length === 0) throw new Error("Unable to fetch AVNU quote");
+
+        const quote = quotes[0];
+        if (!cancelled) setSelectedQuote(quote);
+
+        const tx = await fetchBuildExecuteTransaction(quote.quoteId, address, SLIPPAGE, false);
+        const swapCall = tx.calls?.find((call: any) =>
+          ["swap_exact_token_to", "multi_route_swap", "swap_exact_in"].includes(call.entrypoint),
+        );
+        if (!swapCall) throw new Error("Failed to extract AVNU calldata");
+        const calldata = (swapCall.calldata as any[]).map(value => BigInt(value.toString()));
+
+        const repayInstruction = new CairoCustomEnum({
+          Deposit: undefined,
+          Borrow: undefined,
+          Repay: {
+            basic: { token: debt.address, amount: uint256.bnToUint256(repayAmount), user: address },
+            repay_all: true,
+            context: new CairoOption<bigint[]>(CairoOptionVariant.None),
+          },
+          Withdraw: undefined,
+          Redeposit: undefined,
+          Reborrow: undefined,
+          Swap: undefined,
+          SwapExactIn: undefined,
+          Reswap: undefined,
+          ReswapExactIn: undefined,
+        });
+
+        const withdrawAmount = withBuffer(collateralBalance, 200n);
+        const withdrawInstruction = new CairoCustomEnum({
+          Deposit: undefined,
+          Borrow: undefined,
+          Repay: undefined,
+          Withdraw: {
+            basic: { token: collateral.address, amount: uint256.bnToUint256(withdrawAmount), user: address },
+            withdraw_all: true,
+            context: new CairoOption<bigint[]>(CairoOptionVariant.None),
+          },
+          Redeposit: undefined,
+          Reborrow: undefined,
+          Swap: undefined,
+          SwapExactIn: undefined,
+          Reswap: undefined,
+          ReswapExactIn: undefined,
+        });
+
+        const reswapInstruction = new CairoCustomEnum({
+          Deposit: undefined,
+          Borrow: undefined,
+          Repay: undefined,
+          Withdraw: undefined,
+          Redeposit: undefined,
+          Reborrow: undefined,
+          Swap: undefined,
+          SwapExactIn: undefined,
+          Reswap: {
+            exact_out: toOutputPointer(0),
+            max_in: toOutputPointer(1),
+            user: address,
+            should_pay_out: false,
+            should_pay_in: true,
+            context: new CairoOption(CairoOptionVariant.Some, calldata),
+          },
+          ReswapExactIn: undefined,
+        });
+
+        const instructions: BaseProtocolInstruction[] = [
+          { protocol_name: "nostra", instructions: [repayInstruction, withdrawInstruction] },
+          { protocol_name: "avnu", instructions: [reswapInstruction] },
+        ];
+
+        if (!cancelled) setProtocolInstructions(instructions);
+      } catch (err: any) {
+        if (!cancelled) {
+          setError(err?.message ?? "Failed to prepare close instructions");
+          setProtocolInstructions([]);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    run();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, address, debt?.address, collateral?.address, debtBalance, collateralBalance]);
+
+  useEffect(() => {
+    if (!isOpen || !isAuthReady || protocolInstructions.length === 0) {
+      setFetchedAuthorizations([]);
+      return;
+    }
+
+    let cancelled = false;
+
+    const run = async () => {
+      try {
+        const auths = await getAuthorizations(protocolInstructions as any);
+        if (!cancelled) setFetchedAuthorizations(auths);
+      } catch {
+        if (!cancelled) setFetchedAuthorizations([]);
+      }
+    };
+
+    run();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, isAuthReady, getAuthorizations, protocolInstructions]);
+
+  const calls = useMemo(() => {
+    if (protocolInstructions.length === 0) return [];
+    return [
+      ...(fetchedAuthorizations as any),
+      {
+        contractName: "RouterGateway" as const,
+        functionName: "move_debt" as const,
+        args: CallData.compile({ instructions: protocolInstructions }),
+      },
+    ];
+  }, [protocolInstructions, fetchedAuthorizations]);
+
+  const swapSummary = useMemo(() => {
+    if (!selectedQuote || !debt || !collateral) return null;
+    return {
+      sellToken: collateral,
+      buyToken: debt,
+      sellAmount: selectedQuote.sellAmount,
+      buyAmount: selectedQuote.buyAmount,
+    };
+  }, [selectedQuote, debt, collateral]);
+
+  return {
+    loading,
+    error,
+    selectedQuote,
+    swapSummary,
+    calls,
+  };
+};
+
+export type UseNostraClosePositionResult = ReturnType<typeof useNostraClosePosition>;
+

--- a/packages/nextjs/hooks/useNostraDebtSwitch.ts
+++ b/packages/nextjs/hooks/useNostraDebtSwitch.ts
@@ -1,0 +1,225 @@
+import { useEffect, useMemo, useState } from "react";
+import { CairoCustomEnum, CairoOption, CairoOptionVariant, CallData, uint256 } from "starknet";
+import { fetchBuildExecuteTransaction, fetchQuotes, type Quote } from "@avnu/avnu-sdk";
+import { useLendingAuthorizations, type BaseProtocolInstruction } from "~~/hooks/useLendingAuthorizations";
+
+const SLIPPAGE = 0.05;
+const BUFFER_BPS = 300n; // 3% buffer when borrowing new debt
+
+const withBuffer = (amount: bigint, bufferBps: bigint = BUFFER_BPS) => {
+  if (amount === 0n) return 0n;
+  return (amount * (10_000n + bufferBps)) / 10_000n;
+};
+
+const toOutputPointer = (instructionIndex: number, outputIndex = 0) => ({
+  instruction_index: BigInt(instructionIndex),
+  output_index: BigInt(outputIndex),
+});
+
+export interface SwitchTokenInfo {
+  name: string;
+  address: string;
+  decimals: number;
+  icon: string;
+}
+
+interface UseNostraDebtSwitchArgs {
+  isOpen: boolean;
+  address?: string;
+  currentDebt: SwitchTokenInfo | null;
+  targetDebt: SwitchTokenInfo | null;
+  debtBalance: bigint;
+}
+
+export const useNostraDebtSwitch = ({
+  isOpen,
+  address,
+  currentDebt,
+  targetDebt,
+  debtBalance,
+}: UseNostraDebtSwitchArgs) => {
+  const { getAuthorizations, isReady: isAuthReady } = useLendingAuthorizations();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedQuote, setSelectedQuote] = useState<Quote | null>(null);
+  const [protocolInstructions, setProtocolInstructions] = useState<BaseProtocolInstruction[]>([]);
+  const [fetchedAuthorizations, setFetchedAuthorizations] = useState<any[]>([]);
+  const [avnuCalldata, setAvnuCalldata] = useState<bigint[]>([]);
+
+  useEffect(() => {
+    setSelectedQuote(null);
+    setProtocolInstructions([]);
+    setFetchedAuthorizations([]);
+    setAvnuCalldata([]);
+    setError(null);
+  }, [isOpen, currentDebt?.address, targetDebt?.address]);
+
+  useEffect(() => {
+    if (!isOpen || !address || !currentDebt || !targetDebt || debtBalance === 0n) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const run = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const repayAmount = debtBalance > 0n ? debtBalance : 1n;
+        const quoteRequest = {
+          sellTokenAddress: targetDebt.address,
+          buyTokenAddress: currentDebt.address,
+          buyAmount: repayAmount,
+          takerAddress: address,
+        } as const;
+
+        const quotes = await fetchQuotes(quoteRequest as any);
+        if (quotes.length === 0) throw new Error("Unable to fetch AVNU quote");
+
+        const quote = quotes[0];
+        if (!cancelled) setSelectedQuote(quote);
+
+        const tx = await fetchBuildExecuteTransaction(quote.quoteId, address, SLIPPAGE, false);
+        const swapCall = tx.calls?.find((call: any) =>
+          ["swap_exact_token_to", "multi_route_swap", "swap_exact_in"].includes(call.entrypoint),
+        );
+        if (!swapCall) throw new Error("Failed to extract AVNU calldata");
+        const calldata = (swapCall.calldata as any[]).map(value => BigInt(value.toString()));
+        if (!cancelled) setAvnuCalldata(calldata);
+
+        const repayInstruction = new CairoCustomEnum({
+          Deposit: undefined,
+          Borrow: undefined,
+          Repay: {
+            basic: { token: currentDebt.address, amount: uint256.bnToUint256(repayAmount), user: address },
+            repay_all: true,
+            context: new CairoOption<bigint[]>(CairoOptionVariant.None),
+          },
+          Withdraw: undefined,
+          Redeposit: undefined,
+          Reborrow: undefined,
+          Swap: undefined,
+          SwapExactIn: undefined,
+          Reswap: undefined,
+          ReswapExactIn: undefined,
+        });
+
+        const borrowAmount = withBuffer(quote.sellAmount);
+        const borrowInstruction = new CairoCustomEnum({
+          Deposit: undefined,
+          Borrow: {
+            basic: { token: targetDebt.address, amount: uint256.bnToUint256(borrowAmount), user: address },
+            context: new CairoOption<bigint[]>(CairoOptionVariant.None),
+          },
+          Repay: undefined,
+          Withdraw: undefined,
+          Redeposit: undefined,
+          Reborrow: undefined,
+          Swap: undefined,
+          SwapExactIn: undefined,
+          Reswap: undefined,
+          ReswapExactIn: undefined,
+        });
+
+        const reswapInstruction = new CairoCustomEnum({
+          Deposit: undefined,
+          Borrow: undefined,
+          Repay: undefined,
+          Withdraw: undefined,
+          Redeposit: undefined,
+          Reborrow: undefined,
+          Swap: undefined,
+          SwapExactIn: undefined,
+          Reswap: {
+            exact_out: toOutputPointer(0),
+            max_in: toOutputPointer(1),
+            user: address,
+            should_pay_out: false,
+            should_pay_in: true,
+            context: new CairoOption(CairoOptionVariant.Some, calldata),
+          },
+          ReswapExactIn: undefined,
+        });
+
+        const instructions: BaseProtocolInstruction[] = [
+          { protocol_name: "nostra", instructions: [repayInstruction, borrowInstruction] },
+          { protocol_name: "avnu", instructions: [reswapInstruction] },
+        ];
+
+        if (!cancelled) setProtocolInstructions(instructions);
+      } catch (err: any) {
+        if (!cancelled) {
+          setError(err?.message ?? "Failed to prepare switch instructions");
+          setProtocolInstructions([]);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    run();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, address, currentDebt?.address, targetDebt?.address, debtBalance]);
+
+  useEffect(() => {
+    if (!isOpen || !isAuthReady || protocolInstructions.length === 0) {
+      setFetchedAuthorizations([]);
+      return;
+    }
+
+    let cancelled = false;
+
+    const run = async () => {
+      try {
+        const auths = await getAuthorizations(protocolInstructions as any);
+        if (!cancelled) setFetchedAuthorizations(auths);
+      } catch {
+        if (!cancelled) setFetchedAuthorizations([]);
+      }
+    };
+
+    run();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, isAuthReady, getAuthorizations, protocolInstructions]);
+
+  const calls = useMemo(() => {
+    if (protocolInstructions.length === 0) return [];
+
+    return [
+      ...(fetchedAuthorizations as any),
+      {
+        contractName: "RouterGateway" as const,
+        functionName: "move_debt" as const,
+        args: CallData.compile({ instructions: protocolInstructions }),
+      },
+    ];
+  }, [protocolInstructions, fetchedAuthorizations]);
+
+  const swapSummary = useMemo(() => {
+    if (!selectedQuote || !currentDebt || !targetDebt) return null;
+
+    return {
+      sellToken: targetDebt,
+      buyToken: currentDebt,
+      sellAmount: selectedQuote.sellAmount,
+      buyAmount: selectedQuote.buyAmount,
+    };
+  }, [selectedQuote, currentDebt, targetDebt]);
+
+  return {
+    loading,
+    error,
+    selectedQuote,
+    swapSummary,
+    calls,
+  };
+};
+
+export type UseNostraDebtSwitchResult = ReturnType<typeof useNostraDebtSwitch>;
+


### PR DESCRIPTION
## Summary
- add optional extraActions slots to supply and borrow positions to host protocol-specific controls
- implement dedicated Nostra debt switch and close flows with reusable hooks and StarkNet modals
- enhance the Nostra protocol view with new action buttons, token selection modal, and modal wiring while leaving collateral switching disabled

## Testing
- yarn workspace @se-2/nextjs lint *(fails: command not found: next)*

------
https://chatgpt.com/codex/tasks/task_e_68ca9f9866cc832086c5ac5ecf24dae8