### PR TITLE
Fix vesu context serialization for v1 and v2

### DIFF
--- a/packages/nextjs/components/ProtocolView.tsx
+++ b/packages/nextjs/components/ProtocolView.tsx
@@ -12,7 +12,7 @@ import { FiAlertTriangle, FiPlus } from "react-icons/fi";
 import formatPercentage from "~~/utils/formatPercentage";
 import { calculateNetYieldMetrics } from "~~/utils/netYield";
 import { PositionManager } from "~~/utils/position";
-import type { VesuContext } from "~~/hooks/useLendingAction";
+import type { VesuContext } from "~~/utils/vesu";
 
 export interface ProtocolPosition {
   icon: string;

--- a/packages/nextjs/components/modals/stark/BaseTokenModal.tsx
+++ b/packages/nextjs/components/modals/stark/BaseTokenModal.tsx
@@ -3,12 +3,9 @@ import Image from "next/image";
 import { useReadContract } from "@starknet-react/core";
 import { FiAlertTriangle, FiArrowRight, FiCheck, FiDollarSign } from "react-icons/fi";
 import {
-  BigNumberish,
   BlockNumber,
   ByteArray,
   CairoCustomEnum,
-  CairoOption,
-  CairoOptionVariant,
   CallData,
   RpcProvider,
   byteArray,
@@ -44,7 +41,8 @@ export interface TokenInfo {
   usdPrice?: number;
 }
 
-import type { VesuContext } from "~~/hooks/useLendingAction";
+import type { VesuContext } from "~~/utils/vesu";
+import { buildVesuContextOption } from "~~/utils/vesu";
 
 // Different action types supported
 export type TokenActionType = "borrow" | "deposit" | "repay" | "withdraw";
@@ -134,23 +132,7 @@ export const BaseTokenModal: FC<BaseTokenModalProps> = ({
     const parsedAmount = parseUnits(adjustedAmount, Number(decimals));
     const lowerProtocolName = protocolName.toLowerCase();
 
-    let context = new CairoOption<BigNumberish[]>(CairoOptionVariant.None);
-    if (vesuContext) {
-      // Handle both V1 and V2 VesuContext formats
-      if ('poolId' in vesuContext) {
-        // V1 format: { poolId: bigint, counterpartToken: string }
-        context = new CairoOption<BigNumberish[]>(CairoOptionVariant.Some, [
-          vesuContext.poolId,
-          vesuContext.counterpartToken,
-        ]);
-      } else if ('poolAddress' in vesuContext) {
-        // V2 format: { poolAddress: string, positionCounterpartToken: string }
-        context = new CairoOption<BigNumberish[]>(CairoOptionVariant.Some, [
-          BigInt(vesuContext.poolAddress),
-          vesuContext.positionCounterpartToken,
-        ]);
-      }
-    }
+    const context = buildVesuContextOption(vesuContext);
 
     // Create the appropriate lending instruction based on action type
     let lendingInstruction;

--- a/packages/nextjs/components/modals/stark/BorrowModalStark.tsx
+++ b/packages/nextjs/components/modals/stark/BorrowModalStark.tsx
@@ -1,6 +1,7 @@
 import { FC } from "react";
 import { TokenActionModal, TokenInfo } from "../TokenActionModal";
-import { VesuContext, useLendingAction } from "~~/hooks/useLendingAction";
+import { useLendingAction } from "~~/hooks/useLendingAction";
+import type { VesuContext } from "~~/utils/vesu";
 import { useTokenBalance } from "~~/hooks/useTokenBalance";
 import { PositionManager } from "~~/utils/position";
 

--- a/packages/nextjs/components/modals/stark/DepositModalStark.tsx
+++ b/packages/nextjs/components/modals/stark/DepositModalStark.tsx
@@ -1,6 +1,7 @@
 import { FC } from "react";
 import { TokenActionModal, TokenInfo } from "../TokenActionModal";
-import { VesuContext, useLendingAction } from "~~/hooks/useLendingAction";
+import { useLendingAction } from "~~/hooks/useLendingAction";
+import type { VesuContext } from "~~/utils/vesu";
 import { useTokenBalance } from "~~/hooks/useTokenBalance";
 import { PositionManager } from "~~/utils/position";
 

--- a/packages/nextjs/components/modals/stark/RepayModalStark.tsx
+++ b/packages/nextjs/components/modals/stark/RepayModalStark.tsx
@@ -1,7 +1,8 @@
 import { FC } from "react";
 import { TokenActionModal, TokenInfo } from "../TokenActionModal";
 import { formatUnits } from "viem";
-import { VesuContext, useLendingAction } from "~~/hooks/useLendingAction";
+import { useLendingAction } from "~~/hooks/useLendingAction";
+import type { VesuContext } from "~~/utils/vesu";
 import { useTokenBalance } from "~~/hooks/useTokenBalance";
 import { PositionManager } from "~~/utils/position";
 

--- a/packages/nextjs/components/modals/stark/TokenSelectModalStark.tsx
+++ b/packages/nextjs/components/modals/stark/TokenSelectModalStark.tsx
@@ -3,7 +3,7 @@ import Image from "next/image";
 import { BorrowModalStark } from "./BorrowModalStark";
 import { DepositModalStark } from "./DepositModalStark";
 import { tokenNameToLogo } from "~~/contracts/externalContracts";
-import { VesuContext } from "~~/hooks/useLendingAction";
+import type { VesuContext } from "~~/utils/vesu";
 import formatPercentage from "~~/utils/formatPercentage";
 import { getDisplayRate } from "~~/utils/protocol";
 import { PositionManager } from "~~/utils/position";

--- a/packages/nextjs/components/modals/stark/WithdrawModalStark.tsx
+++ b/packages/nextjs/components/modals/stark/WithdrawModalStark.tsx
@@ -1,7 +1,8 @@
 import { FC } from "react";
 import { TokenActionModal, TokenInfo } from "../TokenActionModal";
 import { formatUnits } from "viem";
-import { VesuContext, useLendingAction } from "~~/hooks/useLendingAction";
+import { useLendingAction } from "~~/hooks/useLendingAction";
+import type { VesuContext } from "~~/utils/vesu";
 import { PositionManager } from "~~/utils/position";
 
 interface WithdrawModalStarkProps {

--- a/packages/nextjs/components/specific/vesu/VesuProtocolView.tsx
+++ b/packages/nextjs/components/specific/vesu/VesuProtocolView.tsx
@@ -2,7 +2,7 @@ import { FC, useEffect, useMemo, useState } from "react";
 
 import { TokenSelectModalStark } from "~~/components/modals/stark/TokenSelectModalStark";
 import { useAccount } from "~~/hooks/useAccount";
-import type { VesuContext } from "~~/hooks/useLendingAction";
+import type { VesuContext } from "~~/utils/vesu";
 import { useVesuLendingPositions } from "~~/hooks/useVesuLendingPositions";
 import { useVesuV2LendingPositions } from "~~/hooks/useVesuV2LendingPositions";
 import type { AssetWithRates } from "~~/hooks/useVesuAssets";

--- a/packages/nextjs/hooks/useLendingAction.ts
+++ b/packages/nextjs/hooks/useLendingAction.ts
@@ -1,15 +1,6 @@
 import type { Network } from "./useTokenBalance";
 import { useTokenBalance } from "./useTokenBalance";
-import {
-  CairoCustomEnum,
-  CairoOption,
-  CairoOptionVariant,
-  CallData,
-  Contract,
-  num,
-  uint256,
-  Call,
-} from "starknet";
+import { CairoCustomEnum, CallData, Contract, num, uint256, Call } from "starknet";
 import { parseUnits } from "viem";
 import { useAccount as useEvmAccount } from "wagmi";
 import { useScaffoldWriteContract as useEvmWrite } from "~~/hooks/scaffold-eth";
@@ -22,17 +13,7 @@ import { notification } from "~~/utils/scaffold-stark";
 
 export type Action = "Borrow" | "Deposit" | "Withdraw" | "Repay";
 
-export interface VesuContextV1 {
-  poolId: bigint;
-  counterpartToken: string;
-}
-
-export interface VesuContextV2 {
-  poolAddress: string;
-  positionCounterpartToken: string;
-}
-
-export type VesuContext = VesuContextV1 | VesuContextV2;
+import { buildVesuContextOption, type VesuContext } from "~~/utils/vesu";
 
 export const useLendingAction = (
   network: Network,
@@ -80,10 +61,7 @@ export const useLendingAction = (
         amount: uint256.bnToUint256(parsedAmount),
         user: starkAddress,
       };
-      let context = new CairoOption(CairoOptionVariant.None);
-      if (vesuContext) {
-        context = new CairoOption(CairoOptionVariant.Some, [vesuContext.poolId, vesuContext.counterpartToken]);
-      }
+      const context = buildVesuContextOption(vesuContext);
       let lendingInstruction;
       switch (action) {
         case "Deposit":

--- a/packages/nextjs/hooks/useVesuLendingPositions.ts
+++ b/packages/nextjs/hooks/useVesuLendingPositions.ts
@@ -3,7 +3,7 @@ import { formatUnits } from "viem";
 
 import type { ProtocolPosition } from "~~/components/ProtocolView";
 import type { CollateralWithAmount } from "~~/components/specific/collateral/CollateralSelector";
-import type { VesuContext } from "~~/hooks/useLendingAction";
+import type { VesuContext } from "~~/utils/vesu";
 import { tokenNameToLogo } from "~~/contracts/externalContracts";
 import { useScaffoldReadContract } from "~~/hooks/scaffold-stark";
 import { useVesuAssets } from "~~/hooks/useVesuAssets";

--- a/packages/nextjs/hooks/useVesuV2LendingPositions.ts
+++ b/packages/nextjs/hooks/useVesuV2LendingPositions.ts
@@ -7,7 +7,7 @@ import type { AssetWithRates } from "~~/hooks/useVesuAssets";
 import type { VesuPositionRow } from "~~/hooks/useVesuLendingPositions";
 import { feltToString } from "~~/utils/protocols";
 import { tokenNameToLogo } from "~~/contracts/externalContracts";
-import type { VesuContextV2 } from "./useLendingAction";
+import type { VesuContextV2 } from "~~/utils/vesu";
 
 const normalizePrice = (price: { value: bigint; is_valid: boolean }) => (price.is_valid ? price.value / 10n ** 10n : 0n);
 

--- a/packages/nextjs/utils/vesu.ts
+++ b/packages/nextjs/utils/vesu.ts
@@ -1,0 +1,42 @@
+import { CairoOption, CairoOptionVariant, type BigNumberish } from "starknet";
+
+export interface VesuContextV1 {
+  poolId: bigint;
+  counterpartToken: string;
+}
+
+export interface VesuContextV2 {
+  poolAddress: string;
+  positionCounterpartToken: string;
+}
+
+export type VesuContext = VesuContextV1 | VesuContextV2;
+
+export const isVesuContextV1 = (context: VesuContext): context is VesuContextV1 =>
+  "poolId" in context;
+
+export const isVesuContextV2 = (context: VesuContext): context is VesuContextV2 =>
+  "poolAddress" in context;
+
+const toBigNumberish = (value: string | bigint): BigNumberish =>
+  typeof value === "bigint" ? value : BigInt(value);
+
+export const buildVesuContextOption = (
+  context?: VesuContext,
+): CairoOption<BigNumberish[]> => {
+  if (!context) {
+    return new CairoOption<BigNumberish[]>(CairoOptionVariant.None);
+  }
+
+  if (isVesuContextV2(context)) {
+    return new CairoOption<BigNumberish[]>(CairoOptionVariant.Some, [
+      toBigNumberish(context.poolAddress),
+      toBigNumberish(context.positionCounterpartToken),
+    ]);
+  }
+
+  return new CairoOption<BigNumberish[]>(CairoOptionVariant.Some, [
+    context.poolId,
+    toBigNumberish(context.counterpartToken),
+  ]);
+};


### PR DESCRIPTION
## Summary
- centralize vesu context type definitions and serialization utilities
- update Starknet lending flows to use the shared helper so Vesu v1 and v2 contexts are encoded correctly

## Testing
- yarn next:lint

------
https://chatgpt.com/codex/tasks/task_e_68e12f600f00832089b470de2cae0ef9