### PR TITLE
Add USDC market-making vault skeleton

### DIFF
--- a/packages/snfoundry/contracts/IRSController.md
+++ b/packages/snfoundry/contracts/IRSController.md
@@ -1,0 +1,731 @@
+# Shares-only IRS Controller Package
+
+## 1. Short intro
+
+You’re building a permissionless controller that clears interest-rate swaps on top of any ERC-4626 vault (via a thin adapter). The controller is lane-agnostic: it doesn’t “know” fixed vs float — it only has two monotone meters per market:
+
+- **H (harvest)**: advances only when the underlying vault realizes yield (Δassets).
+- **T (time)**: advances deterministically using a posted policy `K_ref` (assets per (rate·sec)), converted to shares at current PPS.
+
+A position specifies:
+
+- which meter it credits (earns from) and which it debits (pays from);
+- its exposure `r`; and
+- per-meter scalars (e.g., `m = K_user / K_ref` for the time leg).
+
+Each position pre-funds the debit leg in vault shares. A stop marker on the debit meter guarantees no arrears. Claims, P&L, refunds — all in shares (USDC only at the edges via the adapter).
+
+This supports both `H↔T` (classic IRS on one vault) and `H(A)↔H(B)` (harvest-for-harvest across vaults). Your market-maker contract sits on top to quote `K_user`, add a spread, and open positions on users’ behalf (with their approval for the prepayment).
+
+## 2. Technical design
+
+### 2.1 Markets & meters (multi-lane)
+
+A Market is a pair of meters `M0` and `M1`:
+
+- `type ∈ {Time, Harvest}`
+- `adapter: ContractAddress` (ERC-4626 adapter used to convert assets↔shares and to custodize).
+
+Examples:
+
+- IRS on one vault: `M0 = Harvest(adapterA)`, `M1 = Time(adapterA)`.
+- Cross-asset harvest swap: `M0 = Harvest(adapterA)`, `M1 = Harvest(adapterB)`.
+
+The Time meter always uses the market’s adapter to convert `K_ref·Δt` assets into shares so time is “assets-anchored, shares-settled” (automatically hedges PPS drift). There is no “fixed vault”; the time leg is just a share-dripper.
+
+### 2.2 Indices (“odometers”)
+
+For each meter `j ∈ {0,1}`, keep an index `I_j` with units: shares per 1 rate.
+
+Harvest update on `poke_harvest(market, j)`:
+
+```
+harvestShares = adapter.convert_to_shares(Δassets)
+S_credit_eff = Σ over active positions that credit meter j of (r * s_credit_j)
+cand = I_j + harvestShares / max(S_credit_eff, 1)
+// Expire debit=j using 'cand', then set I_j = cand
+```
+
+Conservation: `Σ credits_on_meter_j == harvestShares`.
+
+Time update on `poke_time(market, now)`:
+
+```
+ΔI_time = adapter.convert_to_shares( K_ref_assets_per_rate_per_sec * Δt )
+I_time += ΔI_time
+```
+
+`K_ref_assets_per_rate_per_sec` is posted for the market (by a designated publisher or MM); positions scale with their own `m = K_user / K_ref`.
+
+### 2.3 Positions
+
+Fields (per position):
+
+- `marketId, owner, active`
+- `credit_side ∈ {0,1}`, `debit_side = 1 - credit_side`
+- `r` (exposure, rate units)
+- `s0_q96, s1_q96` (per-meter scalars; for IRS on one vault use `s_H=1`, `s_T=m`)
+- `fund_shares` (shares of the debit meter’s adapter)
+- `ckpt0_q96, ckpt1_q96` (checkpoints in index units)
+- `stopAt_debit_q96 = ckpt_debit + fund_shares / (r * s_debit)`
+- `net_shares` (P&L in the credit meter’s share token)
+
+Funding: user (or your MM) prepays assets; adapter converts to shares and transfers to the controller. Controller holds all funds as shares.
+
+### 2.4 Expiry scheduling (O(positions that actually expire))
+
+Two bucket lists per market: one keyed by the `M0` index, one by `M1` index.
+
+On each poke of a meter:
+
+- Walk only the buckets with `tick ≤ current_index / tickSize`.
+- For each position in those buckets:
+  - Settle to the cut-off (consume from `fund_shares` with ceil, credit with floor), zero rate, unlink, mark inactive.
+
+Tick sizes are per-meter (e.g., `1e-9 shares/rate` in Q96).
+
+### 2.5 Claims, top-ups, change-rate, close
+
+- `claim(posId, to, in_assets?)`: settle to current indices; transfer up to `net_shares` either as shares (credit token) or assets via adapter; `net_shares` decreases.
+- `top_up(posId, payer, assets)`: settle lazily, convert to shares via the debit adapter, add to `fund_shares`, recompute `stopAt_debit`, re-bucket.
+- `change_rate(posId, new_r)`: settle lazily, update `r`, recompute `stopAt_debit`, re-bucket.
+- `close(posId)` (always allowed): settle to now, refund remaining `fund_shares` to owner, pay/collect `net_shares`, deactivate.
+
+### 2.6 Permissioning
+
+Permissionless: `poke_harvest`, `poke_time`, `open_*` (on behalf with user approval), `top_up`, `change_rate`, `close`, `claim`.
+
+Quoted policy: `K_ref` publisher address per market (often your MM). Anyone can poke time; only the publisher updates `K_ref`. (You can later switch to pure on-chain EMA + bounded premium if you want policyless quoting.)
+
+### 2.7 Caps & utilization steering
+
+- Per market caps: `maxRateCredit0`, `maxRateCredit1`.
+- Optional imbalance cap: bound `|Σ_debit(T) − Σ_credit(T)|` in “shares/sec” (i.e., `Σ (r*s_T*q) * ΔI_T/Δt`). Reject opens that would breach.
+
+Your MM layer can implement an EIP-1559 style premium into `K_user` to steer utilization toward a target (e.g., 70%) and earn a spread.
+
+### 2.8 Cross-asset (`H(A)↔H(B)`)
+
+Works out-of-the-box by configuring `M0=Harvest(adapterA)`, `M1=Harvest(adapterB)`.
+
+A position credits one meter’s shares (say A) and debits the other’s funded pot (B). `net_shares` is in the credit share token; the funded pot is in the debit share token; both are custodied by the controller. Refunds and claims happen in their respective tokens (or the adapter withdraws to USDC at the edge).
+
+## 3. Controller (Cairo-1) — multi-market, meter-agnostic, shares-only
+
+Notes:
+
+- Focus is on the core mechanics: markets/meters, permissionless pokes, positions with credit/debit, funded stops, buckets, settle/claim/close.
+- Utility math (`q96_mul/div`, safe casts) sketched; fill from your common fixed-point lib.
+- The Adapter abstracts ERC-4626 + USDC edges and returns shares as `u256`.
+- Storage uses per-field maps for Starknet friendliness.
+- This compiles once you drop in your q96/math + IERC20 interfaces.
+
+```cairo
+// Cairo 1.x — Shares-only IRS Controller (meter-agnostic, multi-market)
+#[starknet::contract]
+mod IRSController {
+    use starknet::ContractAddress;
+    use core::bool::BoolTrait;
+    use core::option::Option;
+    use core::integer::u256::U256;
+
+    // -------- Adapter interface (ERC-4626 + edges) --------
+    #[starknet::interface]
+    trait I4626Adapter<T> {
+        fn asset(self: @T) -> ContractAddress;                             // USDC (assets)
+        fn shares_token(self: @T) -> ContractAddress;                       // ERC20 for vault shares
+        fn total_assets(self: @T) -> u128;                                  // current assets (USDC 6dp)
+        fn convert_to_shares(self: @T, assets: u128) -> U256;               // at current PPS
+        fn convert_to_assets(self: @T, shares: U256) -> u128;               // at current PPS
+
+        // Pull USDC from 'payer', deposit, and mint shares to 'receiver' (controller)
+        fn pull_deposit_from(
+            ref self: T, payer: ContractAddress, assets: u128, receiver: ContractAddress
+        ) -> U256;
+
+        // Pay out: send 'shares' to 'to' as shares, or redeem to assets and send to 'to'
+        fn payout(
+            ref self: T, to: ContractAddress, shares: U256, in_assets: bool
+        );
+    }
+
+    // -------- Types --------
+    #[derive(Copy, Drop)]
+    enum MeterType { Time: (), Harvest: () }
+
+    // Each market has two meters: M0, M1
+    #[derive(Copy, Drop)]
+    struct MarketKey { id: u64 }
+
+    #[derive(Copy, Drop)]
+    struct PositionKey { id: u64 }
+
+    // -------- Storage --------
+    #[storage]
+    struct Storage {
+        // Markets
+        next_market_id: u64,
+        // meter config
+        m0_type: LegacyMap<u64, u8>,                    // 0=Time, 1=Harvest
+        m1_type: LegacyMap<u64, u8>,
+        m0_adapter: LegacyMap<u64, ContractAddress>,
+        m1_adapter: LegacyMap<u64, ContractAddress>,
+        // indices (Q96 shares/rate)
+        m0_I_q96: LegacyMap<u64, U256>,
+        m1_I_q96: LegacyMap<u64, U256>,
+        // tick sizes (Q96)
+        m0_tick_q96: LegacyMap<u64, U256>,
+        m1_tick_q96: LegacyMap<u64, U256>,
+        // quote policy for Time meters: K_ref in assets/(rate⋅sec), Q96
+        m0_k_ref_per_sec_q96: LegacyMap<u64, U256>,
+        m1_k_ref_per_sec_q96: LegacyMap<u64, U256>,
+        // last timestamps for Time meters
+        m0_last_ts: LegacyMap<u64, u64>,
+        m1_last_ts: LegacyMap<u64, u64>,
+        // last assets for Harvest meters (for delta)
+        m0_last_assets: LegacyMap<u64, u128>,
+        m1_last_assets: LegacyMap<u64, u128>,
+        // sums of effective credit rates per meter (Σ r*s_credit), Q96 scaling
+        m0_S_credit_q96: LegacyMap<u64, U256>,
+        m1_S_credit_q96: LegacyMap<u64, U256>,
+        // caps
+        max_rate_credit0: LegacyMap<u64, U256>,         // cap on Σ r*s_credit for meter 0
+        max_rate_credit1: LegacyMap<u64, U256>,
+
+        // K_ref publisher (can update K_ref); everyone can poke
+        publisher: LegacyMap<u64, ContractAddress>,
+
+        // Buckets: per (market, meter, tick) -> head pos
+        m0_bucket_head: LegacyMap<(u64, u128), u64>,    // (marketId, tick) -> posId
+        m1_bucket_head: LegacyMap<(u64, u128), u64>,
+        bucket_next: LegacyMap<u64, u64>,               // posId -> next posId
+
+        // Positions
+        next_pos_id: u64,
+        pos_market: LegacyMap<u64, u64>,
+        pos_owner: LegacyMap<u64, ContractAddress>,
+        pos_active: LegacyMap<u64, bool>,
+        pos_credit_side: LegacyMap<u64, u8>,            // 0 or 1
+        pos_r: LegacyMap<u64, U256>,                    // exposure
+        pos_s0_q96: LegacyMap<u64, U256>,               // per-meter multipliers
+        pos_s1_q96: LegacyMap<u64, U256>,
+        pos_fund_shares: LegacyMap<u64, U256>,          // shares of the **debit** adapter
+        pos_ckpt0_q96: LegacyMap<u64, U256>,
+        pos_ckpt1_q96: LegacyMap<u64, U256>,
+        pos_stop_debit_q96: LegacyMap<u64, U256>,
+        pos_net_shares: LegacyMap<u64, U256>,           // claim in **credit** share token (unsigned here)
+    }
+
+    // -------- Events --------
+    #[event] fn MarketCreated(market_id: u64, m0_type: u8, m1_type: u8, m0_adapter: ContractAddress, m1_adapter: ContractAddress);
+    #[event] fn QuoteUpdated(market_id: u64, meter: u8, k_ref_per_sec_q96: U256);
+    #[event] fn Open(market_id: u64, pos_id: u64, owner: ContractAddress, credit_side: u8, r: U256, s0_q96: U256, s1_q96: U256, funded: U256);
+    #[event] fn TopUp(pos_id: u64, added_shares: U256);
+    #[event] fn ChangeRate(pos_id: u64, old_r: U256, new_r: U256);
+    #[event] fn Claim(pos_id: u64, to: ContractAddress, paid_shares: U256, in_assets: bool);
+    #[event] fn Close(pos_id: u64, refund_shares: U256, paid_net_shares: U256);
+    #[event] fn PokeTime(market_id: u64, meter: u8, new_I_q96: U256);
+    #[event] fn PokeHarvest(market_id: u64, meter: u8, harvest_shares: U256, new_I_q96: U256);
+    #[event] fn Expire(market_id: u64, meter: u8, pos_id: u64);
+
+    // -------- Internal math helpers (sketch) --------
+    fn q96_mul(a: U256, b: U256) -> U256 { /* ... */ }
+    fn q96_div(a: U256, b: U256) -> U256 { /* ... */ }
+    fn ceil_mul_q96(r: U256, s_q96: U256, dx_q96: U256) -> U256 { /* ceil( r * s * dx ) in shares */ }
+    fn floor_mul_q96(r: U256, s_q96: U256, dx_q96: U256) -> U256 { /* floor */ }
+    fn tick_of(x_q96: U256, tick_q96: U256) -> u128 { /* floor(x / tick) */ }
+
+    // -------- Constructor --------
+    #[constructor]
+    fn constructor(ref self: ContractState) {
+        self.next_market_id.write(1);
+        self.next_pos_id.write(1);
+    }
+
+    // -------- Market creation --------
+    #[external]
+    fn create_market(
+        ref self: ContractState,
+        m0_type: u8, m1_type: u8,
+        m0_adapter: ContractAddress, m1_adapter: ContractAddress,
+        m0_tick_q96: U256, m1_tick_q96: U256,
+        publisher: ContractAddress,
+        max_rate_credit0: U256, max_rate_credit1: U256
+    ) -> u64 {
+        assert(m0_type < 2, 'bad m0'); assert(m1_type < 2, 'bad m1');
+        let id = self.next_market_id.read();
+        self.next_market_id.write(id + 1);
+
+        self.m0_type.write(id, m0_type);
+        self.m1_type.write(id, m1_type);
+        self.m0_adapter.write(id, m0_adapter);
+        self.m1_adapter.write(id, m1_adapter);
+        self.m0_tick_q96.write(id, m0_tick_q96);
+        self.m1_tick_q96.write(id, m1_tick_q96);
+        self.publisher.write(id, publisher);
+        self.max_rate_credit0.write(id, max_rate_credit0);
+        self.max_rate_credit1.write(id, max_rate_credit1);
+
+        // init indices, sums, last anchors
+        self.m0_I_q96.write(id, U256::from(0));
+        self.m1_I_q96.write(id, U256::from(0));
+        self.m0_S_credit_q96.write(id, U256::from(0));
+        self.m1_S_credit_q96.write(id, U256::from(0));
+        self.m0_last_ts.write(id, 0_u64);
+        self.m1_last_ts.write(id, 0_u64);
+        self.m0_last_assets.write(id, 0_u128);
+        self.m1_last_assets.write(id, 0_u128);
+
+        MarketCreated(id, m0_type, m1_type, m0_adapter, m1_adapter);
+        id
+    }
+
+    // -------- Quote policy (publisher only) --------
+    #[external]
+    fn set_k_ref_per_sec(ref self: ContractState, market_id: u64, meter: u8, k_ref_per_sec_q96: U256) {
+        let caller = starknet::get_caller_address();
+        assert(self.publisher.read(market_id) == caller, 'not publisher');
+        if meter == 0_u8 {
+            self.m0_k_ref_per_sec_q96.write(market_id, k_ref_per_sec_q96);
+        } else { self.m1_k_ref_per_sec_q96.write(market_id, k_ref_per_sec_q96); }
+        QuoteUpdated(market_id, meter, k_ref_per_sec_q96);
+    }
+
+    // -------- Open position (on behalf; payer provides USDC approval) --------
+    #[external]
+    fn open_position_on_behalf(
+        ref self: ContractState,
+        market_id: u64,
+        owner: ContractAddress,
+        credit_side: u8,                           // 0 or 1
+        r: U256,
+        s0_q96: U256, s1_q96: U256,               // e.g., Time m in s_T, Harvest = 1e18 (Q96)
+        fund_assets: u128,                         // in USDC (assets)
+        payer: ContractAddress
+    ) -> u64 {
+        assert(credit_side < 2, 'bad side');
+        let debit_side: u8 = if credit_side == 0_u8 { 1_u8 } else { 0_u8 };
+
+        // Cap checks: Σ r*s_credit per meter
+        let s_credit_q96 = if credit_side == 0_u8 { s0_q96 } else { s1_q96 };
+        if credit_side == 0_u8 {
+            let new_sum = self.m0_S_credit_q96.read(market_id) + q96_mul(r, s_credit_q96);
+            assert(new_sum <= self.max_rate_credit0.read(market_id), 'cap m0');
+            self.m0_S_credit_q96.write(market_id, new_sum);
+        } else {
+            let new_sum = self.m1_S_credit_q96.read(market_id) + q96_mul(r, s_credit_q96);
+            assert(new_sum <= self.max_rate_credit1.read(market_id), 'cap m1');
+            self.m1_S_credit_q96.write(market_id, new_sum);
+        }
+
+        // Pull funding into **debit** adapter as shares
+        let debit_adapter = if debit_side == 0_u8 { self.m0_adapter.read(market_id) } else { self.m1_adapter.read(market_id) };
+        let funded = I4626Adapter::pull_deposit_from(ref debit_adapter, payer, fund_assets, starknet::contract_address());
+
+        // Snap checkpoints
+        let ck0 = self.m0_I_q96.read(market_id);
+        let ck1 = self.m1_I_q96.read(market_id);
+        let s_debit_q96 = if debit_side == 0_u8 { s0_q96 } else { s1_q96 };
+        let denom = q96_mul(r, s_debit_q96);
+        let add_q96 = q96_div(funded, denom);                  // funded / (r*s_debit)
+        let ck_debit = if debit_side == 0_u8 { ck0 } else { ck1 };
+        let stop_q96 = ck_debit + add_q96;
+
+        // Store position
+        let pos_id = self.next_pos_id.read();
+        self.next_pos_id.write(pos_id + 1);
+        self.pos_market.write(pos_id, market_id);
+        self.pos_owner.write(pos_id, owner);
+        self.pos_active.write(pos_id, true);
+        self.pos_credit_side.write(pos_id, credit_side);
+        self.pos_r.write(pos_id, r);
+        self.pos_s0_q96.write(pos_id, s0_q96);
+        self.pos_s1_q96.write(pos_id, s1_q96);
+        self.pos_fund_shares.write(pos_id, funded);
+        self.pos_ckpt0_q96.write(pos_id, ck0);
+        self.pos_ckpt1_q96.write(pos_id, ck1);
+        self.pos_stop_debit_q96.write(pos_id, stop_q96);
+        self.pos_net_shares.write(pos_id, U256::from(0));
+
+        // Bucket by debit meter
+        let tick_q96 = if debit_side == 0_u8 { self.m0_tick_q96.read(market_id) } else { self.m1_tick_q96.read(market_id) };
+        let tick = tick_of(stop_q96, tick_q96);
+        bucket_insert(ref self, market_id, debit_side, tick, pos_id);
+
+        Open(market_id, pos_id, owner, credit_side, r, s0_q96, s1_q96, funded);
+        pos_id
+    }
+
+    // -------- Pokes --------
+
+    // Permissionless — advances Time meter j (0 or 1) and expires debit=j
+    #[external]
+    fn poke_time(ref self: ContractState, market_id: u64, meter: u8, now: u64) {
+        assert(meter < 2, 'bad meter');
+        let m_type = if meter == 0_u8 { self.m0_type.read(market_id) } else { self.m1_type.read(market_id) };
+        assert(m_type == 0_u8, 'not a Time meter'); // 0=Time
+
+        let last = if meter == 0_u8 { self.m0_last_ts.read(market_id) } else { self.m1_last_ts.read(market_id) };
+        if now <= last { return; }
+        let dt = now - last;
+
+        // ΔI = convert_to_shares(K_ref_per_sec * dt)
+        let k_q96 = if meter == 0_u8 { self.m0_k_ref_per_sec_q96.read(market_id) } else { self.m1_k_ref_per_sec_q96.read(market_id) };
+        let assets_per_rate = q96_mul(k_q96, U256::from(dt.into()));
+        let adapter = if meter == 0_u8 { self.m0_adapter.read(market_id) } else { self.m1_adapter.read(market_id) };
+        let delta_shares = I4626Adapter::convert_to_shares(@adapter, q96_to_assets(assets_per_rate));
+        let add_q96 = q96_from_shares(delta_shares);
+
+        let new_I = if meter == 0_u8 { self.m0_I_q96.read(market_id) + add_q96 } else { self.m1_I_q96.read(market_id) + add_q96 };
+        if meter == 0_u8 { self.m0_I_q96.write(market_id, new_I); self.m0_last_ts.write(market_id, now); }
+        else { self.m1_I_q96.write(market_id, new_I); self.m1_last_ts.write(market_id, now); }
+
+        // Expire debit=meter up to new_I
+        expire_until(ref self, market_id, meter, new_I);
+
+        PokeTime(market_id, meter, new_I);
+    }
+
+    // Permissionless — advances Harvest meter j (0 or 1) and expires debit=j first
+    #[external]
+    fn poke_harvest(ref self: ContractState, market_id: u64, meter: u8) {
+        assert(meter < 2, 'bad meter');
+        let m_type = if meter == 0_u8 { self.m0_type.read(market_id) } else { self.m1_type.read(market_id) };
+        assert(m_type == 1_u8, 'not a Harvest meter'); // 1=Harvest
+
+        // Δassets, harvestShares
+        let adapter = if meter == 0_u8 { self.m0_adapter.read(market_id) } else { self.m1_adapter.read(market_id) };
+        let last_assets = if meter == 0_u8 { self.m0_last_assets.read(market_id) } else { self.m1_last_assets.read(market_id) };
+        let total = I4626Adapter::total_assets(@adapter);
+        let delta_assets: u128 = if total > last_assets { total - last_assets } else { 0_u128 };
+        if meter == 0_u8 { self.m0_last_assets.write(market_id, total); } else { self.m1_last_assets.write(market_id, total); }
+        if delta_assets == 0_u128 { return; }
+
+        let harvest_shares = I4626Adapter::convert_to_shares(@adapter, delta_assets);
+        let S_credit = if meter == 0_u8 { self.m0_S_credit_q96.read(market_id) } else { self.m1_S_credit_q96.read(market_id) };
+        // candidate index
+        let incr_q96 = if S_credit == U256::from(0) { U256::from(0) } else { q96_div(harvest_shares, S_credit) };
+        let cand = if meter == 0_u8 { self.m0_I_q96.read(market_id) + incr_q96 } else { self.m1_I_q96.read(market_id) + incr_q96 };
+
+        // 1) expire debit=meter using cand (prevents post-stop harvest)
+        expire_until(ref self, market_id, meter, cand);
+
+        // 2) set new index = cand
+        if meter == 0_u8 { self.m0_I_q96.write(market_id, cand); } else { self.m1_I_q96.write(market_id, cand); }
+
+        PokeHarvest(market_id, meter, harvest_shares, cand);
+    }
+
+    // -------- Claim / TopUp / ChangeRate / Close --------
+
+    #[external]
+    fn claim(ref self: ContractState, pos_id: u64, to: ContractAddress, in_assets: bool) {
+        settle_position_to_now(ref self, pos_id);
+        let net = self.pos_net_shares.read(pos_id);
+        if net == U256::from(0) { return; }
+        let (credit_adapter, _debit_adapter) = adapters_for_pos(self, pos_id);
+        // decrease claim then pay
+        self.pos_net_shares.write(pos_id, U256::from(0));
+        I4626Adapter::payout(ref credit_adapter, to, net, in_assets);
+        Claim(pos_id, to, net, in_assets);
+    }
+
+    #[external]
+    fn top_up(ref self: ContractState, pos_id: u64, payer: ContractAddress, assets: u128) {
+        let active = self.pos_active.read(pos_id);
+        assert(active, 'inactive');
+        settle_position_to_now(ref self, pos_id);
+        let market_id = self.pos_market.read(pos_id);
+        let credit_side = self.pos_credit_side.read(pos_id);
+        let debit_side: u8 = if credit_side == 0_u8 { 1_u8 } else { 0_u8 };
+        let debit_adapter = if debit_side == 0_u8 { self.m0_adapter.read(market_id) } else { self.m1_adapter.read(market_id) };
+        let added = I4626Adapter::pull_deposit_from(ref debit_adapter, payer, assets, starknet::contract_address());
+        let fund = self.pos_fund_shares.read(pos_id) + added;
+        self.pos_fund_shares.write(pos_id, fund);
+
+        // recompute stop & re-bucket
+        let r = self.pos_r.read(pos_id);
+        let s0 = self.pos_s0_q96.read(pos_id);
+        let s1 = self.pos_s1_q96.read(pos_id);
+        let ck_debit = if debit_side == 0_u8 { self.pos_ckpt0_q96.read(pos_id) } else { self.pos_ckpt1_q96.read(pos_id) };
+        let s_debit = if debit_side == 0_u8 { s0 } else { s1 };
+        let stop = ck_debit + q96_div(fund, q96_mul(r, s_debit));
+        self.pos_stop_debit_q96.write(pos_id, stop);
+        reinsert_bucket(ref self, pos_id, market_id, debit_side, stop);
+        TopUp(pos_id, added);
+    }
+
+    #[external]
+    fn change_rate(ref self: ContractState, pos_id: u64, new_r: U256) {
+        let active = self.pos_active.read(pos_id);
+        assert(active, 'inactive');
+        settle_position_to_now(ref self, pos_id);
+        let old_r = self.pos_r.read(pos_id);
+        self.pos_r.write(pos_id, new_r);
+
+        // update S_credit for the credited meter
+        let market_id = self.pos_market.read(pos_id);
+        let side = self.pos_credit_side.read(pos_id);
+        let s_credit = if side == 0_u8 { self.pos_s0_q96.read(pos_id) } else { self.pos_s1_q96.read(pos_id) };
+        if side == 0_u8 {
+            let sum = self.m0_S_credit_q96.read(market_id) - q96_mul(old_r, s_credit) + q96_mul(new_r, s_credit);
+            self.m0_S_credit_q96.write(market_id, sum);
+        } else {
+            let sum = self.m1_S_credit_q96.read(market_id) - q96_mul(old_r, s_credit) + q96_mul(new_r, s_credit);
+            self.m1_S_credit_q96.write(market_id, sum);
+        }
+
+        // recompute stop & re-bucket for the debit side
+        let debit_side: u8 = if side == 0_u8 { 1_u8 } else { 0_u8 };
+        let s_debit = if debit_side == 0_u8 { self.pos_s0_q96.read(pos_id) } else { self.pos_s1_q96.read(pos_id) };
+        let ck_debit = if debit_side == 0_u8 { self.pos_ckpt0_q96.read(pos_id) } else { self.pos_ckpt1_q96.read(pos_id) };
+        let fund = self.pos_fund_shares.read(pos_id);
+        let stop = ck_debit + q96_div(fund, q96_mul(new_r, s_debit));
+        self.pos_stop_debit_q96.write(pos_id, stop);
+        reinsert_bucket(ref self, pos_id, market_id, debit_side, stop);
+
+        ChangeRate(pos_id, old_r, new_r);
+    }
+
+    #[external]
+    fn close(ref self: ContractState, pos_id: u64, to: ContractAddress, in_assets: bool) {
+        settle_position_to_now(ref self, pos_id);
+        let active = self.pos_active.read(pos_id);
+        if !active { return; }
+
+        // refund unused fund_shares (debit token) and pay net_shares (credit token)
+        let market_id = self.pos_market.read(pos_id);
+        let side = self.pos_credit_side.read(pos_id);
+        let debit_side: u8 = if side == 0_u8 { 1_u8 } else { 0_u8 };
+        let debit_adapter = if debit_side == 0_u8 { self.m0_adapter.read(market_id) } else { self.m1_adapter.read(market_id) };
+        let credit_adapter = if side == 0_u8 { self.m0_adapter.read(market_id) } else { self.m1_adapter.read(market_id) };
+
+        let refund = self.pos_fund_shares.read(pos_id);
+        if refund > U256::from(0) { I4626Adapter::payout(ref debit_adapter, to, refund, in_assets); }
+        let net = self.pos_net_shares.read(pos_id);
+        if net > U256::from(0) { I4626Adapter::payout(ref credit_adapter, to, net, in_assets); }
+
+        // deactivate, clean sums & buckets
+        let r = self.pos_r.read(pos_id);
+        let s_credit = if side == 0_u8 { self.pos_s0_q96.read(pos_id) } else { self.pos_s1_q96.read(pos_id) };
+        if side == 0_u8 { self.m0_S_credit_q96.write(market_id, self.m0_S_credit_q96.read(market_id) - q96_mul(r, s_credit)); }
+        else { self.m1_S_credit_q96.write(market_id, self.m1_S_credit_q96.read(market_id) - q96_mul(r, s_credit)); }
+        unlink_from_bucket(ref self, pos_id, market_id, debit_side);
+
+        self.pos_active.write(pos_id, false);
+        self.pos_r.write(pos_id, U256::from(0));
+        self.pos_fund_shares.write(pos_id, U256::from(0));
+        self.pos_net_shares.write(pos_id, U256::from(0));
+
+        Close(pos_id, refund, net);
+    }
+
+    // -------- Internals: settle & expiry --------
+
+    fn settle_position_to_now(ref self: ContractState, pos_id: u64) {
+        let market_id = self.pos_market.read(pos_id);
+        let active = self.pos_active.read(pos_id);
+        if !active { return; }
+
+        let side = self.pos_credit_side.read(pos_id);
+        let debit_side: u8 = if side == 0_u8 { 1_u8 } else { 0_u8 };
+        let r = self.pos_r.read(pos_id);
+        let s0 = self.pos_s0_q96.read(pos_id);
+        let s1 = self.pos_s1_q96.read(pos_id);
+
+        // Current indices
+        let I0 = self.m0_I_q96.read(market_id);
+        let I1 = self.m1_I_q96.read(market_id);
+
+        // Credit leg
+        let (ck_credit, s_credit, I_credit) = if side == 0_u8 {
+            (self.pos_ckpt0_q96.read(pos_id), s0, I0)
+        } else { (self.pos_ckpt1_q96.read(pos_id), s1, I1) };
+        let d_credit = if I_credit > ck_credit { I_credit - ck_credit } else { U256::from(0) };
+        let credit_shares = floor_mul_q96(r, s_credit, d_credit);
+
+        // Debit leg (respect stop)
+        let (ck_debit, s_debit, I_debit, stop) = if debit_side == 0_u8 {
+            (self.pos_ckpt0_q96.read(pos_id), s0, I0, self.pos_stop_debit_q96.read(pos_id))
+        } else {
+            (self.pos_ckpt1_q96.read(pos_id), s1, I1, self.pos_stop_debit_q96.read(pos_id))
+        };
+        let capped = if I_debit > stop { stop } else { I_debit };
+        let d_debit = if capped > ck_debit { capped - ck_debit } else { U256::from(0) };
+        let debit_shares = ceil_mul_q96(r, s_debit, d_debit);
+
+        // Apply
+        if credit_shares > U256::from(0) {
+            let net = self.pos_net_shares.read(pos_id) + credit_shares;
+            self.pos_net_shares.write(pos_id, net);
+        }
+        if debit_shares > U256::from(0) {
+            let fund = self.pos_fund_shares.read(pos_id);
+            let new_fund = if fund > debit_shares { fund - debit_shares } else { U256::from(0) };
+            self.pos_fund_shares.write(pos_id, new_fund);
+        }
+
+        // Update checkpoints
+        if side == 0_u8 { self.pos_ckpt0_q96.write(pos_id, I0); } else { self.pos_ckpt1_q96.write(pos_id, I1); }
+        if debit_side == 0_u8 { self.pos_ckpt0_q96.write(pos_id, capped); } else { self.pos_ckpt1_q96.write(pos_id, capped); }
+
+        // If crossed stop => expire
+        if I_debit >= stop {
+            expire_position_finalize(ref self, pos_id, market_id, debit_side);
+        }
+    }
+
+    fn expire_until(ref self: ContractState, market_id: u64, meter: u8, up_to_q96: U256) {
+        // Iterate crossed ticks only
+        let tick_q96 = if meter == 0_u8 { self.m0_tick_q96.read(market_id) } else { self.m1_tick_q96.read(market_id) };
+        let mut tick = /* last processed tick for this market/meter, or recompute from state */ tick_of(up_to_q96, tick_q96);
+        loop {
+            let head = if meter == 0_u8 { self.m0_bucket_head.read((market_id, tick)) } else { self.m1_bucket_head.read((market_id, tick)) };
+            if head == 0_u64 { break; }
+            // consume linked list at this tick
+            let mut cur = head;
+            while cur != 0_u64 {
+                let next = self.bucket_next.read(cur);
+                // settle to cut-off (stop) and finalize
+                settle_position_to_cutoff(ref self, cur, up_to_q96, meter);
+                cur = next;
+            }
+            // advance to previous tick; stopping criterion depends on stored current tick pointer (maintain per market if you wish)
+            // For brevity, assume we clear this tick and break
+            if meter == 0_u8 { self.m0_bucket_head.write((market_id, tick), 0_u64); }
+            else { self.m1_bucket_head.write((market_id, tick), 0_u64); }
+            break;
+        }
+    }
+
+    fn settle_position_to_cutoff(ref self: ContractState, pos_id: u64, cutoff_q96: U256, meter: u8) {
+        // settle both legs; on debit=meter cap index at 'cutoff_q96'
+        let market_id = self.pos_market.read(pos_id);
+        let side = self.pos_credit_side.read(pos_id);
+        let debit_side: u8 = if side == 0_u8 { 1_u8 } else { 0_u8 };
+
+        // current indices with cap
+        let I0 = if meter == 0_u8 { cutoff_q96 } else { self.m0_I_q96.read(market_id) };
+        let I1 = if meter == 1_u8 { cutoff_q96 } else { self.m1_I_q96.read(market_id) };
+
+        // Reuse settle logic but using capped I for the debit meter
+        // (For brevity, call a variant or inline simplified computation)
+        // ...
+        // After applying, finalize
+        expire_position_finalize(ref self, pos_id, market_id, meter);
+    }
+
+    fn expire_position_finalize(ref self: ContractState, pos_id: u64, market_id: u64, debit_side: u8) {
+        // Remove from buckets & sums; zero rate; mark inactive
+        unlink_from_bucket(ref self, pos_id, market_id, debit_side);
+
+        // remove from credited meter sum
+        let credit_side = self.pos_credit_side.read(pos_id);
+        let r = self.pos_r.read(pos_id);
+        let s_credit = if credit_side == 0_u8 { self.pos_s0_q96.read(pos_id) } else { self.pos_s1_q96.read(pos_id) };
+        if credit_side == 0_u8 {
+            self.m0_S_credit_q96.write(market_id, self.m0_S_credit_q96.read(market_id) - q96_mul(r, s_credit));
+        } else {
+            self.m1_S_credit_q96.write(market_id, self.m1_S_credit_q96.read(market_id) - q96_mul(r, s_credit));
+        }
+
+        self.pos_active.write(pos_id, false);
+        self.pos_r.write(pos_id, U256::from(0));
+        Expire(market_id, debit_side, pos_id);
+    }
+
+    // -------- Bucket helpers (sketch) --------
+    fn bucket_insert(ref self: ContractState, market_id: u64, meter: u8, tick: u128, pos_id: u64) {
+        let head = if meter == 0_u8 { self.m0_bucket_head.read((market_id, tick)) } else { self.m1_bucket_head.read((market_id, tick)) };
+        self.bucket_next.write(pos_id, head);
+        if meter == 0_u8 { self.m0_bucket_head.write((market_id, tick), pos_id); }
+        else { self.m1_bucket_head.write((market_id, tick), pos_id); }
+    }
+    fn reinsert_bucket(ref self: ContractState, pos_id: u64, market_id: u64, meter: u8, stop_q96: U256) {
+        unlink_from_bucket(ref self, pos_id, market_id, meter);
+        let tick_q96 = if meter == 0_u8 { self.m0_tick_q96.read(market_id) } else { self.m1_tick_q96.read(market_id) };
+        let tick = tick_of(stop_q96, tick_q96);
+        bucket_insert(ref self, market_id, meter, tick, pos_id);
+    }
+    fn unlink_from_bucket(ref self: ContractState, pos_id: u64, market_id: u64, meter: u8) {
+        // For brevity: maintain a prev pointer or do lazy unlink by flags;
+        // production: store (meter,tick) per pos and a doubly-linked list.
+    }
+
+    // -------- Small utils --------
+    fn adapters_for_pos(self: @ContractState, pos_id: u64) -> (ContractAddress, ContractAddress) {
+        let market_id = self.pos_market.read(pos_id);
+        let side = self.pos_credit_side.read(pos_id);
+        let debit_side: u8 = if side == 0_u8 { 1_u8 } else { 0_u8 };
+        let credit_adapter = if side == 0_u8 { self.m0_adapter.read(market_id) } else { self.m1_adapter.read(market_id) };
+        let debit_adapter = if debit_side == 0_u8 { self.m0_adapter.read(market_id) } else { self.m1_adapter.read(market_id) };
+        (credit_adapter, debit_adapter)
+    }
+
+    // --- Placeholder conversions between assets<->Q96 (implement from your lib) ---
+    fn q96_from_shares(sh: U256) -> U256 { sh }       // if you model shares in Q96 units 1:1
+    fn q96_to_assets(x: U256) -> u128 { /* ... */ 0_u128 }
+}
+```
+
+## 4. How this maps to your MM layer
+
+Your market-maker sets `K_user` (bid/ask around an EMA anchor) and calls `open_position_on_behalf(...)` with:
+
+- `credit_side` (e.g., `0 = Harvest`, `1 = Time`),
+- `s0_q96 = 1` (for Harvest), `s1_q96 = m = K_user / K_ref` (for Time), and
+- `fund_assets` pulled from the user (they approve your MM or the adapter).
+
+You can also have the MM periodically call `set_k_ref_per_sec` on the market it manages.
+
+Anyone (including you) can call pokes; users can claim at any time; closes always succeed; opens are gated only by caps.
+
+## 5. Defaults & guardrails
+
+- Tick sizes: start ~`1e-9 shares/rate (Q96)` per meter; profile and adjust.
+- Caps: set conservative `max_rate_credit*`; add optional imbalance cap (`Σ credit(T) vs Σ debit(T)` in shares/sec).
+- Rounding: floor credits, ceil debits from funded pots.
+- No arrears: stops enforce that a position never consumes beyond its funded pot.
+- Cross-asset: use `create_market(Harvest(adapterA), Harvest(adapterB), ...)`. Claims and refunds are per-token; USDC conversion at the edge via `payout(..., in_assets=true)`.
+
+If you want, I can now fill the math helpers and the bucket unlink (doubly-linked lists), plus a small `Mock4626 + Adapter` and a reference test suite covering:
+
+- conservation on Harvest (`Σ credits == harvestShares`),
+- precise stop behavior on both meters,
+- early close (refund + P&L),
+- cap/imbalance checks, and
+- open-on-behalf flow with user approvals.
+
+## 4. Market-making vault integration
+
+### 4.1 Design highlights
+
+- The paired ERC-4626 vault (USDCMMVault4626) never pays fixed. It continuously warehouses harvest inventory (in vault-share tokens) and sells that inventory to fund its own pay-harvest legs when quoting receive-fixed users.
+- User deposits into the vault remain fully invested. The vault only redeems harvest inventory (never principal) to provide the controller with the `fund_assets` liquidity required for harvest pots.
+- Simple quoting: anchor on an EMA of realized harvest, plus a utilization-based spread. The vault exposes preview helpers so pay-fixed users can see duration/stop information before matching.
+- For the default deployment the IRS market is assumed to have meter 0 = Harvest and meter 1 = Time. Swap the constants if your wiring differs.
+
+### 4.2 Contract skeleton (USDCMMVault4626)
+
+The Cairo `USDCMMVault4626` contract is a production-shaped scaffold that:
+
+1. Implements ERC-20 + ERC-4626 semantics for USDC deposits and share accounting.
+2. Holds harvest inventory via the same adapter as the IRS controller meters.
+3. Quotes and matches pay-fixed users by opening the user VAR leg and a vault FIX counter-leg atomically.
+4. Guarantees the vault never pays fixed: the vault only opens FIX (receive fixed / pay harvest) positions for itself.
+5. Provides inventory management helpers (redeem harvest inventory to assets, claim FIX proceeds back into inventory).
+
+Key flow for `open_user_pay_fixed_and_vault_fix`:
+
+1. User VAR leg: open on-behalf with `credit=Harvest`, `debit=Time`, funded by the user’s USDC.
+2. Compute a symmetric harvest funding target for the vault’s FIX leg by mirroring the user’s duration (`stop` on the Time meter).
+3. Redeem harvest inventory shares to USDC (respecting a caller-provided cap) and open the vault FIX leg with `credit=Time`, `debit=Harvest`.
+4. Track the vault’s FIX positions so the vault can periodically `claim_vault_fix_to_inventory` and recycle harvest inventory.
+
+### 4.3 Wiring & usage checklist
+
+- Deploy one vault per IRS market and wire it with the same adapter + controller addresses used by the market.
+- Users deposit USDC to receive vault shares, then call `open_user_pay_fixed_and_vault_fix` with their exposure and scalar.
+- The vault redeems harvest inventory (never principal) to fund its pay-harvest obligations, ensuring no arrears on the controller.
+- Keepers periodically claim FIX proceeds back into inventory and adjust quoting parameters via `set_quote_params`.
+- Replace the placeholder Q96 math helpers with your fixed-point library, add access control around quoting parameters, and integrate your EMA/utilization policy to compute user scalars.

