### PR TITLE
Aggregate Vesu metrics across pools

### DIFF
--- a/packages/nextjs/components/specific/vesu/VesuPositionsSection.tsx
+++ b/packages/nextjs/components/specific/vesu/VesuPositionsSection.tsx
@@ -16,6 +16,7 @@ import { feltToString } from "~~/utils/protocols";
 import { getTokenNameFallback } from "~~/contracts/tokenNameFallbacks";
 import { tokenNameToLogo } from "~~/contracts/externalContracts";
 import { isVesuContextV1, type VesuProtocolKey } from "~~/utils/vesu";
+import formatPercentage from "~~/utils/formatPercentage";
 
 interface BorrowSelectionRequest {
   tokens: AssetWithRates[];
@@ -35,6 +36,10 @@ interface VesuPositionsSectionProps {
   onDepositRequest: () => void;
   protocolName?: string;
   title?: string;
+  netBalanceUsd: number;
+  netYield30d: number;
+  netApyPercent: number | null;
+  formatCurrency: (value: number) => string;
 }
 
 export const VesuPositionsSection: FC<VesuPositionsSectionProps> = ({
@@ -48,6 +53,10 @@ export const VesuPositionsSection: FC<VesuPositionsSectionProps> = ({
   onDepositRequest,
   protocolName = "Vesu",
   title = "Your Vesu Positions",
+  netBalanceUsd,
+  netYield30d,
+  netApyPercent,
+  formatCurrency,
 }) => {
   const [isCloseModalOpen, setIsCloseModalOpen] = useState(false);
   const [closeParams, setCloseParams] = useState<
@@ -98,6 +107,11 @@ export const VesuPositionsSection: FC<VesuPositionsSectionProps> = ({
   const [isSwitchDebtOpen, setIsSwitchDebtOpen] = useState(false);
   const [isSwitchCollateralOpen, setIsSwitchCollateralOpen] = useState(false);
   const [useNewSelector, setUseNewSelector] = useState(true);
+
+  const formatSignedPercentage = (value: number) => {
+    const formatted = formatPercentage(Math.abs(value));
+    return `${value >= 0 ? "" : "-"}${formatted}%`;
+  };
 
   const selectedSymbolStr = useMemo(() => {
     if (!selectedTarget) return "";
@@ -274,7 +288,39 @@ export const VesuPositionsSection: FC<VesuPositionsSectionProps> = ({
     <div className="card bg-base-100 shadow-md">
       <div className="card-body space-y-4 p-4">
         <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-          <h2 className="card-title text-lg">{title}</h2>
+          <div className="flex flex-col gap-1">
+            <h2 className="card-title text-lg">{title}</h2>
+            {userAddress && (
+              <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-base-content/70">
+                <span className="flex items-center gap-1">
+                  <span>Balance:</span>
+                  <span className={`font-semibold ${netBalanceUsd >= 0 ? "text-success" : "text-error"}`}>
+                    {formatCurrency(netBalanceUsd)}
+                  </span>
+                </span>
+                <span className="flex items-center gap-1">
+                  <span>30D Net Yield:</span>
+                  <span className={`font-semibold ${netYield30d >= 0 ? "text-success" : "text-error"}`}>
+                    {formatCurrency(netYield30d)}
+                  </span>
+                </span>
+                <span className="flex items-center gap-1">
+                  <span>Net APY:</span>
+                  <span
+                    className={`font-semibold ${
+                      netApyPercent == null
+                        ? "text-base-content"
+                        : netApyPercent >= 0
+                          ? "text-success"
+                          : "text-error"
+                    }`}
+                  >
+                    {netApyPercent == null ? "--" : formatSignedPercentage(netApyPercent)}
+                  </span>
+                </span>
+              </div>
+            )}
+          </div>
           {isUpdating && userAddress && (
             <div className="flex items-center text-xs text-base-content/60">
               <span className="loading loading-spinner loading-xs mr-1" /> Updating

--- a/packages/nextjs/components/specific/vesu/VesuProtocolView.tsx
+++ b/packages/nextjs/components/specific/vesu/VesuProtocolView.tsx
@@ -79,7 +79,7 @@ export const VesuProtocolView: FC = () => {
 
   const computeMetrics = (rows: VesuPositionRow[]) => {
     if (rows.length === 0) {
-      return { netBalanceUsd: 0, netYield30d: 0, netApyPercent: 0 };
+      return { netBalanceUsd: 0, netYield30d: 0, netApyPercent: null as number | null };
     }
 
     let totalSupply = 0;
@@ -103,15 +103,6 @@ export const VesuProtocolView: FC = () => {
     return { netBalanceUsd, netYield30d, netApyPercent };
   };
 
-  const { netBalanceUsd: netBalanceUsdV1, netYield30d: netYield30dV1, netApyPercent: netApyPercentV1 } = useMemo(
-    () => computeMetrics(rowsV1),
-    [rowsV1],
-  );
-  const { netBalanceUsd: netBalanceUsdV2, netYield30d: netYield30dV2, netApyPercent: netApyPercentV2 } = useMemo(
-    () => computeMetrics(rowsV2),
-    [rowsV2],
-  );
-
   const hasPositionsV1 = rowsV1.length > 0;
   const hasPositionsV2 = rowsV2.length > 0;
 
@@ -131,6 +122,37 @@ export const VesuProtocolView: FC = () => {
     Re7USDCPrime: useVesuV2LendingPositions(userAddress, normalizeStarknetAddress(VESU_V2_POOLS.Re7USDCPrime)),
     Re7USDCStableCore: useVesuV2LendingPositions(userAddress, normalizeStarknetAddress(VESU_V2_POOLS.Re7USDCStableCore)),
   } as const;
+
+  const { netBalanceUsd: netBalanceUsdV1, netYield30d: netYield30dV1, netApyPercent: netApyPercentV1 } = useMemo(() => {
+    const allRows = [
+      ...v1All.Genesis.rows,
+      ...v1All.CarmineRunes.rows,
+      ...v1All.Re7StarknetEcosystem.rows,
+      ...v1All.Re7xSTRK.rows,
+    ];
+    return computeMetrics(allRows);
+  }, [
+    v1All.Genesis.rows,
+    v1All.CarmineRunes.rows,
+    v1All.Re7StarknetEcosystem.rows,
+    v1All.Re7xSTRK.rows,
+  ]);
+  const { netBalanceUsd: netBalanceUsdV2, netYield30d: netYield30dV2, netApyPercent: netApyPercentV2 } = useMemo(() => {
+    const allRows = [
+      ...v2All.Default.rows,
+      ...v2All.Re7xBTC.rows,
+      ...v2All.Re7USDCCore.rows,
+      ...v2All.Re7USDCPrime.rows,
+      ...v2All.Re7USDCStableCore.rows,
+    ];
+    return computeMetrics(allRows);
+  }, [
+    v2All.Default.rows,
+    v2All.Re7xBTC.rows,
+    v2All.Re7USDCCore.rows,
+    v2All.Re7USDCPrime.rows,
+    v2All.Re7USDCStableCore.rows,
+  ]);
 
   const formatCurrency = (amount: number) => {
     const formatter = new Intl.NumberFormat("en-US", {
@@ -255,8 +277,9 @@ export const VesuProtocolView: FC = () => {
         ).map(([rawName, data]) => {
           const disp = getV1PoolDisplay(rawName as any);
           const name = disp.name;
+          if (data.rows.length === 0) return null;
+          const metrics = computeMetrics(data.rows);
           return (
-          data.rows.length > 0 ? (
             <div key={`v1-${name}`} className="space-y-4">
               <VesuPositionsSection
                 title={`${name} Positions`}
@@ -277,10 +300,12 @@ export const VesuProtocolView: FC = () => {
                   openDepositModal("v1", filtered);
                 }}
                 protocolName="Vesu"
+                netBalanceUsd={metrics.netBalanceUsd}
+                netYield30d={metrics.netYield30d}
+                netApyPercent={metrics.netApyPercent}
+                formatCurrency={formatCurrency}
               />
-              
             </div>
-          ) : null
           );
         })}
       </div>
@@ -342,8 +367,9 @@ export const VesuProtocolView: FC = () => {
         ).map(([rawName, data]) => {
           const disp = getV2PoolDisplay(rawName as any);
           const name = disp.name;
+          if (data.rows.length === 0) return null;
+          const metrics = computeMetrics(data.rows);
           return (
-          data.rows.length > 0 ? (
             <div key={`v2-${name}`} className="space-y-4">
               <VesuPositionsSection
                 title={`${name} Positions`}
@@ -364,10 +390,12 @@ export const VesuProtocolView: FC = () => {
                   openDepositModal("v2", filtered);
                 }}
                 protocolName="vesu_v2"
+                netBalanceUsd={metrics.netBalanceUsd}
+                netYield30d={metrics.netYield30d}
+                netApyPercent={metrics.netApyPercent}
+                formatCurrency={formatCurrency}
               />
-              
             </div>
-          ) : null
           );
         })}
       </div>


### PR DESCRIPTION
## Summary
- aggregate Vesu V1/V2 header metrics across all pools instead of just the selected pool
- surface per-pool balance, 30d net yield, and APY metrics inside each positions section

## Testing
- `yarn next:lint`


------
https://chatgpt.com/codex/tasks/task_e_68efba9b2cd4832083e2018cb066b50c