### PR TITLE
Harmonize Vesu Starknet contexts across versions

### DIFF
--- a/packages/nextjs/components/ProtocolView.tsx
+++ b/packages/nextjs/components/ProtocolView.tsx
@@ -12,7 +12,7 @@ import { FiAlertTriangle, FiPlus } from "react-icons/fi";
 import formatPercentage from "~~/utils/formatPercentage";
 import { calculateNetYieldMetrics } from "~~/utils/netYield";
 import { PositionManager } from "~~/utils/position";
-import type { VesuContext } from "~~/hooks/useLendingAction";
+import type { VesuContext } from "~~/utils/vesu";
 
 export interface ProtocolPosition {
   icon: string;

--- a/packages/nextjs/components/modals/stark/BaseTokenModal.tsx
+++ b/packages/nextjs/components/modals/stark/BaseTokenModal.tsx
@@ -3,12 +3,9 @@ import Image from "next/image";
 import { useReadContract } from "@starknet-react/core";
 import { FiAlertTriangle, FiArrowRight, FiCheck, FiDollarSign } from "react-icons/fi";
 import {
-  BigNumberish,
   BlockNumber,
   ByteArray,
   CairoCustomEnum,
-  CairoOption,
-  CairoOptionVariant,
   CallData,
   RpcProvider,
   byteArray,
@@ -44,7 +41,8 @@ export interface TokenInfo {
   usdPrice?: number;
 }
 
-import type { VesuContext } from "~~/hooks/useLendingAction";
+import type { VesuContext } from "~~/utils/vesu";
+import { buildVesuContextOption } from "~~/utils/vesu";
 
 // Different action types supported
 export type TokenActionType = "borrow" | "deposit" | "repay" | "withdraw";
@@ -134,23 +132,7 @@ export const BaseTokenModal: FC<BaseTokenModalProps> = ({
     const parsedAmount = parseUnits(adjustedAmount, Number(decimals));
     const lowerProtocolName = protocolName.toLowerCase();
 
-    let context = new CairoOption<BigNumberish[]>(CairoOptionVariant.None);
-    if (vesuContext) {
-      // Handle both V1 and V2 VesuContext formats
-      if ('poolId' in vesuContext) {
-        // V1 format: { poolId: bigint, counterpartToken: string }
-        context = new CairoOption<BigNumberish[]>(CairoOptionVariant.Some, [
-          vesuContext.poolId,
-          vesuContext.counterpartToken,
-        ]);
-      } else if ('poolAddress' in vesuContext) {
-        // V2 format: { poolAddress: string, positionCounterpartToken: string }
-        context = new CairoOption<BigNumberish[]>(CairoOptionVariant.Some, [
-          BigInt(vesuContext.poolAddress),
-          vesuContext.positionCounterpartToken,
-        ]);
-      }
-    }
+    const context = buildVesuContextOption(vesuContext);
 
     // Create the appropriate lending instruction based on action type
     let lendingInstruction;

--- a/packages/nextjs/components/modals/stark/BorrowModalStark.tsx
+++ b/packages/nextjs/components/modals/stark/BorrowModalStark.tsx
@@ -1,6 +1,7 @@
 import { FC } from "react";
 import { TokenActionModal, TokenInfo } from "../TokenActionModal";
-import { VesuContext, useLendingAction } from "~~/hooks/useLendingAction";
+import { useLendingAction } from "~~/hooks/useLendingAction";
+import type { VesuContext } from "~~/utils/vesu";
 import { useTokenBalance } from "~~/hooks/useTokenBalance";
 import { PositionManager } from "~~/utils/position";
 

--- a/packages/nextjs/components/modals/stark/DepositModalStark.tsx
+++ b/packages/nextjs/components/modals/stark/DepositModalStark.tsx
@@ -1,6 +1,7 @@
 import { FC } from "react";
 import { TokenActionModal, TokenInfo } from "../TokenActionModal";
-import { VesuContext, useLendingAction } from "~~/hooks/useLendingAction";
+import { useLendingAction } from "~~/hooks/useLendingAction";
+import type { VesuContext } from "~~/utils/vesu";
 import { useTokenBalance } from "~~/hooks/useTokenBalance";
 import { PositionManager } from "~~/utils/position";
 

--- a/packages/nextjs/components/modals/stark/RepayModalStark.tsx
+++ b/packages/nextjs/components/modals/stark/RepayModalStark.tsx
@@ -1,7 +1,8 @@
 import { FC } from "react";
 import { TokenActionModal, TokenInfo } from "../TokenActionModal";
 import { formatUnits } from "viem";
-import { VesuContext, useLendingAction } from "~~/hooks/useLendingAction";
+import { useLendingAction } from "~~/hooks/useLendingAction";
+import type { VesuContext } from "~~/utils/vesu";
 import { useTokenBalance } from "~~/hooks/useTokenBalance";
 import { PositionManager } from "~~/utils/position";
 

--- a/packages/nextjs/components/modals/stark/SwitchCollateralModalStark.tsx
+++ b/packages/nextjs/components/modals/stark/SwitchCollateralModalStark.tsx
@@ -8,13 +8,15 @@ import { useScaffoldMultiWriteContract } from "~~/hooks/scaffold-stark";
 import { notification } from "~~/utils/scaffold-stark";
 import { formatTokenAmount } from "~~/utils/protocols";
 import { useVesuSwitch } from "~~/hooks/useVesuSwitch";
+import type { VesuProtocolKey } from "~~/utils/vesu";
 
 type BasicToken = { name: string; address: string; decimals: number; icon: string };
 
 interface SwitchCollateralModalProps {
   isOpen: boolean;
   onClose: () => void;
-  poolId: bigint;
+  poolKey: string;
+  protocolKey: VesuProtocolKey;
   currentCollateral: BasicToken; // withdraw this
   targetCollateral: BasicToken; // deposit this
   debtToken: BasicToken; // debt context remains the same
@@ -22,7 +24,17 @@ interface SwitchCollateralModalProps {
   debtBalance: bigint;
 }
 
-export const SwitchCollateralModalStark: FC<SwitchCollateralModalProps> = ({ isOpen, onClose, poolId, currentCollateral, targetCollateral, debtToken, collateralBalance, debtBalance }) => {
+export const SwitchCollateralModalStark: FC<SwitchCollateralModalProps> = ({
+  isOpen,
+  onClose,
+  poolKey,
+  protocolKey,
+  currentCollateral,
+  targetCollateral,
+  debtToken,
+  collateralBalance,
+  debtBalance,
+}) => {
   const { address } = useStarkAccount();
   const [submitting, setSubmitting] = useState(false);
   const [preparedOnce, setPreparedOnce] = useState(false);
@@ -35,7 +47,8 @@ export const SwitchCollateralModalStark: FC<SwitchCollateralModalProps> = ({ isO
     targetToken: targetCollateral,
     collateralBalance,
     debtBalance,
-    poolId,
+    poolKey,
+    protocolKey,
   });
 
   if (!preparedOnce && selectedQuote && calls.length > 0) {
@@ -62,6 +75,11 @@ export const SwitchCollateralModalStark: FC<SwitchCollateralModalProps> = ({ isO
   return (
     <BaseModal isOpen={isOpen} onClose={onClose} maxWidthClass="max-w-md" boxClassName="rounded-none p-4">
       <div className="space-y-3">
+        {error && (
+          <div className="alert alert-error bg-error/10 text-error text-xs">
+            {error}
+          </div>
+        )}
         {!selectedQuote ? (
           <div className="mt-2 text-xs text-gray-500">Fetching quote...</div>
         ) : (

--- a/packages/nextjs/components/modals/stark/SwitchDebtModalStark.tsx
+++ b/packages/nextjs/components/modals/stark/SwitchDebtModalStark.tsx
@@ -8,13 +8,15 @@ import { useScaffoldMultiWriteContract } from "~~/hooks/scaffold-stark";
 import { notification } from "~~/utils/scaffold-stark";
 import { formatTokenAmount } from "~~/utils/protocols";
 import { useVesuSwitch } from "~~/hooks/useVesuSwitch";
+import type { VesuProtocolKey } from "~~/utils/vesu";
 
 type BasicToken = { name: string; address: string; decimals: number; icon: string };
 
 interface SwitchDebtModalProps {
   isOpen: boolean;
   onClose: () => void;
-  poolId: bigint;
+  poolKey: string;
+  protocolKey: VesuProtocolKey;
   collateral: BasicToken; // unchanged collateral
   currentDebt: BasicToken; // old debt to repay
   targetDebt: BasicToken; // new debt to borrow
@@ -22,11 +24,21 @@ interface SwitchDebtModalProps {
   collateralBalance: bigint; // to withdraw/redeposit fully
 }
 
-export const SwitchDebtModalStark: FC<SwitchDebtModalProps> = ({ isOpen, onClose, poolId, collateral, currentDebt, targetDebt, debtBalance, collateralBalance }) => {
+export const SwitchDebtModalStark: FC<SwitchDebtModalProps> = ({
+  isOpen,
+  onClose,
+  poolKey,
+  protocolKey,
+  collateral,
+  currentDebt,
+  targetDebt,
+  debtBalance,
+  collateralBalance,
+}) => {
   const { address } = useStarkAccount();
   const [submitting, setSubmitting] = useState(false);
   const [preparedOnce, setPreparedOnce] = useState(false);
-  const { loading, selectedQuote, swapSummary, calls } = useVesuSwitch({
+  const { loading, error, selectedQuote, swapSummary, calls } = useVesuSwitch({
     isOpen,
     type: "debt",
     address,
@@ -35,7 +47,8 @@ export const SwitchDebtModalStark: FC<SwitchDebtModalProps> = ({ isOpen, onClose
     targetToken: targetDebt,
     collateralBalance,
     debtBalance,
-    poolId,
+    poolKey,
+    protocolKey,
   });
 
   // Mark prepared after first successful build
@@ -63,6 +76,11 @@ export const SwitchDebtModalStark: FC<SwitchDebtModalProps> = ({ isOpen, onClose
   return (
     <BaseModal isOpen={isOpen} onClose={onClose} maxWidthClass="max-w-md" boxClassName="rounded-none p-4">
       <div className="space-y-3">
+        {error && (
+          <div className="alert alert-error bg-error/10 text-error text-xs">
+            {error}
+          </div>
+        )}
         {!selectedQuote ? (
           <div className="mt-2 text-xs text-gray-500">Fetching quote...</div>
         ) : (

--- a/packages/nextjs/components/modals/stark/TokenSelectModalStark.tsx
+++ b/packages/nextjs/components/modals/stark/TokenSelectModalStark.tsx
@@ -3,7 +3,7 @@ import Image from "next/image";
 import { BorrowModalStark } from "./BorrowModalStark";
 import { DepositModalStark } from "./DepositModalStark";
 import { tokenNameToLogo } from "~~/contracts/externalContracts";
-import { VesuContext } from "~~/hooks/useLendingAction";
+import type { VesuContext } from "~~/utils/vesu";
 import formatPercentage from "~~/utils/formatPercentage";
 import { getDisplayRate } from "~~/utils/protocol";
 import { PositionManager } from "~~/utils/position";

--- a/packages/nextjs/components/modals/stark/WithdrawModalStark.tsx
+++ b/packages/nextjs/components/modals/stark/WithdrawModalStark.tsx
@@ -1,7 +1,8 @@
 import { FC } from "react";
 import { TokenActionModal, TokenInfo } from "../TokenActionModal";
 import { formatUnits } from "viem";
-import { VesuContext, useLendingAction } from "~~/hooks/useLendingAction";
+import { useLendingAction } from "~~/hooks/useLendingAction";
+import type { VesuContext } from "~~/utils/vesu";
 import { PositionManager } from "~~/utils/position";
 
 interface WithdrawModalStarkProps {

--- a/packages/nextjs/components/specific/vesu/VesuPosition.tsx
+++ b/packages/nextjs/components/specific/vesu/VesuPosition.tsx
@@ -11,6 +11,7 @@ import { tokenNameToLogo } from "~~/contracts/externalContracts";
 import formatPercentage from "~~/utils/formatPercentage";
 import { PositionManager } from "~~/utils/position";
 import { TokenMetadata, feltToString, formatTokenAmount } from "~~/utils/protocols";
+import { createVesuContextV1 } from "~~/utils/vesu";
 
 // Constants
 const YEAR_IN_SECONDS = 31536000; // 365 days
@@ -332,7 +333,7 @@ export const VesuPosition: FC<VesuPositionProps> = ({
               decimals: Number(collateralMetadata.decimals),
             }}
             protocolName="Vesu"
-            vesuContext={nominalDebt !== "0" ? { poolId, counterpartToken: debtAsset } : undefined}
+            vesuContext={nominalDebt !== "0" ? createVesuContextV1(poolId, debtAsset) : undefined}
             position={position}
           />
 
@@ -349,7 +350,7 @@ export const VesuPosition: FC<VesuPositionProps> = ({
             }}
             protocolName="Vesu"
             supplyBalance={BigInt(collateralAmount)}
-            vesuContext={{ poolId, counterpartToken: debtAsset }}
+            vesuContext={createVesuContextV1(poolId, debtAsset)}
             position={position}
           />
 
@@ -359,7 +360,7 @@ export const VesuPosition: FC<VesuPositionProps> = ({
             tokens={tokensWithRates}
             protocolName="Vesu"
             collateralAsset={collateralAsset}
-            vesuContext={{ poolId, counterpartToken: collateralAsset }}
+            vesuContext={createVesuContextV1(poolId, collateralAsset)}
             position={position}
           />
 
@@ -378,7 +379,7 @@ export const VesuPosition: FC<VesuPositionProps> = ({
                 }}
                 protocolName="Vesu"
                 currentDebt={debtNum}
-                vesuContext={{ poolId, counterpartToken: collateralAsset }}
+                vesuContext={createVesuContextV1(poolId, collateralAsset)}
                 position={position}
               />
 
@@ -395,7 +396,7 @@ export const VesuPosition: FC<VesuPositionProps> = ({
                 }}
                 protocolName="Vesu"
                 debtBalance={BigInt(nominalDebt)}
-                vesuContext={{ poolId, counterpartToken: collateralAsset }}
+                vesuContext={createVesuContextV1(poolId, collateralAsset)}
                 position={position}
               />
 

--- a/packages/nextjs/components/specific/vesu/VesuPositionsSection.tsx
+++ b/packages/nextjs/components/specific/vesu/VesuPositionsSection.tsx
@@ -14,6 +14,7 @@ import { SwitchDebtModalStark } from "~~/components/modals/stark/SwitchDebtModal
 import { SwitchCollateralModalStark } from "~~/components/modals/stark/SwitchCollateralModalStark";
 import { feltToString } from "~~/utils/protocols";
 import { tokenNameToLogo } from "~~/contracts/externalContracts";
+import { isVesuContextV1, type VesuProtocolKey } from "~~/utils/vesu";
 
 interface BorrowSelectionRequest {
   tokens: AssetWithRates[];
@@ -52,7 +53,8 @@ export const VesuPositionsSection: FC<VesuPositionsSectionProps> = ({
         debt: { name: string; address: string; decimals: number; icon: string };
         collateralBalance: bigint;
         debtBalance: bigint;
-        poolId: bigint;
+        poolKey: string;
+        protocolKey: VesuProtocolKey;
       }
     | null
   >(null);
@@ -74,7 +76,8 @@ export const VesuPositionsSection: FC<VesuPositionsSectionProps> = ({
       },
       collateralBalance: row.supply.tokenBalance,
       debtBalance: row.borrow.tokenBalance,
-      poolId: row.borrowContext.poolId,
+      poolKey: row.poolKey,
+      protocolKey: row.protocolKey,
     });
     setIsCloseModalOpen(true);
   };
@@ -100,6 +103,7 @@ export const VesuPositionsSection: FC<VesuPositionsSectionProps> = ({
   }, [selectedTarget]);
 
   const openSwapSelector = (type: "debt" | "collateral", row: VesuPositionRow) => {
+    if (!row.borrowContext) return;
     setSwapType(type);
     setSwapRow(row);
     setSelectedTarget(null);
@@ -177,6 +181,8 @@ export const VesuPositionsSection: FC<VesuPositionsSectionProps> = ({
         asset => `0x${asset.address.toString(16).padStart(64, "0")}` !== row.supply.tokenAddress,
       );
       const canInitiateBorrow = !row.hasDebt && Boolean(row.borrowContext) && availableBorrowTokens.length > 0;
+      const borrowPoolContext = row.borrowContext;
+      const supportsPoolDependentActions = Boolean(borrowPoolContext);
       const borrowButtonDisabled = row.supply.actionsDisabled;
 
       const handleBorrowFromSupply = (event: MouseEvent<HTMLButtonElement>) => {
@@ -201,8 +207,8 @@ export const VesuPositionsSection: FC<VesuPositionsSectionProps> = ({
               disableMove
               subtitle={row.isVtoken ? "vToken" : undefined}
               containerClassName="rounded-none"
-              availableActions={{ deposit: true, withdraw: true, move: false, swap: true }}
-              onSwap={() => openSwapSelector("collateral", row)}
+              availableActions={{ deposit: true, withdraw: true, move: false, swap: supportsPoolDependentActions }}
+              onSwap={supportsPoolDependentActions ? () => openSwapSelector("collateral", row) : undefined}
               controlledExpanded={!!expandedRows[row.key]}
               onToggleExpanded={() => toggleRowExpanded(row.key)}
             />
@@ -213,10 +219,20 @@ export const VesuPositionsSection: FC<VesuPositionsSectionProps> = ({
                 networkType="starknet"
                 position={positionManager}
                 containerClassName="rounded-none"
-                availableActions={row.hasDebt ? { borrow: true, repay: true, move: true, close: true, swap: true } : { borrow: true, repay: false, move: false, swap: false, close: false }}
+                availableActions={
+                  row.hasDebt
+                    ? {
+                        borrow: true,
+                        repay: true,
+                        move: supportsPoolDependentActions,
+                        close: supportsPoolDependentActions,
+                        swap: supportsPoolDependentActions,
+                      }
+                    : { borrow: true, repay: false, move: false, swap: false, close: false }
+                }
                 showNoDebtLabel={!row.hasDebt}
-                onClosePosition={row.hasDebt ? () => openCloseForRow(row) : undefined}
-                onSwap={row.hasDebt ? () => openSwapSelector("debt", row) : undefined}
+                onClosePosition={row.hasDebt && supportsPoolDependentActions ? () => openCloseForRow(row) : undefined}
+                onSwap={row.hasDebt && supportsPoolDependentActions ? () => openSwapSelector("debt", row) : undefined}
                 controlledExpanded={!!expandedRows[row.key]}
                 onToggleExpanded={() => toggleRowExpanded(row.key)}
               />
@@ -290,7 +306,8 @@ export const VesuPositionsSection: FC<VesuPositionsSectionProps> = ({
           debt={closeParams.debt}
           collateralBalance={closeParams.collateralBalance}
           debtBalance={closeParams.debtBalance}
-          poolId={closeParams.poolId}
+          poolKey={closeParams.poolKey}
+          protocolKey={closeParams.protocolKey}
         />
       )}
 
@@ -330,7 +347,7 @@ export const VesuPositionsSection: FC<VesuPositionsSectionProps> = ({
           }}
         />
       ) : (
-        swapRow && swapType && (
+        swapRow && swapType && swapRow.borrowContext && isVesuContextV1(swapRow.borrowContext) && (
           <TokenSelectModalStark
             isOpen={isSwapSelectOpen}
             onClose={closeSwapSelector}
@@ -351,11 +368,12 @@ export const VesuPositionsSection: FC<VesuPositionsSectionProps> = ({
       )}
 
       {/* Switch debt modal */}
-      {swapType === "debt" && swapRow && selectedTarget && (
+      {swapType === "debt" && swapRow && selectedTarget && swapRow.borrowContext && (
         <SwitchDebtModalStark
           isOpen={isSwitchDebtOpen}
           onClose={() => setIsSwitchDebtOpen(false)}
-          poolId={swapRow.borrowContext.poolId}
+          poolKey={swapRow.poolKey}
+          protocolKey={swapRow.protocolKey}
           collateral={{
             name: swapRow.supply.name,
             address: swapRow.supply.tokenAddress,
@@ -380,11 +398,12 @@ export const VesuPositionsSection: FC<VesuPositionsSectionProps> = ({
       )}
 
       {/* Switch collateral modal */}
-      {swapType === "collateral" && swapRow && selectedTarget && (
+      {swapType === "collateral" && swapRow && selectedTarget && swapRow.borrowContext && (
         <SwitchCollateralModalStark
           isOpen={isSwitchCollateralOpen}
           onClose={() => setIsSwitchCollateralOpen(false)}
-          poolId={swapRow.borrowContext.poolId}
+          poolKey={swapRow.poolKey}
+          protocolKey={swapRow.protocolKey}
           currentCollateral={{
             name: swapRow.supply.name,
             address: swapRow.supply.tokenAddress,

--- a/packages/nextjs/hooks/useLendingAction.ts
+++ b/packages/nextjs/hooks/useLendingAction.ts
@@ -1,15 +1,6 @@
 import type { Network } from "./useTokenBalance";
 import { useTokenBalance } from "./useTokenBalance";
-import {
-  CairoCustomEnum,
-  CairoOption,
-  CairoOptionVariant,
-  CallData,
-  Contract,
-  num,
-  uint256,
-  Call,
-} from "starknet";
+import { CairoCustomEnum, CallData, Contract, num, uint256, Call } from "starknet";
 import { parseUnits } from "viem";
 import { useAccount as useEvmAccount } from "wagmi";
 import { useScaffoldWriteContract as useEvmWrite } from "~~/hooks/scaffold-eth";
@@ -22,17 +13,7 @@ import { notification } from "~~/utils/scaffold-stark";
 
 export type Action = "Borrow" | "Deposit" | "Withdraw" | "Repay";
 
-export interface VesuContextV1 {
-  poolId: bigint;
-  counterpartToken: string;
-}
-
-export interface VesuContextV2 {
-  poolAddress: string;
-  positionCounterpartToken: string;
-}
-
-export type VesuContext = VesuContextV1 | VesuContextV2;
+import { buildVesuContextOption, type VesuContext } from "~~/utils/vesu";
 
 export const useLendingAction = (
   network: Network,
@@ -80,10 +61,7 @@ export const useLendingAction = (
         amount: uint256.bnToUint256(parsedAmount),
         user: starkAddress,
       };
-      let context = new CairoOption(CairoOptionVariant.None);
-      if (vesuContext) {
-        context = new CairoOption(CairoOptionVariant.Some, [vesuContext.poolId, vesuContext.counterpartToken]);
-      }
+      const context = buildVesuContextOption(vesuContext);
       let lendingInstruction;
       switch (action) {
         case "Deposit":

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -15,7 +15,7 @@
     "vercel:yolo": "vercel --build-env YARN_ENABLE_IMMUTABLE_INSTALLS=false --build-env ENABLE_EXPERIMENTAL_COREPACK=1 --build-env NEXT_PUBLIC_IGNORE_BUILD_ERROR=true --build-env VERCEL_TELEMETRY_DISABLED=1"
   },
   "dependencies": {
-    "@avnu/avnu-sdk": "^3.1.1",
+    "@avnu/avnu-sdk": "3.1.1",
     "@cartridge/connector": "^0.10.7",
     "@cartridge/controller": "^0.10.7",
     "@heroicons/react": "~2.1.5",

--- a/packages/nextjs/utils/vesu.ts
+++ b/packages/nextjs/utils/vesu.ts
@@ -1,0 +1,80 @@
+import { CairoOption, CairoOptionVariant, type BigNumberish } from "starknet";
+
+export type VesuProtocolKey = "vesu" | "vesu_v2";
+
+const normalizeHexAddress = (value: string | bigint): string => {
+  const hex = typeof value === "bigint" ? value.toString(16) : value.replace(/^0x/i, "");
+  return `0x${hex.padStart(64, "0")}`;
+};
+
+export interface VesuContextV1 {
+  protocolKey: "vesu";
+  poolId: bigint;
+  counterpartToken: string;
+}
+
+export interface VesuContextV2 {
+  protocolKey: "vesu_v2";
+  poolAddress: string;
+  positionCounterpartToken: string;
+}
+
+export type VesuContext = VesuContextV1 | VesuContextV2;
+
+export const isVesuContextV1 = (context: VesuContext): context is VesuContextV1 =>
+  context.protocolKey === "vesu";
+
+export const isVesuContextV2 = (context: VesuContext): context is VesuContextV2 =>
+  context.protocolKey === "vesu_v2";
+
+export const createVesuContextV1 = (
+  poolId: bigint | string,
+  counterpartToken: string,
+): VesuContextV1 => ({
+  protocolKey: "vesu",
+  poolId: typeof poolId === "bigint" ? poolId : BigInt(poolId),
+  counterpartToken: normalizeHexAddress(counterpartToken),
+});
+
+export const createVesuContextV2 = (
+  poolAddress: string | bigint,
+  positionCounterpartToken: string,
+): VesuContextV2 => ({
+  protocolKey: "vesu_v2",
+  poolAddress: normalizeHexAddress(poolAddress),
+  positionCounterpartToken: normalizeHexAddress(positionCounterpartToken),
+});
+
+export const createVesuContext = (
+  protocolKey: VesuProtocolKey,
+  poolKey: string | bigint,
+  counterpartToken: string,
+): VesuContext =>
+  protocolKey === "vesu"
+    ? createVesuContextV1(poolKey, counterpartToken)
+    : createVesuContextV2(poolKey, counterpartToken);
+
+export const normalizeStarknetAddress = normalizeHexAddress;
+
+const toBigNumberish = (value: string | bigint): BigNumberish =>
+  typeof value === "bigint" ? value : BigInt(value);
+
+export const buildVesuContextOption = (
+  context?: VesuContext,
+): CairoOption<BigNumberish[]> => {
+  if (!context) {
+    return new CairoOption<BigNumberish[]>(CairoOptionVariant.None);
+  }
+
+  if (isVesuContextV2(context)) {
+    return new CairoOption<BigNumberish[]>(CairoOptionVariant.Some, [
+      toBigNumberish(context.poolAddress),
+      toBigNumberish(context.positionCounterpartToken),
+    ]);
+  }
+
+  return new CairoOption<BigNumberish[]>(CairoOptionVariant.Some, [
+    context.poolId,
+    toBigNumberish(context.counterpartToken),
+  ]);
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -135,7 +135,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@avnu/avnu-sdk@npm:^3.1.1":
+"@avnu/avnu-sdk@npm:3.1.1":
   version: 3.1.1
   resolution: "@avnu/avnu-sdk@npm:3.1.1"
   peerDependencies:
@@ -4843,7 +4843,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@se-2/nextjs@workspace:packages/nextjs"
   dependencies:
-    "@avnu/avnu-sdk": ^3.1.1
+    "@avnu/avnu-sdk": 3.1.1
     "@cartridge/connector": ^0.10.7
     "@cartridge/controller": ^0.10.7
     "@heroicons/react": ~2.1.5


### PR DESCRIPTION
## Summary
- add typed Vesu context helpers that normalize pool identifiers and counterpart tokens for both the v1 pool id and v2 pool address formats
- propagate protocol-aware contexts through Vesu lending hooks, position rows, and the protocol view so supply, withdraw, borrow, and modal flows carry the right gateway metadata
- update Starknet switch and close modals to rebuild Cairo instructions with the new context helpers and protocol keys

## Testing
- CI=1 PATH=$(pwd)/node_modules/.bin:$PATH yarn build

------
https://chatgpt.com/codex/tasks/task_e_68e12f600f00832089b470de2cae0ef9