--- a/packages/snfoundry/contracts/src/irs_controller.cairo
+++ b/packages/snfoundry/contracts/src/irs_controller.cairo
@@ -1,0 +1,20 @@
+pub mod controller;
+pub mod adapters {
+    pub mod erc4626_adapter;
+}
+pub mod logic {
+    pub mod openings;
+    pub mod settlement;
+}
+pub mod math {
+    pub mod q96;
+}
+pub mod state {
+    pub mod buckets;
+    pub mod meters;
+    pub mod position;
+}
+pub mod types {
+    pub mod meter_index;
+    pub mod units;
+}

--- a/packages/snfoundry/contracts/src/irs_controller/adapters/erc4626_adapter.cairo
+++ b/packages/snfoundry/contracts/src/irs_controller/adapters/erc4626_adapter.cairo
@@ -1,0 +1,9 @@
+use starknet::ContractAddress;
+use crate::irs_controller::types::units::{Assets, Shares};
+
+#[starknet::interface]
+pub trait I4626Adapter<TContractState> {
+    fn asset(self: @TContractState) -> ContractAddress;
+    fn shares_token(self: @TContractState) -> ContractAddress;
+    fn convert_to_shares(self: @TContractState, assets: Assets) -> Shares;
+}

--- a/packages/snfoundry/contracts/src/irs_controller/controller.cairo
+++ b/packages/snfoundry/contracts/src/irs_controller/controller.cairo
@@ -1,0 +1,52 @@
+#[starknet::contract]
+mod IRSController {
+    use starknet::storage::{
+        Map, StorageMapReadAccess, StorageMapWriteAccess, StoragePointerReadAccess,
+        StoragePointerWriteAccess,
+    };
+    use starknet::{get_caller_address, ContractAddress};
+
+    use crate::irs_controller::math::q96;
+    use crate::irs_controller::types::units::{Q96, Shares};
+
+    #[storage]
+    struct Storage {
+        next_position_id: u64,
+        quote_publisher_address: ContractAddress,
+        credit_cap_by_meter: Map<u8, Q96>,
+        credit_usage_by_meter: Map<u8, Q96>,
+    }
+
+    #[constructor]
+    fn constructor(ref self: ContractState, publisher: ContractAddress) {
+        self.next_position_id.write(1);
+        self.quote_publisher_address.write(publisher);
+    }
+
+    #[external(v0)]
+    fn configure_credit_cap(ref self: ContractState, meter: u8, cap: Q96) {
+        let caller = get_caller_address();
+        assert(caller == self.quote_publisher_address.read(), 'not-authorized');
+        self.credit_cap_by_meter.write(meter, cap);
+    }
+
+    #[external(v0)]
+    fn open_position(
+        ref self: ContractState,
+        owner: ContractAddress,
+        meter: u8,
+        exposure: Q96,
+        funded_shares: Shares,
+    ) -> u64 {
+        let usage = self.credit_usage_by_meter.read(meter);
+        let _cap = self.credit_cap_by_meter.read(meter);
+        let new_usage = q96::add(usage, exposure);
+
+        self.credit_usage_by_meter.write(meter, new_usage);
+        let id = self.next_position_id.read();
+        self.next_position_id.write(id + 1);
+
+        let _ = (owner, funded_shares);
+        id
+    }
+}

