### PR TITLE
Fix Starknet optimal rate display fallback

### DIFF
--- a/packages/nextjs/components/BorrowPosition.tsx
+++ b/packages/nextjs/components/BorrowPosition.tsx
@@ -92,6 +92,10 @@ export const BorrowPosition: FC<BorrowPositionProps> = ({
     type: "borrow",
   });
 
+  const hasOptimalProtocol = Boolean(optimalProtocol);
+  const displayedOptimalProtocol = hasOptimalProtocol ? optimalProtocol : protocolName;
+  const displayedOptimalRate = hasOptimalProtocol ? optimalRateDisplay : currentRate;
+
   // Determine if there's a better rate available on another protocol
   const ratesAreSame = Math.abs(currentRate - optimalRateDisplay) < 0.000001;
   const hasBetterRate =
@@ -260,14 +264,14 @@ export const BorrowPosition: FC<BorrowPositionProps> = ({
               <div className="text-sm text-base-content/70 overflow-hidden h-6">Best APR</div>
               <div className="font-medium flex items-center h-6">
                 <span className="tabular-nums whitespace-nowrap text-ellipsis min-w-0 line-clamp-1">
-                  {formatPercentage(optimalRateDisplay)}%
+                  {formatPercentage(displayedOptimalRate)}%
                 </span>
                 <Image
-                  src={getProtocolLogo(optimalProtocol)}
-                  alt={optimalProtocol}
-                  width={optimalProtocol == "vesu" ? 35 : 16}
-                  height={optimalProtocol == "vesu" ? 35 : 16}
-                  className={`flex-shrink-0 ${optimalProtocol == "vesu" ? "" : "rounded-md"} ml-1`}
+                  src={getProtocolLogo(displayedOptimalProtocol)}
+                  alt={displayedOptimalProtocol}
+                  width={displayedOptimalProtocol == "vesu" ? 35 : 16}
+                  height={displayedOptimalProtocol == "vesu" ? 35 : 16}
+                  className={`flex-shrink-0 ${displayedOptimalProtocol == "vesu" ? "" : "rounded-md"} ml-1`}
                 />
               </div>
             </div>

--- a/packages/nextjs/components/SupplyPosition.tsx
+++ b/packages/nextjs/components/SupplyPosition.tsx
@@ -92,6 +92,10 @@ export const SupplyPosition: FC<SupplyPositionProps> = ({
     type: "supply",
   });
 
+  const hasOptimalProtocol = Boolean(optimalProtocol);
+  const displayedOptimalProtocol = hasOptimalProtocol ? optimalProtocol : protocolName;
+  const displayedOptimalRate = hasOptimalProtocol ? optimalRateDisplay : currentRate;
+
   const formatNumber = (num: number) =>
     new Intl.NumberFormat("en-US", {
       minimumFractionDigits: 2,
@@ -226,14 +230,14 @@ export const SupplyPosition: FC<SupplyPositionProps> = ({
               <div className="text-sm text-base-content/70 overflow-hidden h-6">Best APY</div>
               <div className="font-medium flex items-center h-6">
                 <span className="tabular-nums whitespace-nowrap text-ellipsis min-w-0 line-clamp-1">
-                  {formatPercentage(optimalRateDisplay)}%
+                  {formatPercentage(displayedOptimalRate)}%
                 </span>
                 <Image
-                  src={getProtocolLogo(optimalProtocol)}
-                  alt={optimalProtocol}
-                  width={optimalProtocol == "vesu" ? 35 : 16}
-                  height={optimalProtocol == "vesu" ? 35 : 16}
-                  className={`flex-shrink-0 ${optimalProtocol == "vesu" ? "" : "rounded-md"} ml-1`}
+                  src={getProtocolLogo(displayedOptimalProtocol)}
+                  alt={displayedOptimalProtocol}
+                  width={displayedOptimalProtocol == "vesu" ? 35 : 16}
+                  height={displayedOptimalProtocol == "vesu" ? 35 : 16}
+                  className={`flex-shrink-0 ${displayedOptimalProtocol == "vesu" ? "" : "rounded-md"} ml-1`}
                 />
               </div>
             </div>


### PR DESCRIPTION
## Summary
- ensure Starknet protocol cards reuse the current protocol and rate when no optimal data is returned
- prevent broken logos and 0% optimal APR/APY when Starknet optimal rate lookup fails

## Testing
- yarn next:lint

------
https://chatgpt.com/codex/tasks/task_e_68cd3b5099c483208ac7c89d690a5a9a