### PR TITLE
Track wallet address on connect

### DIFF
--- a/packages/nextjs/components/WalletAnalytics.tsx
+++ b/packages/nextjs/components/WalletAnalytics.tsx
@@ -5,8 +5,9 @@ import { useAccountEffect } from "wagmi";
 
 export function WalletAnalytics() {
   useAccountEffect({
-    onConnect({ chainId, connector, isReconnected }) {
+    onConnect({ address, chainId, connector, isReconnected }) {
       track("wallet_connected", {
+        address,
         chainId,
         connector: connector?.name ?? "unknown",
         isReconnected,


### PR DESCRIPTION
## Summary
- include the connected wallet address in the wallet_connected analytics event

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690c895e2170832086e229591e65299b