### PR TITLE
Fetch Vesu V2 rates from API

### DIFF
--- a/packages/nextjs/hooks/useVesuV2Assets.ts
+++ b/packages/nextjs/hooks/useVesuV2Assets.ts
@@ -1,4 +1,4 @@
-import { useMemo, useEffect } from "react";
+import { useMemo, useEffect, useState } from "react";
 import { useScaffoldReadContract } from "~~/hooks/scaffold-stark";
 import type { TokenMetadata } from "~~/utils/protocols";
 // import { toAnnualRates } from "~~/utils/protocols";
@@ -107,6 +107,127 @@ export const useVesuV2Assets = (poolAddress: string) => {
     }
   }, [assetsError]);
 
+  type RateField = { value?: unknown; decimals?: unknown } | null | undefined;
+  type ApiAsset = {
+    address?: unknown;
+    stats?: {
+      borrowApr?: RateField;
+      supplyApy?: RateField;
+      defiSpringSupplyApr?: RateField;
+      btcFiSupplyApr?: RateField;
+    } | null;
+  };
+
+  const [poolRates, setPoolRates] = useState<Record<string, { borrowAPR: number; supplyAPY: number }>>({});
+  const [ratesError, setRatesError] = useState<Error | null>(null);
+  const [isRatesLoading, setIsRatesLoading] = useState(false);
+
+  const extractRateValue = (field: RateField): number => {
+    if (!field || typeof field !== "object") return 0;
+    const { value, decimals } = field as { value?: unknown; decimals?: unknown };
+
+    const valueStr =
+      typeof value === "string"
+        ? value
+        : typeof value === "number"
+          ? value.toString()
+          : typeof value === "bigint"
+            ? value.toString()
+            : undefined;
+    if (!valueStr) return 0;
+
+    const decimalsNum =
+      typeof decimals === "number"
+        ? decimals
+        : typeof decimals === "string"
+          ? Number(decimals)
+          : typeof decimals === "bigint"
+            ? Number(decimals)
+            : 18;
+
+    if (!Number.isFinite(decimalsNum)) return 0;
+
+    const decimalsInt = Math.max(0, Math.floor(decimalsNum));
+
+    const base = Number(valueStr);
+    if (!Number.isFinite(base)) return 0;
+
+    const scale = 10 ** decimalsInt;
+    return scale === 0 ? 0 : base / scale;
+  };
+
+  useEffect(() => {
+    if (!poolAddress) {
+      setPoolRates({});
+      return;
+    }
+
+    const abortController = new AbortController();
+    let isMounted = true;
+
+    const fetchRates = async () => {
+      setIsRatesLoading(true);
+      setRatesError(null);
+
+      try {
+        const normalizedPoolAddress = poolAddress.toLowerCase();
+        const response = await fetch(
+          `https://api.vesu.xyz/pools/${normalizedPoolAddress}?onlyEnabledAssets=true`,
+          { signal: abortController.signal },
+        );
+
+        if (!response.ok) {
+          throw new Error(`Failed to fetch Vesu V2 rates: ${response.status} ${response.statusText}`);
+        }
+
+        const json = (await response.json()) as { data?: { assets?: ApiAsset[] } };
+        const assets = Array.isArray(json?.data?.assets) ? (json?.data?.assets as ApiAsset[]) : [];
+
+        const nextRates: Record<string, { borrowAPR: number; supplyAPY: number }> = {};
+
+        for (const asset of assets) {
+          const address = typeof asset.address === "string" ? asset.address.toLowerCase() : undefined;
+          if (!address) continue;
+
+          const stats = asset.stats ?? undefined;
+          const borrowAPR = extractRateValue(stats?.borrowApr);
+          const directSupply = extractRateValue(stats?.supplyApy);
+          const defiSpringSupply = extractRateValue(stats?.defiSpringSupplyApr);
+          const btcFiSupply = extractRateValue(stats?.btcFiSupplyApr);
+          const supplyAPY = directSupply > 0 ? directSupply : defiSpringSupply > 0 ? defiSpringSupply : btcFiSupply;
+
+          nextRates[address] = {
+            borrowAPR,
+            supplyAPY,
+          };
+        }
+
+        if (isMounted) {
+          setPoolRates(nextRates);
+        }
+      } catch (error) {
+        if (!isMounted) return;
+        if (typeof DOMException !== "undefined" && error instanceof DOMException && error.name === "AbortError") {
+          return;
+        }
+        console.error("Error fetching Vesu V2 rates:", error);
+        setRatesError(error instanceof Error ? error : new Error("Unknown error fetching Vesu V2 rates"));
+        setPoolRates({});
+      } finally {
+        if (isMounted) {
+          setIsRatesLoading(false);
+        }
+      }
+    };
+
+    fetchRates();
+
+    return () => {
+      isMounted = false;
+      abortController.abort();
+    };
+  }, [poolAddress]);
+
   const normalizedAssets = useMemo(() => parseSupportedAssets(supportedAssets), [supportedAssets]);
 
   // Fetch explicit allowlists for collateral and debt (V2 variant)
@@ -125,22 +246,24 @@ export const useVesuV2Assets = (poolAddress: string) => {
 
   const assetsWithRates = useMemo<AssetWithRates[]>(() => {
     return normalizedAssets.map((asset: any) => {
-      if (asset.scale === 0n) {
-        return { ...asset, borrowAPR: 0, supplyAPY: 0 };
-      }
-
-      // V2 calculation TODO; keep zeros to avoid misleading data
-      // Fallback for empty symbol names
       const hexAddress = `0x${asset.address.toString(16).padStart(64, "0")}`;
+      const normalizedAddress = hexAddress.toLowerCase();
+      const rates = poolRates[normalizedAddress];
+
       if (!asset.symbol || (typeof asset.symbol === "bigint" && asset.symbol === 0n)) {
         const fallback = getTokenNameFallback(hexAddress);
         if (fallback) {
           asset.symbol = fallback;
         }
       }
-      return { ...asset, borrowAPR: 0, supplyAPY: 0 };
+
+      return {
+        ...asset,
+        borrowAPR: rates?.borrowAPR ?? 0,
+        supplyAPY: rates?.supplyAPY ?? 0,
+      };
     });
-  }, [normalizedAssets]);
+  }, [normalizedAssets, poolRates]);
 
   const assetMap = useMemo(() => {
     const map = new Map<string, AssetWithRates>();
@@ -176,8 +299,8 @@ export const useVesuV2Assets = (poolAddress: string) => {
     assetMap,
     collateralSet,
     debtSet,
-    isLoading: supportedAssets == null,
-    assetsError,
+    isLoading: supportedAssets == null || isRatesLoading,
+    assetsError: assetsError ?? ratesError,
   };
 };
 


### PR DESCRIPTION
## Summary
- fetch Vesu V2 pool rates from the Vesu public API and cache them per asset
- merge the remote borrow APR and supply APY into the existing asset data while preserving fallbacks
- surface API loading and error state alongside contract data for downstream consumers

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_69063e405e0083209e3079035be4b2d4