### PR TITLE
Add modify delegation revoke calls after instruction execution

### DIFF
--- a/packages/nextjs/components/modals/stark/BaseTokenModal.tsx
+++ b/packages/nextjs/components/modals/stark/BaseTokenModal.tsx
@@ -25,6 +25,8 @@ import { useAccount } from "~~/hooks/useAccount";
 import { universalErc20Abi } from "~~/utils/Constants";
 import formatPercentage from "~~/utils/formatPercentage";
 import { feltToString } from "~~/utils/protocols";
+import { buildModifyDelegationRevokeCalls } from "~~/utils/authorizations";
+import type { LendingAuthorization } from "~~/hooks/useLendingAuthorizations";
 
 // Helper to convert a string to its felt representation
 const stringToFelt = (s: string): string => {
@@ -254,7 +256,7 @@ export const BaseTokenModal: FC<BaseTokenModalProps> = ({
   const calls = useMemo(() => {
     if (!fullInstruction) return [];
 
-    const authorizations = [];
+    const authorizations: LendingAuthorization[] = [];
     if (protocolInstructions) {
       const instructionsArray = protocolInstructions as unknown as [bigint, bigint, bigint[]][];
       for (const instruction of instructionsArray) {
@@ -271,6 +273,8 @@ export const BaseTokenModal: FC<BaseTokenModalProps> = ({
       }
     }
 
+    const revokeAuthorizations = buildModifyDelegationRevokeCalls(authorizations);
+
     return [
       ...(authorizations as any),
       {
@@ -278,6 +282,7 @@ export const BaseTokenModal: FC<BaseTokenModalProps> = ({
         functionName: "process_protocol_instructions" as const,
         args: fullInstruction,
       },
+      ...(revokeAuthorizations as any),
     ];
   }, [fullInstruction, protocolInstructions]);
 

--- a/packages/nextjs/components/modals/stark/ClosePositionModalStark.tsx
+++ b/packages/nextjs/components/modals/stark/ClosePositionModalStark.tsx
@@ -13,7 +13,8 @@ import {
 import { fetchBuildExecuteTransaction, fetchQuotes } from "@avnu/avnu-sdk";
 import type { Quote } from "@avnu/avnu-sdk";
 import { useAccount as useStarkAccount } from "~~/hooks/useAccount";
-import { useLendingAuthorizations } from "~~/hooks/useLendingAuthorizations";
+import { useLendingAuthorizations, type LendingAuthorization } from "~~/hooks/useLendingAuthorizations";
+import { buildModifyDelegationRevokeCalls } from "~~/utils/authorizations";
 import { useScaffoldMultiWriteContract } from "~~/hooks/scaffold-stark";
 import { notification } from "~~/utils/scaffold-stark";
 import { formatTokenAmount } from "~~/utils/protocols";
@@ -53,7 +54,7 @@ export const ClosePositionModalStark: FC<ClosePositionModalProps> = ({
   const { address } = useStarkAccount();
   const { getAuthorizations, isReady: isAuthReady } = useLendingAuthorizations();
   const [avnuCalldata, setAvnuCalldata] = useState<bigint[]>([]);
-  const [fetchedAuthorizations, setFetchedAuthorizations] = useState<any[]>([]);
+  const [fetchedAuthorizations, setFetchedAuthorizations] = useState<LendingAuthorization[]>([]);
   const [selectedQuote, setSelectedQuote] = useState<Quote | null>(null);
 
   useEffect(() => {
@@ -226,6 +227,7 @@ export const ClosePositionModalStark: FC<ClosePositionModalProps> = ({
 
   const calls = useMemo(() => {
     if (protocolInstructions.length === 0) return [];
+    const revokeAuthorizations = buildModifyDelegationRevokeCalls(fetchedAuthorizations);
     return [
       ...(fetchedAuthorizations as any),
       {
@@ -233,6 +235,7 @@ export const ClosePositionModalStark: FC<ClosePositionModalProps> = ({
         functionName: "move_debt" as const,
         args: CallData.compile({ instructions: protocolInstructions }),
       },
+      ...(revokeAuthorizations as any),
     ];
   }, [fetchedAuthorizations, protocolInstructions]);
 

--- a/packages/nextjs/hooks/useNostraDebtSwitch.ts
+++ b/packages/nextjs/hooks/useNostraDebtSwitch.ts
@@ -1,7 +1,8 @@
 import { useEffect, useMemo, useState } from "react";
 import { CairoCustomEnum, CairoOption, CairoOptionVariant, CallData, uint256 } from "starknet";
 import { fetchBuildExecuteTransaction, fetchQuotes, type Quote } from "@avnu/avnu-sdk";
-import { useLendingAuthorizations, type BaseProtocolInstruction } from "~~/hooks/useLendingAuthorizations";
+import { useLendingAuthorizations, type BaseProtocolInstruction, type LendingAuthorization } from "~~/hooks/useLendingAuthorizations";
+import { buildModifyDelegationRevokeCalls } from "~~/utils/authorizations";
 
 const SLIPPAGE = 0.05;
 const BUFFER_BPS = 300n; // 3% buffer when borrowing new debt
@@ -43,7 +44,7 @@ export const useNostraDebtSwitch = ({
   const [error, setError] = useState<string | null>(null);
   const [selectedQuote, setSelectedQuote] = useState<Quote | null>(null);
   const [protocolInstructions, setProtocolInstructions] = useState<BaseProtocolInstruction[]>([]);
-  const [fetchedAuthorizations, setFetchedAuthorizations] = useState<any[]>([]);
+  const [fetchedAuthorizations, setFetchedAuthorizations] = useState<LendingAuthorization[]>([]);
   const [avnuCalldata, setAvnuCalldata] = useState<bigint[]>([]);
 
   useEffect(() => {
@@ -191,6 +192,7 @@ export const useNostraDebtSwitch = ({
   const calls = useMemo(() => {
     if (protocolInstructions.length === 0) return [];
 
+    const revokeAuthorizations = buildModifyDelegationRevokeCalls(fetchedAuthorizations);
     return [
       ...(fetchedAuthorizations as any),
       {
@@ -198,6 +200,7 @@ export const useNostraDebtSwitch = ({
         functionName: "move_debt" as const,
         args: CallData.compile({ instructions: protocolInstructions }),
       },
+      ...(revokeAuthorizations as any),
     ];
   }, [protocolInstructions, fetchedAuthorizations]);
 

--- a/packages/nextjs/utils/authorizations.ts
+++ b/packages/nextjs/utils/authorizations.ts
@@ -1,0 +1,15 @@
+import { num } from "starknet";
+import type { LendingAuthorization } from "~~/hooks/useLendingAuthorizations";
+
+export const buildModifyDelegationRevokeCalls = (
+  authorizations: ReadonlyArray<LendingAuthorization>,
+): LendingAuthorization[] => {
+  const revokeValue = num.toHexString(0n);
+  return authorizations
+    .filter(authorization => authorization.entrypoint === "modify_delegation" && authorization.calldata.length > 0)
+    .map(authorization => ({
+      contractAddress: authorization.contractAddress,
+      entrypoint: authorization.entrypoint,
+      calldata: [...authorization.calldata.slice(0, -1), revokeValue],
+    }));
+};


### PR DESCRIPTION
## Summary
- add a reusable helper for building Vesu modify_delegation revocation calls
- append modify_delegation:false calls after executing protocol instructions across Starknet lending flows

## Testing
- yarn next:lint *(fails: command not found: next)*

------
https://chatgpt.com/codex/tasks/task_e_68e28448cb30832090fe6e7d157ba3f1