### PR TITLE
Add net yield metrics to Vesu and Nostra views

### DIFF
--- a/packages/nextjs/components/ProtocolView.tsx
+++ b/packages/nextjs/components/ProtocolView.tsx
@@ -10,6 +10,7 @@ import { DepositModalStark } from "./modals/stark/DepositModalStark";
 import { TokenSelectModalStark } from "./modals/stark/TokenSelectModalStark";
 import { FiAlertTriangle, FiPlus } from "react-icons/fi";
 import formatPercentage from "~~/utils/formatPercentage";
+import { calculateNetYieldMetrics } from "~~/utils/netYield";
 import { PositionManager } from "~~/utils/position";
 import type { VesuContext } from "~~/hooks/useLendingAction";
 
@@ -143,6 +144,14 @@ export const ProtocolView: FC<ProtocolViewProps> = ({
     [suppliedPositions, borrowedPositions],
   );
 
+  const { netYield30d, netApyPercent } = useMemo(
+    () =>
+      calculateNetYieldMetrics(suppliedPositions, borrowedPositions, {
+        netBalanceOverride: netBalance,
+      }),
+    [suppliedPositions, borrowedPositions, netBalance],
+  );
+
   // Format currency with sign.
   const formatCurrency = (amount: number) => {
     const formatted = new Intl.NumberFormat("en-US", {
@@ -152,6 +161,11 @@ export const ProtocolView: FC<ProtocolViewProps> = ({
       maximumFractionDigits: 2,
     }).format(Math.abs(amount));
     return amount >= 0 ? formatted : `-${formatted}`;
+  };
+
+  const formatSignedPercentage = (value: number) => {
+    const formatted = formatPercentage(Math.abs(value));
+    return `${value >= 0 ? "" : "-"}${formatted}%`;
   };
 
   // Use effective showAll state (component state OR forced from props)
@@ -262,11 +276,35 @@ export const ProtocolView: FC<ProtocolViewProps> = ({
               </div>
               <div className="flex flex-col">
                 <div className="text-xl font-bold tracking-tight">{protocolName}</div>
-                <div className="text-base-content/70 flex items-center gap-1">
-                  <span className="text-sm">Balance:</span>
-                  <span className={`text-sm font-medium ${netBalance >= 0 ? "text-success" : "text-error"}`}>
-                    {formatCurrency(netBalance)}
-                  </span>
+                <div className="text-base-content/70 flex flex-col gap-1 text-sm">
+                  <div className="flex items-center gap-1">
+                    <span>Balance:</span>
+                    <span className={`font-medium ${netBalance >= 0 ? "text-success" : "text-error"}`}>
+                      {formatCurrency(netBalance)}
+                    </span>
+                  </div>
+                  <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs">
+                    <span className="flex items-center gap-1">
+                      <span>30D Net Yield:</span>
+                      <span className={`font-semibold ${netYield30d >= 0 ? "text-success" : "text-error"}`}>
+                        {formatCurrency(netYield30d)}
+                      </span>
+                    </span>
+                    <span className="flex items-center gap-1">
+                      <span>Net APY:</span>
+                      <span
+                        className={`font-semibold ${
+                          netApyPercent == null
+                            ? "text-base-content"
+                            : netApyPercent >= 0
+                              ? "text-success"
+                              : "text-error"
+                        }`}
+                      >
+                        {netApyPercent == null ? "--" : formatSignedPercentage(netApyPercent)}
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>

--- a/packages/nextjs/components/specific/vesu/VesuMarketSection.tsx
+++ b/packages/nextjs/components/specific/vesu/VesuMarketSection.tsx
@@ -5,6 +5,7 @@ import { FiChevronDown, FiChevronUp } from "react-icons/fi";
 import type { ProtocolPosition } from "~~/components/ProtocolView";
 import { BorrowPosition } from "~~/components/BorrowPosition";
 import { SupplyPosition } from "~~/components/SupplyPosition";
+import formatPercentage from "~~/utils/formatPercentage";
 
 interface VesuMarketSectionProps {
   isOpen: boolean;
@@ -16,6 +17,8 @@ interface VesuMarketSectionProps {
   userAddress?: string;
   hasPositions: boolean;
   netBalanceUsd: number;
+  netYield30d: number;
+  netApyPercent: number | null;
   onDeposit: () => void;
   canDeposit: boolean;
   formatCurrency: (value: number) => string;
@@ -31,10 +34,17 @@ export const VesuMarketSection: FC<VesuMarketSectionProps> = ({
   userAddress,
   hasPositions,
   netBalanceUsd,
+  netYield30d,
+  netApyPercent,
   onDeposit,
   canDeposit,
   formatCurrency,
 }) => {
+  const formatSignedPercentage = (value: number) => {
+    const formatted = formatPercentage(Math.abs(value));
+    return `${value >= 0 ? "" : "-"}${formatted}%`;
+  };
+
   const renderMarketContent = () => {
     if (assetsError) {
       return (
@@ -125,11 +135,35 @@ export const VesuMarketSection: FC<VesuMarketSectionProps> = ({
               <div className="text-xl font-bold tracking-tight">Vesu</div>
               <div className="text-xs text-base-content/70">Manage your Starknet lending positions</div>
               {userAddress && (
-                <div className="mt-1 flex items-center gap-1 text-xs text-base-content/70">
-                  <span>Balance:</span>
-                  <span className={`font-semibold ${netBalanceUsd >= 0 ? "text-success" : "text-error"}`}>
-                    {formatCurrency(netBalanceUsd)}
-                  </span>
+                <div className="mt-1 flex flex-col gap-1 text-xs text-base-content/70">
+                  <div className="flex items-center gap-1">
+                    <span>Balance:</span>
+                    <span className={`font-semibold ${netBalanceUsd >= 0 ? "text-success" : "text-error"}`}>
+                      {formatCurrency(netBalanceUsd)}
+                    </span>
+                  </div>
+                  <div className="flex flex-wrap gap-x-4 gap-y-1">
+                    <span className="flex items-center gap-1">
+                      <span>30D Net Yield:</span>
+                      <span className={`font-semibold ${netYield30d >= 0 ? "text-success" : "text-error"}`}>
+                        {formatCurrency(netYield30d)}
+                      </span>
+                    </span>
+                    <span className="flex items-center gap-1">
+                      <span>Net APY:</span>
+                      <span
+                        className={`font-semibold ${
+                          netApyPercent == null
+                            ? "text-base-content"
+                            : netApyPercent >= 0
+                              ? "text-success"
+                              : "text-error"
+                        }`}
+                      >
+                        {netApyPercent == null ? "--" : formatSignedPercentage(netApyPercent)}
+                      </span>
+                    </span>
+                  </div>
                 </div>
               )}
             </div>

--- a/packages/nextjs/components/specific/vesu/VesuProtocolView.tsx
+++ b/packages/nextjs/components/specific/vesu/VesuProtocolView.tsx
@@ -12,6 +12,7 @@ import type { PositionManager } from "~~/utils/position";
 import { POOL_IDS } from "./VesuMarkets";
 import { VesuMarketSection } from "./VesuMarketSection";
 import { VesuPositionsSection } from "./VesuPositionsSection";
+import { calculateNetYieldMetrics } from "~~/utils/netYield";
 
 type BorrowSelectionState = {
   tokens: AssetWithRates[];
@@ -66,6 +67,20 @@ export const VesuProtocolView: FC = () => {
 
     return totalSupply - totalDebt;
   }, [rows]);
+
+  const supplyPositions = useMemo(() => rows.map(row => row.supply), [rows]);
+  const borrowPositions = useMemo(
+    () => rows.flatMap(row => (row.borrow ? [row.borrow] : [])),
+    [rows],
+  );
+
+  const { netYield30d, netApyPercent } = useMemo(
+    () =>
+      calculateNetYieldMetrics(supplyPositions, borrowPositions, {
+        netBalanceOverride: netBalanceUsd,
+      }),
+    [supplyPositions, borrowPositions, netBalanceUsd],
+  );
 
   const formatCurrency = (amount: number) => {
     const formatter = new Intl.NumberFormat("en-US", {
@@ -123,6 +138,8 @@ export const VesuProtocolView: FC = () => {
         userAddress={userAddress}
         hasPositions={hasPositions}
         netBalanceUsd={netBalanceUsd}
+        netYield30d={netYield30d}
+        netApyPercent={netApyPercent}
         onDeposit={() => openDepositModal(assetsWithRates)}
         canDeposit={assetsWithRates.length > 0}
         formatCurrency={formatCurrency}

--- a/packages/nextjs/utils/netYield.ts
+++ b/packages/nextjs/utils/netYield.ts
@@ -1,0 +1,86 @@
+import type { ProtocolPosition } from "~~/components/ProtocolView";
+
+const DAYS_IN_YEAR = 365;
+const EPSILON = 1e-8;
+
+type PositionLike = Pick<ProtocolPosition, "balance" | "currentRate">;
+
+export interface NetYieldMetrics {
+  totalSupplied: number;
+  totalBorrowed: number;
+  netAnnualYield: number;
+  netYield30d: number;
+  netApyPercent: number | null;
+  netBalance: number;
+}
+
+interface CalculateNetYieldOptions {
+  /**
+   * Optional override for the equity/net balance value used when computing the
+   * APY. When omitted the function will use `totalSupplied - totalBorrowed`.
+   */
+  netBalanceOverride?: number;
+  /** Number of days used for the period calculation (defaults to 30). */
+  days?: number;
+}
+
+const toNumber = (value: number) => (Number.isFinite(value) ? value : 0);
+
+const toDecimalRate = (rate: number) => toNumber(Math.abs(rate)) / 100;
+
+/**
+ * Calculates aggregate yield information for a set of supplied and borrowed
+ * protocol positions. Balances are expected to be expressed in USD terms and
+ * rates in percentage points (e.g. 5 for 5%).
+ */
+export const calculateNetYieldMetrics = (
+  supplied: PositionLike[],
+  borrowed: PositionLike[],
+  options: CalculateNetYieldOptions = {},
+): NetYieldMetrics => {
+  let totalSupplied = 0;
+  let totalBorrowed = 0;
+  let supplyAnnualYield = 0;
+  let borrowAnnualCost = 0;
+
+  supplied.forEach(position => {
+    const balance = toNumber(position.balance);
+    if (balance <= 0) return;
+
+    const rateDecimal = toDecimalRate(position.currentRate);
+
+    totalSupplied += balance;
+    supplyAnnualYield += balance * rateDecimal;
+  });
+
+  borrowed.forEach(position => {
+    const balance = Math.abs(toNumber(position.balance));
+    if (balance <= 0) return;
+
+    const rateDecimal = toDecimalRate(position.currentRate);
+
+    totalBorrowed += balance;
+    borrowAnnualCost += balance * rateDecimal;
+  });
+
+  const netAnnualYield = supplyAnnualYield - borrowAnnualCost;
+  const computedNetBalance = totalSupplied - totalBorrowed;
+
+  const baseForApy = options.netBalanceOverride ?? computedNetBalance;
+  const denominator = Math.abs(baseForApy);
+  const netApyPercent = denominator > EPSILON ? (netAnnualYield / denominator) * 100 : null;
+
+  const days = options.days ?? 30;
+  const netYield30d = netAnnualYield * (days / DAYS_IN_YEAR);
+
+  return {
+    totalSupplied,
+    totalBorrowed,
+    netAnnualYield,
+    netYield30d,
+    netApyPercent,
+    netBalance: computedNetBalance,
+  };
+};
+
+export default calculateNetYieldMetrics;


### PR DESCRIPTION
## Summary
- add a reusable helper that computes aggregate net yield metrics from protocol positions
- surface 30-day net yield and net APY figures in the protocol header used by Nostra and other EVM views
- calculate and display the same yield metrics in the Vesu market header alongside the existing balance

## Testing
- yarn lint *(fails: Cannot find module '/workspace/kapan/packages/hardhat/node_modules/eslint/bin/eslint.js')*


------
https://chatgpt.com/codex/tasks/task_e_68d18489c62c832097538f559bde1eba