### PR TITLE
Add stable layout shells around client-only sections

### DIFF
--- a/packages/nextjs/app/app/page.tsx
+++ b/packages/nextjs/app/app/page.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import type { NextPage } from "next";
 import { NetworkFilter, NetworkOption } from "~~/components/NetworkFilter";
 import CallToAction, { CallToActionSectionProps } from "~~/components/common/CallToAction";
+import StableArea from "~~/components/common/StableArea";
 import { AaveProtocolView } from "~~/components/specific/aave/AaveProtocolView";
 import { CompoundProtocolView } from "~~/components/specific/compound/CompoundProtocolView";
 import { VenusProtocolView } from "~~/components/specific/venus/VenusProtocolView";
@@ -67,11 +68,13 @@ const App: NextPage = () => {
   ];
 
   return (
-    <div className="container mx-auto flex p-0">
-      <div className="hidden lg:block">
-        <LendingSidebar />
+    <div className="container mx-auto flex flex-col gap-6 p-0 lg:flex-row lg:gap-10 min-h-[calc(100vh-6rem)] py-6">
+      <div className="hidden lg:block lg:flex-shrink-0">
+        <StableArea minHeight="32rem" className="sticky top-[4.5rem]">
+          <LendingSidebar />
+        </StableArea>
       </div>
-      <div className="flex-1">
+      <div className="flex-1 space-y-6">
         <NetworkFilter networks={networkOptions} defaultNetwork="starknet" onNetworkChange={setSelectedNetwork} />
 
         {selectedNetwork === "arbitrum" && (
@@ -82,17 +85,27 @@ const App: NextPage = () => {
 
         {/* Protocol Views */}
         {selectedNetwork === "arbitrum" && (
-          <>
-            <AaveProtocolView />
-            <CompoundProtocolView />
-            <VenusProtocolView />
-          </>
+          <div className="space-y-6">
+            <StableArea as="section" minHeight="28rem" className="block" innerClassName="h-full">
+              <AaveProtocolView />
+            </StableArea>
+            <StableArea as="section" minHeight="28rem" className="block" innerClassName="h-full">
+              <CompoundProtocolView />
+            </StableArea>
+            <StableArea as="section" minHeight="28rem" className="block" innerClassName="h-full">
+              <VenusProtocolView />
+            </StableArea>
+          </div>
         )}
         {selectedNetwork === "starknet" && (
-          <>
-            <VesuProtocolView />
-            <NostraProtocolView />
-          </>
+          <div className="space-y-6">
+            <StableArea as="section" minHeight="28rem" className="block" innerClassName="h-full">
+              <VesuProtocolView />
+            </StableArea>
+            <StableArea as="section" minHeight="28rem" className="block" innerClassName="h-full">
+              <NostraProtocolView />
+            </StableArea>
+          </div>
         )}
         {/* Custom Call to Action with additional section */}
         <CallToAction sections={customSections} />

--- a/packages/nextjs/app/markets/page.tsx
+++ b/packages/nextjs/app/markets/page.tsx
@@ -10,6 +10,7 @@ import { NetworkFilter, NetworkOption } from "~~/components/NetworkFilter";
 import { MarketsGrouped } from "~~/components/markets/MarketsGrouped";
 import { ContractResponse, POOL_IDS } from "~~/components/specific/vesu/VesuMarkets";
 import { useScaffoldReadContract } from "~~/hooks/scaffold-stark";
+import StableArea from "~~/components/common/StableArea";
 
 const MarketLoader = () => (
   <div className="flex justify-center py-10">
@@ -60,11 +61,13 @@ const MarketsPage: NextPage = () => {
   });
 
   return (
-    <div className="container mx-auto px-5 flex">
-      <div className="hidden lg:block">
-        <LendingSidebar />
+    <div className="container mx-auto flex flex-col gap-6 px-5 lg:flex-row lg:gap-10 min-h-[calc(100vh-6rem)] py-6">
+      <div className="hidden lg:block lg:flex-shrink-0">
+        <StableArea minHeight="32rem" className="sticky top-[4.5rem]">
+          <LendingSidebar />
+        </StableArea>
       </div>
-      <div className="flex-1">
+      <div className="flex-1 space-y-6">
         <div className="flex items-center mb-4">
           {groupMode === "protocol" && (
             <NetworkFilter networks={networkOptions} defaultNetwork="starknet" onNetworkChange={setSelectedNetwork} />
@@ -117,27 +120,39 @@ const MarketsPage: NextPage = () => {
           </div>
         </div>
         {groupMode === "token" ? (
-          <MarketsGrouped search={search} />
+          <StableArea as="section" minHeight="32rem" innerClassName="h-full">
+            <MarketsGrouped search={search} />
+          </StableArea>
         ) : (
-          <>
+          <div className="space-y-6">
             {selectedNetwork === "arbitrum" && (
               <>
-                <AaveMarkets viewMode={viewMode} search={search} />
-                <CompoundMarkets viewMode={viewMode} search={search} />
-                <VenusMarkets viewMode={viewMode} search={search} />
+                <StableArea as="section" minHeight="30rem" className="block" innerClassName="h-full">
+                  <AaveMarkets viewMode={viewMode} search={search} />
+                </StableArea>
+                <StableArea as="section" minHeight="30rem" className="block" innerClassName="h-full">
+                  <CompoundMarkets viewMode={viewMode} search={search} />
+                </StableArea>
+                <StableArea as="section" minHeight="30rem" className="block" innerClassName="h-full">
+                  <VenusMarkets viewMode={viewMode} search={search} />
+                </StableArea>
               </>
             )}
             {selectedNetwork === "starknet" && (
               <>
-                <VesuMarkets
-                  supportedAssets={supportedAssets as ContractResponse | undefined}
-                  viewMode={viewMode}
-                  search={search}
-                />
-                <NostraMarkets viewMode={viewMode} search={search} />
+                <StableArea as="section" minHeight="30rem" className="block" innerClassName="h-full">
+                  <VesuMarkets
+                    supportedAssets={supportedAssets as ContractResponse | undefined}
+                    viewMode={viewMode}
+                    search={search}
+                  />
+                </StableArea>
+                <StableArea as="section" minHeight="30rem" className="block" innerClassName="h-full">
+                  <NostraMarkets viewMode={viewMode} search={search} />
+                </StableArea>
               </>
             )}
-          </>
+          </div>
         )}
       </div>
     </div>

--- a/packages/nextjs/components/common/StableArea.tsx
+++ b/packages/nextjs/components/common/StableArea.tsx
@@ -1,0 +1,47 @@
+import { PropsWithChildren } from "react";
+
+type StableAreaProps = PropsWithChildren<{
+  /**
+   * Minimum height to reserve for the wrapped area. Accepts a number (pixels) or any CSS length string.
+   * Defaults to 20rem which matches the approximate size of protocol cards on desktop.
+   */
+  minHeight?: number | string;
+  /** Optional class applied to the outer wrapper element. */
+  className?: string;
+  /** Optional class applied to the inner element that actually reserves the height. */
+  innerClassName?: string;
+  /**
+   * Element to render as the wrapper. Defaults to a div so that the component can be used inside flex/grid layouts
+   * without introducing semantic issues.
+   */
+  as?: keyof JSX.IntrinsicElements;
+}>;
+
+/**
+ * Utility wrapper that reserves a predictable block of space so that client-only components can hydrate without
+ * causing cumulative layout shift. This is particularly useful when using `next/dynamic` with `ssr: false`, where
+ * the server initially renders nothing and the client later mounts a much taller component.
+ */
+export const StableArea = ({
+  minHeight = "20rem",
+  className,
+  innerClassName,
+  as: Component = "div",
+  children,
+}: StableAreaProps) => {
+  const style =
+    typeof minHeight === "number"
+      ? { minHeight: `${minHeight}px` }
+      : { minHeight };
+  const combinedInnerClassName = ["w-full", innerClassName].filter(Boolean).join(" ");
+
+  return (
+    <Component className={className}>
+      <div className={combinedInnerClassName} style={style}>
+        {children}
+      </div>
+    </Component>
+  );
+};
+
+export default StableArea;

--- a/packages/nextjs/components/home/HeroSection.tsx
+++ b/packages/nextjs/components/home/HeroSection.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import Image from "next/image";
 import Link from "next/link";
 import DebtComparison from "./DebtComparison.client";
+import StableArea from "../common/StableArea";
 
 const HeroSection = () => {
   return (
@@ -80,7 +81,9 @@ const HeroSection = () => {
           <div className="card bg-base-100 bg-opacity-98 shadow-2xl border border-base-300 rounded-lg">
             <div className="card-body p-6">
               {/* Debt comparison component */}
-              <DebtComparison />
+              <StableArea minHeight="26rem" innerClassName="h-full">
+                <DebtComparison />
+              </StableArea>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add a shared StableArea wrapper to reserve height for client-only sections
- wrap hero, lending, and markets views with StableArea to curb layout shifts
- adjust page shells to keep sidebars and content spacing consistent while data loads

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68cc68d4d70c832095b2e235f63602d1