### PR TITLE
Add snforge mainnet fork tests to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,4 +63,34 @@ jobs:
         AAVE_POOL_ADDRESSES_PROVIDER: "0xa97684ead0e402dC232d5A977953DF7ECBaB3CDb"
         AAVE_UI_POOL_DATA_PROVIDER: "0x5c5228aC8BC1528482514aF3e27E692495148717"
         BALANCER_VAULT3: "0xbA1333333333a1BA1108E8412f11850A5C319bA9"
-        BALANCER_VAULT2: "0xBA12222222228d8Ba445958a75a0704d566BF2C8" 
+        BALANCER_VAULT2: "0xBA12222222228d8Ba445958a75a0704d566BF2C8"
+
+  snforge-tests:
+    name: Starknet Forge Tests
+    runs-on: ubuntu-latest
+    if: ${{ secrets.STARKNET_RPC_URL_MAINNET != '' }}
+    defaults:
+      run:
+        working-directory: packages/snfoundry
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Scarb
+        uses: software-mansion/setup-scarb@v1
+        with:
+          scarb-version: "2.9.4"
+
+      - name: Install Starknet Foundry
+        run: |
+          curl -L https://raw.githubusercontent.com/foundry-rs/starknet-foundry/master/scripts/install.sh | sh
+          echo "$HOME/.starknet-foundry/bin" >> $GITHUB_PATH
+          ~/.starknet-foundry/bin/snfoundryup
+
+      - name: Run snforge tests against mainnet fork
+        env:
+          RPC_URL_MAINNET: ${{ secrets.STARKNET_RPC_URL_MAINNET }}
+        run: |
+          set -a
+          source ./.env
+          cd contracts
+          FORK_URL=$RPC_URL_MAINNET snforge test


### PR DESCRIPTION
## Summary
- add a Starknet Foundry job that runs the snforge suite against a mainnet fork when the RPC secret is available
- install Scarb and Starknet Foundry before executing the snforge tests

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cd854f7a3c832097a20b9e5c0f64e3