### PR TITLE
Add analytics tracking for launch and network switch

### DIFF
--- a/packages/nextjs/components/home/HeroSection.tsx
+++ b/packages/nextjs/components/home/HeroSection.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { useMemo } from "react";
+import { track } from "@vercel/analytics";
 import DebtComparison from "./DebtComparison.client";
 import StableArea from "../common/StableArea";
 
@@ -44,7 +45,14 @@ const HeroSection = () => {
               
               <div className="flex flex-wrap items-center gap-4 mt-6">
                 <div className="flex gap-2">
-                  <a href="/app" onClick={(e) => { e.preventDefault(); window.location.assign(appUrl); }}>
+                  <a
+                    href="/app"
+                    onClick={e => {
+                      e.preventDefault();
+                      track("Application launched", { source: "landing_page" });
+                      window.location.assign(appUrl);
+                    }}
+                  >
                     <button className="btn btn-primary">Launch App</button>
                   </a>
                   <Link href="/info" passHref>

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/NetworkSwitcher.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/NetworkSwitcher.tsx
@@ -4,6 +4,7 @@ import { useTheme } from "next-themes";
 import { Chain } from "viem/chains";
 import { useAccount, useSwitchChain } from "wagmi";
 import { ChevronDownIcon } from "@heroicons/react/24/outline";
+import { track } from "@vercel/analytics";
 import { useOutsideClick } from "~~/hooks/scaffold-eth";
 import { getNetworkColor } from "~~/hooks/scaffold-eth";
 import { getTargetNetworks } from "~~/utils/scaffold-eth";
@@ -100,6 +101,10 @@ export const NetworkSwitcher = () => {
                   className={`w-full px-4 py-3 text-left hover:bg-base-300/50 ${isActive ? "bg-base-300/70" : ""} flex items-center gap-3`}
                   onClick={() => {
                     if (!isActive) {
+                      track("Network switched event", {
+                        network: network.name,
+                        chainId: network.id,
+                      });
                       switchChain?.({ chainId: network.id });
                     }
                     setIsOpen(false);

--- a/packages/nextjs/components/scaffold-stark/CustomConnectButton/NetworkOptions.tsx
+++ b/packages/nextjs/components/scaffold-stark/CustomConnectButton/NetworkOptions.tsx
@@ -6,6 +6,7 @@ import { useSwitchChain } from "@starknet-react/core";
 import { useAccount } from "~~/hooks/useAccount";
 import { useEffect, useMemo } from "react";
 import { constants } from "starknet";
+import { track } from "@vercel/analytics";
 
 type NetworkOptionsProps = {
   hidden?: boolean;
@@ -39,11 +40,16 @@ export const NetworkOptions = ({ hidden = false }: NetworkOptionsProps) => {
             <button
               className="menu-item btn-sm !rounded-xl flex gap-3 py-3 whitespace-nowrap"
               type="button"
-              onClick={() =>
+              onClick={() => {
+                const nextChainId = allowedNetworksMapping[allowedNetwork.network];
+                track("Network switched event", {
+                  network: allowedNetwork.name,
+                  chainId: nextChainId,
+                });
                 switchChain({
-                  chainId: allowedNetworksMapping[allowedNetwork.network],
-                })
-              }
+                  chainId: nextChainId,
+                });
+              }}
             >
               <ArrowsRightLeftIcon className="h-6 w-4 ml-2 sm:ml-0" />
               <span>


### PR DESCRIPTION
## Summary
- track landing page launch button clicks as a Vercel analytics event
- track network switching in both EVM and Starknet switchers including target network metadata

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6908d4a454848320bd3931d6070a534f