--- a/packages/snfoundry/contracts/src/irs_controller/logic/openings.cairo
+++ b/packages/snfoundry/contracts/src/irs_controller/logic/openings.cairo
@@ -1,0 +1,14 @@
+use starknet::ContractAddress;
+use crate::irs_controller::types::units::{Q96, Shares, Assets};
+
+#[derive(Copy, Drop, Serde)]
+pub struct OpenPositionRequest {
+    pub owner: ContractAddress,
+    pub credit_meter: u8,
+    pub exposure: Q96,
+    pub prepaid_assets: Assets,
+}
+
+pub fn estimate_stop_index(current_index: Q96, funded_shares: Shares) -> Q96 {
+    current_index + funded_shares
+}

--- a/packages/snfoundry/contracts/src/irs_controller/logic/settlement.cairo
+++ b/packages/snfoundry/contracts/src/irs_controller/logic/settlement.cairo
@@ -1,0 +1,11 @@
+use crate::irs_controller::types::units::{Q96, Shares};
+
+#[derive(Copy, Drop, Serde)]
+pub struct SettlementOutcome {
+    pub new_credit_checkpoint: Q96,
+    pub credit_delta: Shares,
+}
+
+pub fn settle_to_index(current_index: Q96, accrued: Shares) -> SettlementOutcome {
+    SettlementOutcome { new_credit_checkpoint: current_index, credit_delta: accrued }
+}

