### PR TITLE
fix: ensure Next.js build uses updated starknet APIs

### DIFF
--- a/packages/nextjs/hooks/scaffold-stark/useScaffoldContract.ts
+++ b/packages/nextjs/hooks/scaffold-stark/useScaffoldContract.ts
@@ -18,13 +18,13 @@ export const useScaffoldContract = <TContractName extends ContractName>({
   const { account } = useAccount();
 
   const contract = useMemo(() => {
-    if (!deployedContractData) return undefined;
+    if (!deployedContractData || !publicClient) return undefined;
 
-    const contractInstance = new Contract({
-      abi: deployedContractData.abi as Abi,
-      address: deployedContractData.address,
-      providerOrAccount: publicClient,
-    });
+    const contractInstance = new Contract(
+      deployedContractData.abi as Abi,
+      deployedContractData.address,
+      publicClient,
+    );
 
     if (account) {
       contractInstance.connect(account);

--- a/packages/nextjs/hooks/scaffold-stark/useScaffoldEventHistory.ts
+++ b/packages/nextjs/hooks/scaffold-stark/useScaffoldEventHistory.ts
@@ -3,7 +3,7 @@ import { useTargetNetwork } from "./useTargetNetwork";
 import { useStarkBlockNumber } from "./useBlockNumberContext";
 import { Abi, ExtractAbiEvent, ExtractAbiEventNames } from "abi-wan-kanabi/kanabi";
 import { RpcProvider, hash } from "starknet";
-import { CallData, createAbiParser, events as starknetEvents } from "starknet";
+import { CallData, events as starknetEvents } from "starknet";
 import { useDeployedContractInfo } from "~~/hooks/scaffold-stark";
 import { replacer } from "~~/utils/scaffold-stark/common";
 import { ContractAbi, ContractName, UseScaffoldEventHistoryConfig } from "~~/utils/scaffold-stark/contract";
@@ -182,7 +182,6 @@ export const useScaffoldEventHistory = <
   const eventHistoryData = useMemo(() => {
     if (deployedContractData) {
       const abi = deployedContractData.abi as Abi;
-      const abiParser = createAbiParser(abi);
       return (events || []).map(event => {
         const logs = [JSON.parse(JSON.stringify(event.log))];
         const parsed = starknetEvents.parseEvents(
@@ -190,7 +189,6 @@ export const useScaffoldEventHistory = <
           starknetEvents.getAbiEvents(abi),
           CallData.getAbiStruct(abi),
           CallData.getAbiEnum(abi),
-          abiParser,
         );
         const args = parsed.length ? parsed[0][eventName] : {};
         const { event: rawEvent, ...rest } = event;

--- a/packages/nextjs/hooks/scaffold-stark/useScaffoldMultiWriteContract.ts
+++ b/packages/nextjs/hooks/scaffold-stark/useScaffoldMultiWriteContract.ts
@@ -63,10 +63,10 @@ export const useScaffoldMultiWriteContract = <
               contractName as ContractName
             ] as Contract<TContractName>;
             // we convert to starknetjs contract instance here since deployed data may be undefined if contract is not deployed
-            const contractInstance = new StarknetJsContract({
-              abi: contract.abi,
-              address: contract.address,
-            });
+            const contractInstance = new StarknetJsContract(
+              contract.abi as Abi,
+              contract.address,
+            );
 
             console.log("unparsed args", unParsedArgs);
             return contractInstance.populate(functionName, unParsedArgs as any[]);

--- a/packages/nextjs/hooks/scaffold-stark/useScaffoldWriteContract.ts
+++ b/packages/nextjs/hooks/scaffold-stark/useScaffoldWriteContract.ts
@@ -47,10 +47,10 @@ export const useScaffoldWriteContract = <
       }
 
       // we convert to starknetjs contract instance here since deployed data may be undefined if contract is not deployed
-      const contractInstance = new StarknetJsContract({
-        abi: deployedContractData.abi,
-        address: deployedContractData.address,
-      });
+      const contractInstance = new StarknetJsContract(
+        deployedContractData.abi as Abi,
+        deployedContractData.address,
+      );
 
       const newCalls = deployedContractData ? [contractInstance.populate(functionName, newArgs as any[])] : [];
 

--- a/packages/nextjs/hooks/useLendingAction.ts
+++ b/packages/nextjs/hooks/useLendingAction.ts
@@ -1,6 +1,7 @@
 import type { Network } from "./useTokenBalance";
 import { useTokenBalance } from "./useTokenBalance";
 import {
+  Abi,
   CairoCustomEnum,
   CairoOption,
   CairoOptionVariant,
@@ -118,11 +119,11 @@ export const useLendingAction = (
       };
       const fullInstruction = CallData.compile({ instructions: [baseInstruction] });
       const authInstruction = CallData.compile({ instructions: [baseInstruction], rawSelectors: false });
-      const contract = new Contract({
-        abi: starkRouterGateway.abi,
-        address: starkRouterGateway.address,
-        providerOrAccount: starkAccount,
-      });
+      const contract = new Contract(
+        starkRouterGateway.abi as Abi,
+        starkRouterGateway.address,
+        starkAccount,
+      );
       const protocolInstructions = await contract.call(
         "get_authorizations_for_instructions",
         authInstruction,

--- a/packages/nextjs/hooks/useLendingAuthorizations.ts
+++ b/packages/nextjs/hooks/useLendingAuthorizations.ts
@@ -1,4 +1,4 @@
-import { CallData, Contract, num } from "starknet";
+import { Abi, CallData, Contract, num } from "starknet";
 import { useAccount as useStarkAccount } from "~~/hooks/useAccount";
 import { useDeployedContractInfo as useStarkDeployedContractInfo } from "~~/hooks/scaffold-stark";
 import { feltToString } from "~~/utils/protocols";
@@ -29,11 +29,11 @@ export const useLendingAuthorizations = () => {
       rawSelectors: false,
     });
 
-    const contract = new Contract({
-      abi: routerGateway.abi,
-      address: routerGateway.address,
-      providerOrAccount: account,
-    });
+    const contract = new Contract(
+      routerGateway.abi as Abi,
+      routerGateway.address,
+      account,
+    );
     const protocolInstructions = await contract.call(
       "get_authorizations_for_instructions",
       authInstruction,

--- a/packages/nextjs/utils/scaffold-stark/eventKeyFilter.ts
+++ b/packages/nextjs/utils/scaffold-stark/eventKeyFilter.ts
@@ -1,7 +1,7 @@
 import { feltToHex } from "./common";
 import { ContractAbi, ContractName } from "./contract";
 import { ExtractAbiEvent, ExtractAbiEventNames } from "abi-wan-kanabi/kanabi";
-import { Abi, AbiEntry, AbiEnums, AbiStructs, CallData, createAbiParser, parseCalldataField } from "starknet";
+import { Abi, AbiEntry, AbiEnums, AbiStructs, CallData, parseCalldataField } from "starknet";
 
 const stringToByteArrayFelt = (str: string): string[] => {
   const bytes = new TextEncoder().encode(str);
@@ -32,19 +32,13 @@ export const serializeEventKey = (
   abiEntry: AbiEntry,
   structs: AbiStructs,
   enums: AbiEnums,
-  parser: ReturnType<typeof createAbiParser>,
+  parser: CallData["parser"],
 ): string[] => {
   if (abiEntry.type === "core::byte_array::ByteArray") {
     return stringToByteArrayFelt(input).map(item => feltToHex(BigInt(item)));
   }
   const args = [input][Symbol.iterator]();
-  const parsed = parseCalldataField({
-    argsIterator: args,
-    input: abiEntry,
-    structs,
-    enums,
-    parser,
-  });
+  const parsed = parseCalldataField(args, abiEntry, structs, enums);
   if (typeof parsed === "string") {
     return [feltToHex(BigInt(parsed))];
   }
@@ -93,7 +87,7 @@ export const composeEventFilterKeys = (
   }
   const enums = CallData.getAbiEnum(abi);
   const structs = CallData.getAbiStruct(abi);
-  const parser = createAbiParser(abi);
+  const parser = new CallData(abi).parser;
   const members = event.members as unknown as {
     name: string;
     type: string;


### PR DESCRIPTION
## Summary
- update scaffold-stark hooks to instantiate `Contract` with the new starknet constructor signature and required provider checks
- remove deprecated `createAbiParser` usage and adjust event filtering helpers to the current starknet parsing API
- refresh lending hooks to align with the latest starknet contract interface

## Testing
- yarn build


------
https://chatgpt.com/codex/tasks/task_e_68cd877b5b2883208b733b21c644e7dd