### PR TITLE
Update Vesu positions header interactions

### DIFF
--- a/packages/nextjs/components/BorrowPosition.tsx
+++ b/packages/nextjs/components/BorrowPosition.tsx
@@ -33,6 +33,7 @@ export type BorrowPositionProps = ProtocolPosition & {
   borrowCtaLabel?: string;
   showNoDebtLabel?: boolean;
   showInfoDropdown?: boolean;
+  headerOpensMoveModal?: boolean;
 };
 
 export const BorrowPosition: FC<BorrowPositionProps> = ({
@@ -61,6 +62,7 @@ export const BorrowPosition: FC<BorrowPositionProps> = ({
   borrowCtaLabel,
   showNoDebtLabel = false,
   showInfoDropdown = true,
+  headerOpensMoveModal = false,
 }) => {
   const moveModal = useModal();
   const repayModal = useModal();
@@ -132,6 +134,18 @@ export const BorrowPosition: FC<BorrowPositionProps> = ({
 
   const movePoolId = vesuContext?.borrow?.poolId ?? vesuContext?.repay?.poolId;
 
+  const canOpenMoveModalFromHeader =
+    headerOpensMoveModal && hasBalance && !actionsDisabled && isWalletConnected;
+
+  const handleHeaderActivation = (
+    event: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>,
+  ) => {
+    if (!headerOpensMoveModal) return;
+    event.stopPropagation();
+    if (!canOpenMoveModalFromHeader) return;
+    moveModal.open();
+  };
+
   // Toggle expanded state
   const toggleExpanded = (e: React.MouseEvent) => {
     // Don't expand if clicking on the info button or its dropdown
@@ -143,6 +157,30 @@ export const BorrowPosition: FC<BorrowPositionProps> = ({
     }
     expanded.toggle();
   };
+
+  const headerClassName = `order-1 lg:order-none lg:col-span-3 flex items-center ${
+    headerOpensMoveModal ? "gap-1" : ""
+  } ${canOpenMoveModalFromHeader ? "cursor-pointer" : ""}`;
+
+  const headerInteractiveProps: {
+    role?: "button";
+    tabIndex?: number;
+    onClick?: (event: React.MouseEvent<HTMLDivElement>) => void;
+    onKeyDown?: (event: React.KeyboardEvent<HTMLDivElement>) => void;
+    "aria-disabled"?: boolean;
+  } = headerOpensMoveModal
+    ? {
+        role: "button",
+        tabIndex: 0,
+        onClick: handleHeaderActivation,
+        onKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => {
+          if (event.key === "Enter" || event.key === " ") {
+            handleHeaderActivation(event);
+          }
+        },
+        "aria-disabled": !canOpenMoveModalFromHeader,
+      }
+    : {};
 
   // Get the collateral view with isVisible prop
   const collateralViewWithVisibility = collateralView
@@ -165,11 +203,13 @@ export const BorrowPosition: FC<BorrowPositionProps> = ({
       >
         <div className="grid grid-cols-1 lg:grid-cols-12 relative">
           {/* Header: Icon and Title */}
-          <div className="order-1 lg:order-none lg:col-span-3 flex items-center">
+          <div className={headerClassName} {...headerInteractiveProps}>
             <div className="w-7 h-7 relative min-w-[28px] min-h-[28px]">
               <Image src={icon} alt={`${name} icon`} layout="fill" className="rounded-full" />
             </div>
-            <span className="ml-2 font-semibold text-lg truncate">{name}</span>
+            <span className={`ml-2 font-semibold text-lg truncate ${headerOpensMoveModal ? "underline" : ""}`}>
+              {name}
+            </span>
             {showInfoDropdown && (
               <div
                 className="dropdown dropdown-end dropdown-bottom flex-shrink-0 ml-1"

--- a/packages/nextjs/components/specific/vesu/VesuProtocolView.tsx
+++ b/packages/nextjs/components/specific/vesu/VesuProtocolView.tsx
@@ -775,6 +775,7 @@ export const VesuProtocolView: FC = () => {
                         disableMove
                         subtitle={row.isVtoken ? "vToken" : undefined}
                         containerClassName="rounded-none"
+                        showInfoDropdown={false}
                       />
                       {row.borrow ? (
                         <BorrowPosition
@@ -784,9 +785,11 @@ export const VesuProtocolView: FC = () => {
                           position={positionManager}
                           containerClassName="rounded-none"
                           availableActions={
-                            row.hasDebt ? undefined : { borrow: true, repay: false, move: false }
+                            row.hasDebt ? { move: false } : { borrow: true, repay: false, move: false }
                           }
                           showNoDebtLabel={!row.hasDebt}
+                          showInfoDropdown={false}
+                          headerOpensMoveModal={row.hasDebt}
                         />
                       ) : (
                         <div className="p-3 bg-base-200/60 border border-dashed border-base-300 h-full flex items-center justify-between gap-3">


### PR DESCRIPTION
## Summary
- remove redundant info dropdowns from Vesu supply and borrow rows
- add an optional header shortcut that opens the move debt modal and underline the token label when active
- wire the new shortcut into the Vesu protocol view and hide the old move button

## Testing
- yarn next:lint

------
https://chatgpt.com/codex/tasks/task_e_68cabbadfb9083208ef69791c4d86cf3