--- a/packages/snfoundry/contracts/src/irs_controller/math/q96.cairo
+++ b/packages/snfoundry/contracts/src/irs_controller/math/q96.cairo
@@ -1,0 +1,9 @@
+use crate::irs_controller::types::units::{Q96, Shares};
+
+pub fn add(lhs: Q96, rhs: Q96) -> Q96 {
+    lhs + rhs
+}
+
+pub fn scale_shares(rate: Q96, scalar: Q96) -> Shares {
+    rate * scalar
+}

--- a/packages/snfoundry/contracts/src/irs_controller/state/buckets.cairo
+++ b/packages/snfoundry/contracts/src/irs_controller/state/buckets.cairo
@@ -1,0 +1,9 @@
+#[derive(Copy, Drop, Serde)]
+pub struct BucketEntry {
+    pub position_id: u64,
+    pub meter: u8,
+}
+
+pub fn attach(position_id: u64, meter: u8) -> BucketEntry {
+    BucketEntry { position_id, meter }
+}

--- a/packages/snfoundry/contracts/src/irs_controller/state/meters.cairo
+++ b/packages/snfoundry/contracts/src/irs_controller/state/meters.cairo
@@ -1,0 +1,15 @@
+use crate::irs_controller::types::units::{Q96, Shares, Assets};
+
+#[derive(Copy, Drop, Serde)]
+pub enum MeterType {
+    Time: (),
+    Harvest: (),
+}
+
+pub fn compute_time_increment(_last: u64, _now: u64, _rate: Q96) -> Q96 {
+    0
+}
+
+pub fn compute_harvest_shares(_before: Assets, _after: Assets) -> Shares {
+    0
+}

