### PR TITLE
Add front-end Vesu v2 interest rate calculation

### DIFF
--- a/packages/nextjs/hooks/useVesuAssets.ts
+++ b/packages/nextjs/hooks/useVesuAssets.ts
@@ -49,6 +49,11 @@ const parseSupportedAssets = (assets: unknown): TokenMetadata[] => {
       target_rate_percent?: unknown;
       fee_shares?: unknown;
       last_updated?: unknown;
+      min_target_utilization?: unknown;
+      max_target_utilization?: unknown;
+      rate_half_life?: unknown;
+      max_full_utilization_rate?: unknown;
+      min_full_utilization_rate?: unknown;
     };
 
     const priceCandidate = candidate.price as { value?: unknown; is_valid?: unknown } | undefined;
@@ -99,6 +104,19 @@ const parseSupportedAssets = (assets: unknown): TokenMetadata[] => {
           typeof candidate.target_rate_percent === "bigint" ? candidate.target_rate_percent : undefined,
         fee_shares: typeof candidate.fee_shares === "bigint" ? candidate.fee_shares : undefined,
         last_updated: typeof candidate.last_updated === "bigint" ? candidate.last_updated : undefined,
+        min_target_utilization:
+          typeof candidate.min_target_utilization === "bigint" ? candidate.min_target_utilization : undefined,
+        max_target_utilization:
+          typeof candidate.max_target_utilization === "bigint" ? candidate.max_target_utilization : undefined,
+        rate_half_life: typeof candidate.rate_half_life === "bigint" ? candidate.rate_half_life : undefined,
+        max_full_utilization_rate:
+          typeof candidate.max_full_utilization_rate === "bigint"
+            ? candidate.max_full_utilization_rate
+            : undefined,
+        min_full_utilization_rate:
+          typeof candidate.min_full_utilization_rate === "bigint"
+            ? candidate.min_full_utilization_rate
+            : undefined,
       },
     ];
   });

--- a/packages/nextjs/utils/protocols.ts
+++ b/packages/nextjs/utils/protocols.ts
@@ -107,6 +107,11 @@ export type TokenMetadata = {
   target_rate_percent?: bigint;
   fee_shares?: bigint;
   last_updated?: bigint;
+  min_target_utilization?: bigint;
+  max_target_utilization?: bigint;
+  rate_half_life?: bigint;
+  max_full_utilization_rate?: bigint;
+  min_full_utilization_rate?: bigint;
   borrowAPR?: number;
   supplyAPY?: number;
 };

--- a/packages/nextjs/utils/vesuV2Rates.ts
+++ b/packages/nextjs/utils/vesuV2Rates.ts
@@ -1,21 +1,32 @@
-import { SCALE, YEAR_IN_SECONDS } from "./protocols";
+import { SCALE } from "./protocols";
 
-const ZERO = 0n;
-const ONE = SCALE;
-const SCALE_FLOAT = Number(SCALE);
+const UTILIZATION_SCALE = 10n ** 5n;
+const UTILIZATION_SCALE_TO_SCALE = 10n ** 13n;
+const YEAR_IN_SECONDS_V2 = 360 * 24 * 60 * 60;
 
