### PR TITLE
Fix withdraw modal for Vesu positions without debt

### DIFF
--- a/packages/nextjs/components/specific/vesu/VesuPosition.tsx
+++ b/packages/nextjs/components/specific/vesu/VesuPosition.tsx
@@ -350,7 +350,7 @@ export const VesuPosition: FC<VesuPositionProps> = ({
             }}
             protocolName="Vesu"
             supplyBalance={BigInt(collateralAmount)}
-            vesuContext={createVesuContextV1(poolId, debtAsset)}
+            vesuContext={nominalDebt !== "0" ? createVesuContextV1(poolId, debtAsset) : undefined}
             position={position}
           />
 


### PR DESCRIPTION
## Summary
- ensure the Vesu withdraw modal only passes a context when there is active debt to avoid vault redemptions for lending-only positions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2bd42486c83208722c840fe32b6f9