--- a/packages/snfoundry/contracts/src/irs_controller/state/position.cairo
+++ b/packages/snfoundry/contracts/src/irs_controller/state/position.cairo
@@ -1,0 +1,9 @@
+use starknet::ContractAddress;
+use crate::irs_controller::types::units::{Q96, Shares};
+
+pub struct Position {
+    pub owner: ContractAddress,
+    pub credit_meter: u8,
+    pub exposure: Q96,
+    pub funded_shares: Shares,
+}

--- a/packages/snfoundry/contracts/src/irs_controller/types/meter_index.cairo
+++ b/packages/snfoundry/contracts/src/irs_controller/types/meter_index.cairo
@@ -1,0 +1,12 @@
+#[derive(Copy, Drop, Serde, PartialEq)]
+pub enum MeterIndex {
+    M0: (),
+    M1: (),
+}
+
+pub fn opposite(index: MeterIndex) -> MeterIndex {
+    match index {
+        MeterIndex::M0(()) => MeterIndex::M1(()),
+        MeterIndex::M1(()) => MeterIndex::M0(()),
+    }
+}

--- a/packages/snfoundry/contracts/src/irs_controller/types/units.cairo
+++ b/packages/snfoundry/contracts/src/irs_controller/types/units.cairo
@@ -1,0 +1,15 @@
+pub type Q96 = felt252;
+pub type Shares = felt252;
+pub type Assets = u128;
+
+pub fn q96_zero() -> Q96 {
+    0
+}
+
+pub fn shares_zero() -> Shares {
+    0
+}
+
+pub fn assets_zero() -> Assets {
+    0
+}

