### PR TITLE
Display Vesu V1 and V2 protocol views together

### DIFF
--- a/packages/nextjs/components/specific/vesu/VesuMarketSection.tsx
+++ b/packages/nextjs/components/specific/vesu/VesuMarketSection.tsx
@@ -24,6 +24,9 @@ interface VesuMarketSectionProps {
   formatCurrency: (value: number) => string;
   protocolName?: string;
   headerExtra?: JSX.Element;
+  title?: string;
+  description?: string;
+  iconSrc?: string;
 }
 
 export const VesuMarketSection: FC<VesuMarketSectionProps> = ({
@@ -43,6 +46,9 @@ export const VesuMarketSection: FC<VesuMarketSectionProps> = ({
   formatCurrency,
   protocolName = "Vesu",
   headerExtra,
+  title = "Vesu",
+  description = "Manage your Starknet lending positions",
+  iconSrc = "/logos/vesu.svg",
 }) => {
   const formatSignedPercentage = (value: number) => {
     const formatted = formatPercentage(Math.abs(value));
@@ -134,11 +140,11 @@ export const VesuMarketSection: FC<VesuMarketSectionProps> = ({
         <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
           <div className="flex items-center gap-3">
             <div className="relative flex h-12 w-12 items-center justify-center rounded-lg bg-base-200 p-1">
-              <Image src="/logos/vesu.svg" alt="Vesu icon" width={36} height={36} className="object-contain" />
+              <Image src={iconSrc} alt={`${title} icon`} width={36} height={36} className="object-contain" />
             </div>
             <div className="flex flex-col">
-              <div className="text-xl font-bold tracking-tight">Vesu</div>
-              <div className="text-xs text-base-content/70">Manage your Starknet lending positions</div>
+              <div className="text-xl font-bold tracking-tight">{title}</div>
+              <div className="text-xs text-base-content/70">{description}</div>
               {userAddress && (
                 <div className="mt-1 flex flex-col gap-1 text-xs text-base-content/70">
                   <div className="flex items-center gap-1">

--- a/packages/nextjs/components/specific/vesu/VesuPositionsSection.tsx
+++ b/packages/nextjs/components/specific/vesu/VesuPositionsSection.tsx
@@ -33,6 +33,7 @@ interface VesuPositionsSectionProps {
   onBorrowRequest: (request: BorrowSelectionRequest) => void;
   onDepositRequest: () => void;
   protocolName?: string;
+  title?: string;
 }
 
 export const VesuPositionsSection: FC<VesuPositionsSectionProps> = ({
@@ -45,6 +46,7 @@ export const VesuPositionsSection: FC<VesuPositionsSectionProps> = ({
   onBorrowRequest,
   onDepositRequest,
   protocolName = "Vesu",
+  title = "Your Vesu Positions",
 }) => {
   const [isCloseModalOpen, setIsCloseModalOpen] = useState(false);
   const [closeParams, setCloseParams] = useState<
@@ -268,7 +270,7 @@ export const VesuPositionsSection: FC<VesuPositionsSectionProps> = ({
     <div className="card bg-base-100 shadow-md">
       <div className="card-body space-y-4 p-4">
         <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-          <h2 className="card-title text-lg">Your Vesu Positions</h2>
+          <h2 className="card-title text-lg">{title}</h2>
           {isUpdating && userAddress && (
             <div className="flex items-center text-xs text-base-content/60">
               <span className="loading loading-spinner loading-xs mr-1" /> Updating

--- a/packages/nextjs/components/specific/vesu/VesuProtocolView.tsx
+++ b/packages/nextjs/components/specific/vesu/VesuProtocolView.tsx
@@ -9,6 +9,7 @@ import {
   type VesuContext,
 } from "~~/utils/vesu";
 import { useVesuLendingPositions } from "~~/hooks/useVesuLendingPositions";
+import type { VesuPositionRow } from "~~/hooks/useVesuLendingPositions";
 import { useVesuV2LendingPositions } from "~~/hooks/useVesuV2LendingPositions";
 import type { AssetWithRates } from "~~/hooks/useVesuAssets";
 import type { PositionManager } from "~~/utils/position";
@@ -16,10 +17,12 @@ import type { PositionManager } from "~~/utils/position";
 import { POOL_IDS } from "./VesuMarkets";
 import { VesuMarketSection } from "./VesuMarketSection";
 import { VesuPositionsSection } from "./VesuPositionsSection";
-import { VesuVersionToggle } from "./VesuVersionToggle";
 import { calculateNetYieldMetrics } from "~~/utils/netYield";
 
+type VesuVersionKey = "v1" | "v2";
+
 type BorrowSelectionState = {
+  version: VesuVersionKey;
   tokens: AssetWithRates[];
   collateralAddress: string;
   vesuContext: VesuContext;
@@ -27,6 +30,7 @@ type BorrowSelectionState = {
 } | null;
 
 type DepositSelectionState = {
+  version: VesuVersionKey;
   tokens: AssetWithRates[];
   vesuContext?: VesuContext;
   position?: PositionManager;
@@ -38,37 +42,44 @@ export const VesuProtocolView: FC = () => {
   const poolAddress = "0x451fe483d5921a2919ddd81d0de6696669bccdacd859f72a4fba7656b97c3b5"; // V2 pool address
   const normalizedPoolAddress = normalizeStarknetAddress(poolAddress);
 
-  const [selectedVersion, setSelectedVersion] = useState<"v1" | "v2">("v1");
-
-  // V1 data
   const v1Data = useVesuLendingPositions(userAddress, poolId);
-  
-  // V2 data
   const v2Data = useVesuV2LendingPositions(userAddress, normalizedPoolAddress);
 
-  // Use data based on selected version
   const {
-    assetsWithRates,
-    suppliablePositions,
-    borrowablePositions,
-    rows,
-    isUpdating,
-    hasLoadedOnce,
-    isLoadingAssets,
-    refetchPositions,
-    assetsError,
-  } = selectedVersion === "v1" ? v1Data : v2Data;
+    assetsWithRates: assetsWithRatesV1,
+    suppliablePositions: suppliablePositionsV1,
+    borrowablePositions: borrowablePositionsV1,
+    rows: rowsV1,
+    isUpdating: isUpdatingV1,
+    hasLoadedOnce: hasLoadedOnceV1,
+    isLoadingAssets: isLoadingAssetsV1,
+    refetchPositions: refetchPositionsV1,
+    assetsError: assetsErrorV1,
+  } = v1Data;
+
+  const {
+    assetsWithRates: assetsWithRatesV2,
+    suppliablePositions: suppliablePositionsV2,
+    borrowablePositions: borrowablePositionsV2,
+    rows: rowsV2,
+    isUpdating: isUpdatingV2,
+    hasLoadedOnce: hasLoadedOnceV2,
+    isLoadingAssets: isLoadingAssetsV2,
+    refetchPositions: refetchPositionsV2,
+    assetsError: assetsErrorV2,
+  } = v2Data;
 
   const [borrowSelection, setBorrowSelection] = useState<BorrowSelectionState>(null);
   const [depositSelection, setDepositSelection] = useState<DepositSelectionState>(null);
-  const [isMarketsOpen, setIsMarketsOpen] = useState(!userAddress);
-  const [marketsManuallyToggled, setMarketsManuallyToggled] = useState(false);
+  const [isMarketsOpen, setIsMarketsOpen] = useState(() => ({
+    v1: !userAddress,
+    v2: !userAddress,
+  }));
+  const [marketsManuallyToggled, setMarketsManuallyToggled] = useState(() => ({ v1: false, v2: false }));
 
-  const hasPositions = rows.length > 0;
-
-  const netBalanceUsd = useMemo(() => {
+  const computeMetrics = (rows: VesuPositionRow[]) => {
     if (rows.length === 0) {
-      return 0;
+      return { netBalanceUsd: 0, netYield30d: 0, netApyPercent: 0 };
     }
 
     let totalSupply = 0;
@@ -81,22 +92,28 @@ export const VesuProtocolView: FC = () => {
       }
     });
 
-    return totalSupply - totalDebt;
-  }, [rows]);
+    const netBalanceUsd = totalSupply - totalDebt;
+    const supplyPositions = rows.map(row => row.supply);
+    const borrowPositions = rows.flatMap(row => (row.borrow ? [row.borrow] : []));
 
-  const supplyPositions = useMemo(() => rows.map(row => row.supply), [rows]);
-  const borrowPositions = useMemo(
-    () => rows.flatMap(row => (row.borrow ? [row.borrow] : [])),
-    [rows],
+    const { netYield30d, netApyPercent } = calculateNetYieldMetrics(supplyPositions, borrowPositions, {
+      netBalanceOverride: netBalanceUsd,
+    });
+
+    return { netBalanceUsd, netYield30d, netApyPercent };
+  };
+
+  const { netBalanceUsd: netBalanceUsdV1, netYield30d: netYield30dV1, netApyPercent: netApyPercentV1 } = useMemo(
+    () => computeMetrics(rowsV1),
+    [rowsV1],
+  );
+  const { netBalanceUsd: netBalanceUsdV2, netYield30d: netYield30dV2, netApyPercent: netApyPercentV2 } = useMemo(
+    () => computeMetrics(rowsV2),
+    [rowsV2],
   );
 
-  const { netYield30d, netApyPercent } = useMemo(
-    () =>
-      calculateNetYieldMetrics(supplyPositions, borrowPositions, {
-        netBalanceOverride: netBalanceUsd,
-      }),
-    [supplyPositions, borrowPositions, netBalanceUsd],
-  );
+  const hasPositionsV1 = rowsV1.length > 0;
+  const hasPositionsV2 = rowsV2.length > 0;
 
   const formatCurrency = (amount: number) => {
     const formatter = new Intl.NumberFormat("en-US", {
@@ -111,91 +128,140 @@ export const VesuProtocolView: FC = () => {
 
   useEffect(() => {
     if (!userAddress) {
-      setIsMarketsOpen(true);
-      setMarketsManuallyToggled(false);
+      setIsMarketsOpen({ v1: true, v2: true });
+      setMarketsManuallyToggled({ v1: false, v2: false });
       return;
     }
 
-    setMarketsManuallyToggled(false);
+    setMarketsManuallyToggled({ v1: false, v2: false });
   }, [userAddress]);
 
   useEffect(() => {
-    if (!userAddress || marketsManuallyToggled) return;
-    setIsMarketsOpen(!hasPositions);
-  }, [userAddress, hasPositions, marketsManuallyToggled]);
+    if (!userAddress || marketsManuallyToggled.v1) return;
+    const desired = !hasPositionsV1;
+    setIsMarketsOpen(prev => (prev.v1 === desired ? prev : { ...prev, v1: desired }));
+  }, [userAddress, hasPositionsV1, marketsManuallyToggled.v1]);
 
   useEffect(() => {
-    const handler = () => refetchPositions();
+    if (!userAddress || marketsManuallyToggled.v2) return;
+    const desired = !hasPositionsV2;
+    setIsMarketsOpen(prev => (prev.v2 === desired ? prev : { ...prev, v2: desired }));
+  }, [userAddress, hasPositionsV2, marketsManuallyToggled.v2]);
+
+  useEffect(() => {
+    const handler = () => {
+      refetchPositionsV1();
+      refetchPositionsV2();
+    };
     window.addEventListener("txCompleted", handler);
     return () => {
       window.removeEventListener("txCompleted", handler);
     };
-  }, [refetchPositions]);
+  }, [refetchPositionsV1, refetchPositionsV2]);
 
-  const handleToggleMarkets = () => {
-    setIsMarketsOpen(previous => !previous);
-    setMarketsManuallyToggled(true);
+  const handleToggleMarkets = (version: VesuVersionKey) => {
+    setIsMarketsOpen(previous => ({ ...previous, [version]: !previous[version] }));
+    setMarketsManuallyToggled(previous => ({ ...previous, [version]: true }));
   };
 
-  const openDepositModal = (tokens: AssetWithRates[], options?: { vesuContext?: VesuContext; position?: PositionManager }) => {
+  const openDepositModal = (
+    version: VesuVersionKey,
+    tokens: AssetWithRates[],
+    options?: { vesuContext?: VesuContext; position?: PositionManager },
+  ) => {
     if (tokens.length === 0) return;
     const zeroCounterpart = normalizeStarknetAddress(0n);
     const inferredContext =
       options?.vesuContext ??
-      (selectedVersion === "v1"
+      (version === "v1"
         ? createVesuContextV1(poolId, zeroCounterpart)
         : createVesuContextV2(normalizedPoolAddress, zeroCounterpart));
-    setDepositSelection({ tokens, vesuContext: inferredContext, position: options?.position });
+    setDepositSelection({ version, tokens, vesuContext: inferredContext, position: options?.position });
   };
 
 
   return (
     <div className="flex w-full flex-col space-y-6 p-4">
-      <VesuMarketSection
-        isOpen={isMarketsOpen}
-        onToggle={handleToggleMarkets}
-        isLoadingAssets={isLoadingAssets}
-        assetsError={assetsError}
-        suppliablePositions={suppliablePositions}
-        borrowablePositions={borrowablePositions}
-        userAddress={userAddress}
-        hasPositions={hasPositions}
-        netBalanceUsd={netBalanceUsd}
-        netYield30d={netYield30d}
-        netApyPercent={netApyPercent}
-        onDeposit={() => openDepositModal(assetsWithRates)}
-        canDeposit={assetsWithRates.length > 0}
-        formatCurrency={formatCurrency}
-        protocolName={selectedVersion === "v1" ? "Vesu" : "vesu_v2"}
-        // Inline version toggle at header area
-        headerExtra={
-          <VesuVersionToggle
-            selectedVersion={selectedVersion}
-            onVersionChange={setSelectedVersion}
-          />
-        }
-      />
+      <div className="space-y-6">
+        <VesuMarketSection
+          isOpen={isMarketsOpen.v1}
+          onToggle={() => handleToggleMarkets("v1")}
+          isLoadingAssets={isLoadingAssetsV1}
+          assetsError={assetsErrorV1}
+          suppliablePositions={suppliablePositionsV1}
+          borrowablePositions={borrowablePositionsV1}
+          userAddress={userAddress}
+          hasPositions={hasPositionsV1}
+          netBalanceUsd={netBalanceUsdV1}
+          netYield30d={netYield30dV1}
+          netApyPercent={netApyPercentV1}
+          onDeposit={() => openDepositModal("v1", assetsWithRatesV1)}
+          canDeposit={assetsWithRatesV1.length > 0}
+          formatCurrency={formatCurrency}
+          protocolName="Vesu"
+          title="Vesu V1"
+          description="Manage Genesis pool positions"
+        />
 
-      <VesuPositionsSection
-        rows={rows}
-        assetsWithRates={assetsWithRates}
-        userAddress={userAddress}
-        accountStatus={status}
-        hasLoadedOnce={hasLoadedOnce}
-        isUpdating={isUpdating}
-        onBorrowRequest={({ tokens, collateralAddress, vesuContext, position }) =>
-          setBorrowSelection({ tokens, collateralAddress, vesuContext, position })
-        }
-        onDepositRequest={() => openDepositModal(assetsWithRates)}
-        protocolName={selectedVersion === "v1" ? "Vesu" : "vesu_v2"}
-      />
+        <VesuPositionsSection
+          title="Genesis Positions"
+          rows={rowsV1}
+          assetsWithRates={assetsWithRatesV1}
+          userAddress={userAddress}
+          accountStatus={status}
+          hasLoadedOnce={hasLoadedOnceV1}
+          isUpdating={isUpdatingV1}
+          onBorrowRequest={({ tokens, collateralAddress, vesuContext, position }) =>
+            setBorrowSelection({ version: "v1", tokens, collateralAddress, vesuContext, position })
+          }
+          onDepositRequest={() => openDepositModal("v1", assetsWithRatesV1)}
+          protocolName="Vesu"
+        />
+      </div>
+
+      <div className="space-y-6">
+        <VesuMarketSection
+          isOpen={isMarketsOpen.v2}
+          onToggle={() => handleToggleMarkets("v2")}
+          isLoadingAssets={isLoadingAssetsV2}
+          assetsError={assetsErrorV2}
+          suppliablePositions={suppliablePositionsV2}
+          borrowablePositions={borrowablePositionsV2}
+          userAddress={userAddress}
+          hasPositions={hasPositionsV2}
+          netBalanceUsd={netBalanceUsdV2}
+          netYield30d={netYield30dV2}
+          netApyPercent={netApyPercentV2}
+          onDeposit={() => openDepositModal("v2", assetsWithRatesV2)}
+          canDeposit={assetsWithRatesV2.length > 0}
+          formatCurrency={formatCurrency}
+          protocolName="vesu_v2"
+          title="Vesu V2"
+          description="Manage Prime pool positions"
+        />
+
+        <VesuPositionsSection
+          title="Prime Positions"
+          rows={rowsV2}
+          assetsWithRates={assetsWithRatesV2}
+          userAddress={userAddress}
+          accountStatus={status}
+          hasLoadedOnce={hasLoadedOnceV2}
+          isUpdating={isUpdatingV2}
+          onBorrowRequest={({ tokens, collateralAddress, vesuContext, position }) =>
+            setBorrowSelection({ version: "v2", tokens, collateralAddress, vesuContext, position })
+          }
+          onDepositRequest={() => openDepositModal("v2", assetsWithRatesV2)}
+          protocolName="vesu_v2"
+        />
+      </div>
 
       {borrowSelection && (
         <TokenSelectModalStark
           isOpen={borrowSelection !== null}
           onClose={() => setBorrowSelection(null)}
           tokens={borrowSelection.tokens}
-          protocolName={selectedVersion === "v1" ? "Vesu" : "vesu_v2"}
+          protocolName={borrowSelection.version === "v1" ? "Vesu" : "vesu_v2"}
           collateralAsset={borrowSelection.collateralAddress}
           vesuContext={borrowSelection.vesuContext}
           position={borrowSelection.position}
@@ -206,7 +272,7 @@ export const VesuProtocolView: FC = () => {
           isOpen={depositSelection !== null}
           onClose={() => setDepositSelection(null)}
           tokens={depositSelection.tokens}
-          protocolName={selectedVersion === "v1" ? "Vesu" : "vesu_v2"}
+          protocolName={depositSelection.version === "v1" ? "Vesu" : "vesu_v2"}
           vesuContext={depositSelection.vesuContext}
           position={depositSelection.position}
           action="deposit"


### PR DESCRIPTION
## Summary
- render both Vesu V1 (Genesis) and Vesu V2 (Prime) market/position sections simultaneously with dedicated headers
- add configurable titles and descriptions to the shared market and positions components
- update modal handling so borrow/deposit flows use the correct version-specific context

## Testing
- yarn next:lint

------
https://chatgpt.com/codex/tasks/task_e_68ecb781618c83209fdb1c460bd54e1a