### PR TITLE
Fix Vesu V2 move modal collateral contexts

### DIFF
--- a/packages/nextjs/hooks/useVesuV2LendingPositions.ts
+++ b/packages/nextjs/hooks/useVesuV2LendingPositions.ts
@@ -396,6 +396,10 @@ export const useVesuV2LendingPositions = (
             borrowPosition = {
               ...baseBorrowPosition,
               balance: -debtUsd,
+              moveSupport: {
+                preselectedCollaterals: moveCollaterals,
+                disableCollateralSelection: true,
+              },
             };
           } else {
             borrowPosition = baseBorrowPosition;


### PR DESCRIPTION
## Summary
- ensure Vesu V2 borrow rows provide pre-selected collateral for the move modal
- correct the Starknet move modal to use the source V2 pool address and block same-pool migrations

## Testing
- yarn next:lint

------
https://chatgpt.com/codex/tasks/task_e_68efb909d8588320867040158ce555b2