--- a/packages/snfoundry/contracts/src/lib.cairo
+++ b/packages/snfoundry/contracts/src/lib.cairo
@@ -1,13 +1,15 @@
+pub mod irs_controller;
+pub mod usdc_mm_vault_4626;
 pub mod interfaces {
     pub mod IGateway;
+    pub mod nostra;
     pub mod vesu;
     pub mod vesu_data;
-    pub mod nostra;
 }
 pub mod gateways {
-    pub mod vesu_gateway;
     pub mod NostraGateway;
     pub mod RouterGateway;
+    pub mod vesu_gateway;
 }
 
 pub mod utils {

--- a/packages/snfoundry/contracts/src/usdc_mm_vault_4626.cairo
+++ b/packages/snfoundry/contracts/src/usdc_mm_vault_4626.cairo
@@ -1,0 +1,444 @@
+// Cairo 1.x — ERC4626-compatible Market Making Vault for USDC
+// - Accepts USDC and mints vault shares (ERC4626).
+// - Market-makes against a single IRSControllerSingle market (two meters).
+// - Never pays fixed: vault only opens FIX (receive fixed / pay harvest) positions.
+// - Uses ONLY its harvested share inventory to fund its pay-harvest pots (can redeem inventory to USDC to satisfy controller's fund_assets input).
+// - Matches users who want VAR (pay fixed / receive harvest) by opening user's VAR on-behalf + a vault FIX counterposition.
+//
+// Assumed meter mapping for the bound IRS market (edit if yours differs):
+//   METER_INDEX_0 = Harvest meter (debit for FIX)
+//   METER_INDEX_1 = Time    meter (credit for FIX)
+//
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[starknet::contract]
+mod USDCMMVault4626 {
+    use starknet::ContractAddress;
+    use core::integer::u256::U256;
+    use core::traits::TryInto;
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // External interfaces (match your deployed IRS + Adapter ABIs)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    #[starknet::interface]
+    trait IUSDC<T> {
+        fn decimals(self: @T) -> u8;
+        fn balance_of(self: @T, owner: ContractAddress) -> u128;
+        fn transfer_from(ref self: T, from: ContractAddress, to: ContractAddress, value: u128);
+        fn transfer(ref self: T, to: ContractAddress, value: u128);
+        fn approve(ref self: T, spender: ContractAddress, value: u128);
+    }
+
+    #[starknet::interface]
+    trait IShareToken<T> {
+        fn balance_of(self: @T, owner: ContractAddress) -> U256;
+        fn transfer(ref self: T, to: ContractAddress, amount: U256);
+        fn approve(ref self: T, spender: ContractAddress, amount: U256);
+    }
+
+    // The same Adapter interface used in the controller
+    #[starknet::interface]
+    trait I4626Adapter<T> {
+        fn asset(self: @T) -> ContractAddress;                          // USDC
+        fn shares_token(self: @T) -> ContractAddress;                   // Vault share token (ERC20-like)
+        fn total_assets(self: @T) -> u128;
+        fn convert_to_shares(self: @T, assets_amount: u128) -> U256;
+        fn convert_to_assets(self: @T, shares_amount: U256) -> u128;
+        fn pull_deposit_from(ref self: T, payer: ContractAddress, assets_amount: u128, receiver: ContractAddress) -> U256;
+        fn payout(ref self: T, to: ContractAddress, shares_amount: U256, redeem_in_assets: bool);
+    }
+
+    // Single-market IRS controller interface (subset)
+    #[starknet::interface]
+    trait IIRSControllerSingle<T> {
+        // For vault FIX (receive fixed / pay harvest): credit_meter_index = TIME(1), debit_meter_index = HARVEST(0)
+        // For user VAR   (receive harvest / pay fixed): credit_meter_index = HARVEST(0), debit_meter_index = TIME(1)
+        fn open_position_on_behalf(
+            ref self: T,
+            owner_address: ContractAddress,
+            credit_meter_index: u8,
+            exposure_rate: U256,
+            meter0_scalar_q96: U256,   // s for meter 0 (Harvest)
+            meter1_scalar_q96: U256,   // s for meter 1 (Time)
+            prepay_assets_usdc: u128,
+            funding_payer_address: ContractAddress
+        ) -> u64;
+
+        fn claim(
+            ref self: T,
+            pos_id: u64,
+            to: ContractAddress,
+            in_assets: bool
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Constants / Conventions
+    // ─────────────────────────────────────────────────────────────────────────
+
+    const METER_INDEX_HARVEST: u8 = 0;
+    const METER_INDEX_TIME: u8 = 1;
+
+    // Q96 ONE (fixed-point) — plug from your math lib
+    const Q96_ONE: U256 = U256::from(0x1000000000000000000000000);
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Storage (ERC20 + ERC4626 + MM state)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    #[storage]
+    struct Storage {
+        // ===== ERC20 (vault shares) =====
+        name: felt252,
+        symbol: felt252,
+        decimals: u8,                 // Vault share decimals (recommend 18)
+        total_supply: U256,
+        balances: LegacyMap<ContractAddress, U256>,
+        allowances: LegacyMap<(ContractAddress, ContractAddress), U256>,
+
+        // ===== ERC4626 config =====
+        usdc_asset: ContractAddress,              // underlying asset (USDC)
+        adapter: ContractAddress,                 // same adapter as IRS market meters
+        controller: ContractAddress,              // IRS controller (single market)
+        share_token_of_adapter: ContractAddress,  // the ERC20 share token of the adapter's vault (to hold harvest inventory)
+
+        // ===== Vault AUM bookkeeping =====
+        // We keep TVL in raw USDC to compute shares <-> assets conversions.
+        total_assets_usdc: u128,                  // tracked USDC AUM (principal + realized P&L in assets when realized)
+
+        // ===== Quoting & utilization =====
+        utilization_target_bps: u16,      // e.g., 7000 = 70%
+        base_spread_bps_per_year: u16,    // e.g., 10 bps/y baseline
+        eip1559_tick_bps_per_day: u16,    // nudges spread vs utilization target
+        max_spread_bps_per_year: u16,     // cap, e.g., 25 bps/y
+
+        // EMA (anchor) of realized harvest, in assets per (rate·second) as Q96 (matches controller unit)
+        ema_harvest_assets_per_rate_per_second_q96: U256,
+
+        // Track vault’s FIX positions (so we can claim / manage)
+        next_internal_position_id: u64,
+        internal_fix_positions: LegacyMap<u64, u64>,  // local_id -> controller_pos_id
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Events
+    // ─────────────────────────────────────────────────────────────────────────
+
+    #[event] fn Deposit(caller: ContractAddress, receiver: ContractAddress, assets_usdc: u128, shares: U256);
+    #[event] fn Withdraw(caller: ContractAddress, receiver: ContractAddress, owner: ContractAddress, assets_usdc: u128, shares: U256);
+    #[event] fn MMOpenPayFixed(user: ContractAddress, exposure_rate: U256, meter0_scalar_q96: U256, meter1_scalar_q96: U256, user_controller_pos_id: u64, vault_controller_pos_id: u64);
+    #[event] fn InventoryRedeemedToAssets(amount_shares: U256, assets_out_usdc: u128);
+    #[event] fn ClaimedToInventory(controller_pos_id: u64, shares_received: U256);
+    #[event] fn QuoteParamsUpdated(util_target_bps: u16, base_spread_bps_y: u16, tick_bps_day: u16, max_spread_bps_y: u16);
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Internal math helpers (wire your real Q96 math here)
+    // ─────────────────────────────────────────────────────────────────────────
+    fn q96_mul(a: U256, b: U256) -> U256 {
+        // TODO:  (a * b) >> 96 with overflow checks
+        a + b // placeholder
+    }
+    fn q96_div(a: U256, b: U256) -> U256 {
+        // TODO:  (a << 96) / b with overflow checks
+        if b == U256::from(0) { U256::from(0) } else { a }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // ERC20 (vault share token) — minimal implementation
+    // ─────────────────────────────────────────────────────────────────────────
+
+    #[event] fn Transfer(from: ContractAddress, to: ContractAddress, value: U256);
+    #[event] fn Approval(owner: ContractAddress, spender: ContractAddress, value: U256);
+
+    #[external]
+    fn name(self: @ContractState) -> felt252 { self.name.read() }
+
+    #[external]
+    fn symbol(self: @ContractState) -> felt252 { self.symbol.read() }
+
+    #[external]
+    fn decimals(self: @ContractState) -> u8 { self.decimals.read() }
+
+    #[external]
+    fn total_supply(self: @ContractState) -> U256 { self.total_supply.read() }
+
+    #[external]
+    fn balance_of(self: @ContractState, owner: ContractAddress) -> U256 { self.balances.read(owner) }
+
+    #[external]
+    fn allowance(self: @ContractState, owner: ContractAddress, spender: ContractAddress) -> U256 {
+        self.allowances.read((owner, spender))
+    }
+
+    #[external]
+    fn approve(ref self: ContractState, spender: ContractAddress, value: U256) -> bool {
+        let owner = starknet::get_caller_address();
+        self.allowances.write((owner, spender), value);
+        Approval(owner, spender, value);
+        true
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // ERC4626 view functions
+    // ─────────────────────────────────────────────────────────────────────────
+
+    #[external]
+    fn asset(self: @ContractState) -> ContractAddress { self.usdc_asset.read() }
+
+    #[external]
+    fn total_assets(self: @ContractState) -> u128 { self.total_assets_usdc.read() }
+
+    fn convert_to_shares_internal(self: @ContractState, assets_usdc: u128) -> U256 {
+        let supply = self.total_supply.read();
+        let tvl = self.total_assets_usdc.read();
+        if supply == U256::from(0) || tvl == 0_u128 {
+            return U256::from(assets_usdc);
+        }
+        U256::from(assets_usdc) * supply / U256::from(tvl)
+    }
+
+    fn convert_to_assets_internal(self: @ContractState, shares: U256) -> u128 {
+        let supply = self.total_supply.read();
+        let tvl = self.total_assets_usdc.read();
+        if supply == U256::from(0) {
+            return 0_u128;
+        }
+        let num = shares * U256::from(tvl);
+        num.try_into().unwrap_or(0_u128)
+    }
+
+    #[external]
+    fn preview_deposit(self: @ContractState, assets_usdc: u128) -> U256 { self.convert_to_shares_internal(assets_usdc) }
+
+    #[external]
+    fn preview_mint(self: @ContractState, shares: U256) -> u128 { self.convert_to_assets_internal(shares) }
+
+    #[external]
+    fn preview_withdraw(self: @ContractState, assets_usdc: u128) -> U256 { self.convert_to_shares_internal(assets_usdc) }
+
+    #[external]
+    fn preview_redeem(self: @ContractState, shares: U256) -> u128 { self.convert_to_assets_internal(shares) }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // ERC4626 mutating functions
+    // ─────────────────────────────────────────────────────────────────────────
+
+    #[external]
+    fn deposit(ref self: ContractState, assets_usdc: u128, receiver: ContractAddress) -> U256 {
+        let usdc = self.usdc_asset.read();
+        let caller = starknet::get_caller_address();
+        IUSDC::transfer_from(ref usdc, caller, starknet::contract_address(), assets_usdc);
+
+        let shares = self.convert_to_shares_internal(assets_usdc);
+        let prev = self.balances.read(receiver);
+        self.balances.write(receiver, prev + shares);
+        self.total_supply.write(self.total_supply.read() + shares);
+
+        self.total_assets_usdc.write(self.total_assets_usdc.read() + assets_usdc);
+
+        Deposit(caller, receiver, assets_usdc, shares);
+        shares
+    }
+
+    #[external]
+    fn mint(ref self: ContractState, shares: U256, receiver: ContractAddress) -> u128 {
+        let assets = self.convert_to_assets_internal(shares);
+        let usdc = self.usdc_asset.read();
+        let caller = starknet::get_caller_address();
+        IUSDC::transfer_from(ref usdc, caller, starknet::contract_address(), assets);
+
+        self.balances.write(receiver, self.balances.read(receiver) + shares);
+        self.total_supply.write(self.total_supply.read() + shares);
+        self.total_assets_usdc.write(self.total_assets_usdc.read() + assets);
+
+        Deposit(caller, receiver, assets, shares);
+        assets
+    }
+
+    #[external]
+    fn withdraw(ref self: ContractState, assets_usdc: u128, receiver: ContractAddress, owner: ContractAddress) -> U256 {
+        let shares = self.convert_to_shares_internal(assets_usdc);
+        self.burn_from(owner, shares);
+
+        let usdc = self.usdc_asset.read();
+        IUSDC::transfer(ref usdc, receiver, assets_usdc);
+
+        self.total_assets_usdc.write(self.total_assets_usdc.read() - assets_usdc);
+
+        Withdraw(starknet::get_caller_address(), receiver, owner, assets_usdc, shares);
+        shares
+    }
+
+    #[external]
+    fn redeem(ref self: ContractState, shares: U256, receiver: ContractAddress, owner: ContractAddress) -> u128 {
+        let assets = self.convert_to_assets_internal(shares);
+        self.burn_from(owner, shares);
+
+        let usdc = self.usdc_asset.read();
+        IUSDC::transfer(ref usdc, receiver, assets);
+
+        self.total_assets_usdc.write(self.total_assets_usdc.read() - assets);
+
+        Withdraw(starknet::get_caller_address(), receiver, owner, assets, shares);
+        assets
+    }
+
+    fn burn_from(ref self: ContractState, owner: ContractAddress, shares: U256) {
+        let caller = starknet::get_caller_address();
+        if caller != owner {
+            let allowed = self.allowances.read((owner, caller));
+            assert(allowed >= shares, 'insufficient allowance');
+            self.allowances.write((owner, caller), allowed - shares);
+        }
+        let bal = self.balances.read(owner);
+        assert(bal >= shares, 'insufficient shares');
+        self.balances.write(owner, bal - shares);
+        self.total_supply.write(self.total_supply.read() - shares);
+        let zero_address = ContractAddress::from_felt252(0);
+        Transfer(owner, zero_address, shares);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Market making: quoting & matching
+    // ─────────────────────────────────────────────────────────────────────────
+
+    fn current_inventory_shares(self: @ContractState) -> U256 {
+        let share_token = self.share_token_of_adapter.read();
+        IShareToken::balance_of(@share_token, starknet::contract_address())
+    }
+
+    #[external]
+    fn set_quote_params(
+        ref self: ContractState,
+        utilization_target_bps: u16,
+        base_spread_bps_per_year: u16,
+        eip1559_tick_bps_per_day: u16,
+        max_spread_bps_per_year: u16
+    ) {
+        self.utilization_target_bps.write(utilization_target_bps);
+        self.base_spread_bps_per_year.write(base_spread_bps_per_year);
+        self.eip1559_tick_bps_per_day.write(eip1559_tick_bps_per_day);
+        self.max_spread_bps_per_year.write(max_spread_bps_per_year);
+        QuoteParamsUpdated(utilization_target_bps, base_spread_bps_per_year, eip1559_tick_bps_per_day, max_spread_bps_per_year);
+    }
+
+    #[external]
+    fn preview_open_user_pay_fixed(
+        self: @ContractState,
+        exposure_rate: U256,
+        m_user_q96: U256,
+        user_prepay_assets_usdc: u128
+    ) -> (U256, U256) {
+        let adapter = self.adapter.read();
+        let funded_fixed_shares = I4626Adapter::convert_to_shares(@adapter, user_prepay_assets_usdc);
+        let denom_q96 = q96_mul(exposure_rate, m_user_q96);
+        let time_delta_index_q96 = q96_div(funded_fixed_shares, denom_q96);
+
+        let required_harvest_fund_shares = q96_mul(exposure_rate, time_delta_index_q96);
+        (time_delta_index_q96, required_harvest_fund_shares)
+    }
+
+    #[external]
+    fn open_user_pay_fixed_and_vault_fix(
+        ref self: ContractState,
+        user_address: ContractAddress,
+        exposure_rate: U256,
+        m_user_q96: U256,
+        user_prepay_assets_usdc: u128,
+        max_inventory_shares_to_consume: U256
+    ) {
+        let controller = self.controller.read();
+        let adapter = self.adapter.read();
+        let share_token = self.share_token_of_adapter.read();
+
+        let user_pos_id = IIRSControllerSingle::open_position_on_behalf(
+            ref controller,
+            user_address,
+            METER_INDEX_HARVEST,
+            exposure_rate,
+            Q96_ONE,
+            m_user_q96,
+            user_prepay_assets_usdc,
+            user_address
+        );
+
+        let funded_fixed_shares = I4626Adapter::convert_to_shares(@adapter, user_prepay_assets_usdc);
+        let denom_q96 = q96_mul(exposure_rate, m_user_q96);
+        let time_delta_index_q96 = q96_div(funded_fixed_shares, denom_q96);
+
+        let required_harvest_fund_shares = q96_mul(exposure_rate, time_delta_index_q96);
+        let current_inventory = IShareToken::balance_of(@share_token, starknet::contract_address());
+        assert(current_inventory >= required_harvest_fund_shares, 'insufficient harvest inventory');
+        assert(required_harvest_fund_shares <= max_inventory_shares_to_consume, 'inventory slippage');
+
+        I4626Adapter::payout(ref adapter, starknet::contract_address(), required_harvest_fund_shares, true);
+        let assets_from_inventory: u128 = I4626Adapter::convert_to_assets(@adapter, required_harvest_fund_shares);
+        InventoryRedeemedToAssets(required_harvest_fund_shares, assets_from_inventory);
+
+        let vault_pos_id = IIRSControllerSingle::open_position_on_behalf(
+            ref controller,
+            starknet::contract_address(),
+            METER_INDEX_TIME,
+            exposure_rate,
+            Q96_ONE,
+            m_user_q96,
+            assets_from_inventory,
+            starknet::contract_address()
+        );
+
+        let local_id = self.next_internal_position_id.read();
+        self.next_internal_position_id.write(local_id + 1);
+        self.internal_fix_positions.write(local_id, vault_pos_id);
+
+        MMOpenPayFixed(user_address, exposure_rate, Q96_ONE, m_user_q96, user_pos_id, vault_pos_id);
+    }
+
+    #[external]
+    fn claim_vault_fix_to_inventory(ref self: ContractState, local_internal_id: u64) {
+        let controller = self.controller.read();
+        let pos_id = self.internal_fix_positions.read(local_internal_id);
+        assert(pos_id != 0_u64, 'unknown pos');
+
+        IIRSControllerSingle::claim(ref controller, pos_id, starknet::contract_address(), false);
+
+        let share_token = self.share_token_of_adapter.read();
+        let bal = IShareToken::balance_of(@share_token, starknet::contract_address());
+        ClaimedToInventory(pos_id, bal);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Admin / wiring
+    // ─────────────────────────────────────────────────────────────────────────
+
+    #[constructor]
+    fn constructor(
+        ref self: ContractState,
+        name: felt252,
+        symbol: felt252,
+        decimals: u8,
+        usdc_asset: ContractAddress,
+        adapter: ContractAddress,
+        controller: ContractAddress
+    ) {
+        self.name.write(name);
+        self.symbol.write(symbol);
+        self.decimals.write(decimals);
+        self.usdc_asset.write(usdc_asset);
+        self.adapter.write(adapter);
+        self.controller.write(controller);
+
+        let share_token = I4626Adapter::shares_token(@adapter);
+        self.share_token_of_adapter.write(share_token);
+
+        self.total_assets_usdc.write(0_u128);
+        self.next_internal_position_id.write(1_u64);
+
+        self.utilization_target_bps.write(7000_u16);
+        self.base_spread_bps_per_year.write(10_u16);
+        self.eip1559_tick_bps_per_day.write(2_u16);
+        self.max_spread_bps_per_year.write(25_u16);
+
+        self.ema_harvest_assets_per_rate_per_second_q96.write(U256::from(0));
+    }
+}


### PR DESCRIPTION
## Summary
- document the market-making vault integration flow alongside the IRS controller package
- add a Cairo `USDCMMVault4626` contract skeleton that handles ERC-4626 accounting and market-making hooks
- expose the new vault module from the contracts library for downstream consumers

## Testing
- `scarb build` *(fails: command not found in devcontainer)*

------
https://chatgpt.com/codex/tasks/task_e_68d545cad5d883208739029d69a16371