-const clampBigInt = (value: bigint, min: bigint, max: bigint) => {
-  if (value < min) return min;
-  if (value > max) return max;
-  return value;
-};
+export interface VesuV2AssetSnapshot {
+  total_nominal_debt: bigint;
+  last_rate_accumulator: bigint;
+  reserve: bigint;
+  scale: bigint;
+  last_full_utilization_rate?: bigint | null;
+  last_updated?: bigint | null;
+}
+
+export interface VesuV2InterestRateConfig {
+  zero_utilization_rate?: bigint | null;
+  target_utilization?: bigint | null;
+  target_rate_percent?: bigint | null;
+  min_target_utilization?: bigint | null;
+  max_target_utilization?: bigint | null;
+  rate_half_life?: bigint | null;
+  max_full_utilization_rate?: bigint | null;
+  min_full_utilization_rate?: bigint | null;
+}
 
 export interface VesuV2RateInputs {
-  utilization: bigint;
-  zeroUtilizationRate?: bigint | null;
-  fullUtilizationRate?: bigint | null;
-  targetUtilization?: bigint | null;
-  targetRatePercent?: bigint | null;
+  asset: VesuV2AssetSnapshot;
+  interestRateConfig: VesuV2InterestRateConfig;
 }
 
 export interface VesuV2RateResult {
@@ -25,101 +36,238 @@ export interface VesuV2RateResult {
   supplyAPY: number;
 }
 
+interface NormalizedInterestRateConfig {
+  zero_utilization_rate: bigint;
+  target_utilization: bigint;
+  target_rate_percent: bigint;
+  min_target_utilization: bigint;
+  max_target_utilization: bigint;
+  rate_half_life: bigint;
+  max_full_utilization_rate: bigint;
+  min_full_utilization_rate: bigint;
+}
+
 const isBigInt = (value: unknown): value is bigint => typeof value === "bigint";
 
-const calculateTargetRate = (
-  zeroUtilizationRate: bigint,
-  fullUtilizationRate: bigint,
-  targetRatePercent: bigint,
-) => {
-  const span = fullUtilizationRate - zeroUtilizationRate;
-  if (span === ZERO) {
-    return zeroUtilizationRate;
+const toBorrowApr = (interestPerSecond: bigint): number => {
+  const perSecond = Number(interestPerSecond) / Number(SCALE);
+  if (!Number.isFinite(perSecond)) {
+    return 0;
+  }
+  return perSecond * YEAR_IN_SECONDS_V2;
+};
+
+const toBorrowApy = (interestPerSecond: bigint): number => {
+  const perSecond = Number(interestPerSecond) / Number(SCALE);
+  if (!Number.isFinite(perSecond)) {
+    return 0;
   }
 
-  return zeroUtilizationRate + (span * targetRatePercent) / SCALE;
+  const apy = (1 + perSecond) ** YEAR_IN_SECONDS_V2 - 1;
+  return Number.isFinite(apy) ? apy : 0;
+};
+
+const toAnnualRatesV2 = (
+  interestPerSecond: bigint,
+  { total_nominal_debt, last_rate_accumulator, reserve, scale }: VesuV2AssetSnapshot,
+): Pick<VesuV2RateResult, "borrowAPR" | "supplyAPY"> => {
+  if (scale === 0n) {
+    return { borrowAPR: 0, supplyAPY: 0 };
+  }
+
+  const borrowAPR = toBorrowApr(interestPerSecond);
+  if (!Number.isFinite(borrowAPR) || borrowAPR < 0) {
+    return { borrowAPR: 0, supplyAPY: 0 };
+  }
+
+  const baseApy = toBorrowApy(interestPerSecond);
+  if (!Number.isFinite(baseApy) || baseApy < 0) {
+    return { borrowAPR: borrowAPR || 0, supplyAPY: 0 };
+  }
+
+  const totalBorrowed = Number((total_nominal_debt * last_rate_accumulator) / SCALE);
+  const reserveScale = Number((reserve * SCALE) / scale);
+  const denominator = reserveScale + totalBorrowed;
+
+  const supplyAPY = denominator === 0 ? 0 : (baseApy * totalBorrowed) / denominator;
+
+  return {
+    borrowAPR,
+    supplyAPY: Number.isFinite(supplyAPY) && supplyAPY > 0 ? supplyAPY : 0,
+  };
+};
+
+const calculateDebt = (nominalDebt: bigint, rateAccumulator: bigint, assetScale: bigint) => {
+  return assetScale === 0n ? 0n : (((nominalDebt * rateAccumulator) / SCALE) * assetScale) / SCALE;
+};
+
+const calculateUtilization = ({
+  total_nominal_debt,
+  last_rate_accumulator,
+  scale,
+  reserve,
+}: VesuV2AssetSnapshot) => {
+  const totalDebt = calculateDebt(total_nominal_debt, last_rate_accumulator, scale);
+  const totalAssets = reserve + totalDebt;
+  if (totalAssets === 0n) {
+    return 0n;
+  }
+  return (totalDebt * SCALE) / totalAssets;
+};
+
+const fullUtilizationRate = (
+  interest_rate_config: NormalizedInterestRateConfig,
+  timeDelta: bigint,
+  utilization: bigint,
+  fullUtilizationRateValue: bigint,
+) => {
+  const {
+    min_target_utilization,
+    max_target_utilization,
+    rate_half_life,
+    max_full_utilization_rate,
+    min_full_utilization_rate,
+  } = interest_rate_config;
+
+  if (rate_half_life === 0n) {
+    return clampBigInt(fullUtilizationRateValue, min_full_utilization_rate, max_full_utilization_rate);
+  }
+
+  const halfLifeScale = rate_half_life * SCALE;
+
+  const newFullUtilizationRate = (() => {
+    if (utilization < min_target_utilization && min_target_utilization !== 0n) {
+      const utilizationDelta = ((min_target_utilization - utilization) * SCALE) / min_target_utilization;
+      const decay = halfLifeScale + utilizationDelta * timeDelta;
+      if (decay === 0n) {
+        return fullUtilizationRateValue;
+      }
+      return (fullUtilizationRateValue * halfLifeScale) / decay;
+    }
+
+    if (utilization > max_target_utilization && max_target_utilization < UTILIZATION_SCALE) {
+      const denominator = UTILIZATION_SCALE - max_target_utilization;
+      if (denominator === 0n) {
+        return max_full_utilization_rate;
+      }
+      const utilizationDelta = ((utilization - max_target_utilization) * SCALE) / denominator;
+      const growth = halfLifeScale + utilizationDelta * timeDelta;
+      return growth === 0n ? fullUtilizationRateValue : (fullUtilizationRateValue * growth) / halfLifeScale;
+    }
+
+    return fullUtilizationRateValue;
+  })();
+
+  return clampBigInt(newFullUtilizationRate, min_full_utilization_rate, max_full_utilization_rate);
+};
+
+const clampBigInt = (value: bigint, min: bigint, max: bigint) => {
+  if (value < min) return min;
+  if (value > max) return max;
+  return value;
 };
 
 const calculateInterestRate = (
+  interest_rate_config: NormalizedInterestRateConfig,
   utilization: bigint,
-  targetUtilization: bigint,
-  zeroUtilizationRate: bigint,
-  fullUtilizationRate: bigint,
-  targetRate: bigint,
-): bigint => {
-  const safeUtilization = clampBigInt(utilization, ZERO, ONE);
-  const safeTargetUtilization = clampBigInt(targetUtilization, ZERO, ONE);
-  const safeFullUtilizationRate = fullUtilizationRate < zeroUtilizationRate ? zeroUtilizationRate : fullUtilizationRate;
+  timeDelta: bigint,
+  lastFullUtilizationRate: bigint,
+): { interestRate: bigint; targetRate: bigint } => {
+  const normalizedUtilization = clampBigInt(
+    utilization / UTILIZATION_SCALE_TO_SCALE,
+    0n,
+    UTILIZATION_SCALE,
+  );
+  const { target_utilization, zero_utilization_rate, target_rate_percent } = interest_rate_config;
 
-  if (safeTargetUtilization === ZERO) {
-    return safeFullUtilizationRate;
+  const newFullUtilizationRate = fullUtilizationRate(
+    interest_rate_config,
+    timeDelta,
+    normalizedUtilization,
+    lastFullUtilizationRate,
+  );
+
+  const targetRate =
+    ((newFullUtilizationRate - zero_utilization_rate) * target_rate_percent) / SCALE + zero_utilization_rate;
+
+  if (target_utilization === 0n) {
+    return { interestRate: newFullUtilizationRate, targetRate };
   }
 
-  if (safeUtilization <= safeTargetUtilization) {
-    const numerator = safeUtilization * (targetRate - zeroUtilizationRate);
-    const delta = numerator / safeTargetUtilization;
-    return zeroUtilizationRate + delta;
+  if (normalizedUtilization < target_utilization) {
+    const delta = (normalizedUtilization * (targetRate - zero_utilization_rate)) / target_utilization;
+    return { interestRate: zero_utilization_rate + delta, targetRate };
   }
 
-  const utilizationSpan = ONE - safeTargetUtilization;
-  if (utilizationSpan === ZERO) {
-    return safeFullUtilizationRate;
+  const utilizationSpan = SCALE - target_utilization;
+  if (utilizationSpan === 0n) {
+    return { interestRate: newFullUtilizationRate, targetRate };
   }
 
-  const numerator = (safeUtilization - safeTargetUtilization) * (safeFullUtilizationRate - targetRate);
-  const delta = numerator / utilizationSpan;
-  return targetRate + delta;
+  const delta =
+    ((normalizedUtilization - target_utilization) * (newFullUtilizationRate - targetRate)) / utilizationSpan;
+
+  return { interestRate: targetRate + delta, targetRate };
 };
 
-const toNumberRate = (value: bigint) => {
-  if (!isBigInt(value)) return 0;
-  return Number(value) / SCALE_FLOAT;
-};
-
-const toBorrowApr = (interestRatePerSecond: bigint): number => {
-  const perSecond = toNumberRate(interestRatePerSecond);
-  if (!Number.isFinite(perSecond)) return 0;
-
-  const exponent = perSecond * YEAR_IN_SECONDS;
-  const clamped = Math.max(Math.min(exponent, 50), -50);
-  const apr = Math.expm1(clamped);
-  if (!Number.isFinite(apr) || apr < 0) {
-    return 0;
-  }
-  return apr;
-};
-
-const toSupplyApr = (borrowApr: number, utilization: bigint): number => {
-  if (!Number.isFinite(borrowApr) || borrowApr <= 0) return 0;
-  const utilizationRatio = Number(clampBigInt(utilization, ZERO, ONE)) / SCALE_FLOAT;
-  if (!Number.isFinite(utilizationRatio) || utilizationRatio <= 0) return 0;
-  const apr = borrowApr * utilizationRatio;
-  return Number.isFinite(apr) && apr > 0 ? apr : 0;
-};
-
-export const calculateVesuV2AnnualRates = (inputs: VesuV2RateInputs): VesuV2RateResult | null => {
-  const { utilization, zeroUtilizationRate, fullUtilizationRate, targetRatePercent, targetUtilization } = inputs;
+const normalizeInterestConfig = (
+  interestRateConfig: VesuV2InterestRateConfig,
+): NormalizedInterestRateConfig | null => {
+  const zeroUtilizationRate = interestRateConfig.zero_utilization_rate;
+  const targetUtilization = interestRateConfig.target_utilization;
+  const targetRatePercent = interestRateConfig.target_rate_percent;
+  const minTargetUtilization = interestRateConfig.min_target_utilization;
+  const maxTargetUtilization = interestRateConfig.max_target_utilization;
+  const rateHalfLife = interestRateConfig.rate_half_life;
+  const maxFullUtilizationRate = interestRateConfig.max_full_utilization_rate;
+  const minFullUtilizationRate = interestRateConfig.min_full_utilization_rate;
 
   if (
     !isBigInt(zeroUtilizationRate) ||
-    !isBigInt(fullUtilizationRate) ||
+    !isBigInt(targetUtilization) ||
     !isBigInt(targetRatePercent) ||
-    !isBigInt(targetUtilization)
+    !isBigInt(minTargetUtilization) ||
+    !isBigInt(maxTargetUtilization) ||
+    !isBigInt(rateHalfLife) ||
+    !isBigInt(maxFullUtilizationRate) ||
+    !isBigInt(minFullUtilizationRate)
   ) {
     return null;
   }
 
-  const targetRate = calculateTargetRate(zeroUtilizationRate, fullUtilizationRate, targetRatePercent);
-  const interestRatePerSecond = calculateInterestRate(
+  return {
+    zero_utilization_rate: zeroUtilizationRate,
+    target_utilization: targetUtilization,
+    target_rate_percent: targetRatePercent,
+    min_target_utilization: minTargetUtilization,
+    max_target_utilization: maxTargetUtilization,
+    rate_half_life: rateHalfLife,
+    max_full_utilization_rate: maxFullUtilizationRate,
+    min_full_utilization_rate: minFullUtilizationRate,
+  };
+};
+
+export const calculateVesuV2AnnualRates = (inputs: VesuV2RateInputs): VesuV2RateResult | null => {
+  const { asset, interestRateConfig } = inputs;
+  const normalizedInterestConfig = normalizeInterestConfig(interestRateConfig);
+  const lastFullUtilizationRate = asset.last_full_utilization_rate;
+  const lastUpdated = asset.last_updated;
+
+  if (!normalizedInterestConfig || !isBigInt(lastFullUtilizationRate) || !isBigInt(lastUpdated)) {
+    return null;
+  }
+
+  const now = BigInt(Math.floor(Date.now() / 1000));
+  const timeDelta = now > lastUpdated ? now - lastUpdated : 0n;
+  const utilization = calculateUtilization(asset);
+  const { interestRate: interestRatePerSecond, targetRate } = calculateInterestRate(
+    normalizedInterestConfig,
     utilization,
-    targetUtilization,
-    zeroUtilizationRate,
-    fullUtilizationRate,
-    targetRate,
+    timeDelta,
+    lastFullUtilizationRate,
   );
 
-  const borrowAPR = toBorrowApr(interestRatePerSecond);
-  const supplyAPY = toSupplyApr(borrowAPR, utilization);
+  const { borrowAPR, supplyAPY } = toAnnualRatesV2(interestRatePerSecond, asset);
 
   return {
     interestRatePerSecond,


### PR DESCRIPTION
## Summary
- capture additional rate controller fields from supported asset metadata
- add Vesu v2 rate utilities that implement the glossary formulas for target and per-second interest
- compute Vesu v2 borrow and supply rates in the assets hook with a legacy fallback

## Testing
- yarn next:lint

------
https://chatgpt.com/codex/tasks/task_e_68ebd70f2c2c8320b75fae413da7fbdd