### PR TITLE
Rename Vesu V2 default pool to Prime

### DIFF
--- a/packages/nextjs/components/modals/stark/MovePositionModal.tsx
+++ b/packages/nextjs/components/modals/stark/MovePositionModal.tsx
@@ -105,7 +105,7 @@ export const MovePositionModal: FC<MovePositionModalProps> = ({
     () => protocols.find(p => p.name !== fromProtocol)?.name || "",
   );
   const [selectedPoolId, setSelectedPoolId] = useState<bigint>(VESU_V1_POOLS["Genesis"]);
-  const [selectedV2PoolAddress, setSelectedV2PoolAddress] = useState<string>(VESU_V2_POOLS["Default"]);
+  const [selectedV2PoolAddress, setSelectedV2PoolAddress] = useState<string>(VESU_V2_POOLS["Prime"]);
   const [amount, setAmount] = useState("");
   const [isAmountMaxClicked, setIsAmountMaxClicked] = useState(false);
   const amountRef = useRef("");
@@ -936,7 +936,7 @@ export const MovePositionModal: FC<MovePositionModalProps> = ({
       setSelectedV2PoolAddress(
         fromProtocol === "VesuV2" && normalizedCurrentV2PoolAddress
           ? normalizedCurrentV2PoolAddress
-          : VESU_V2_POOLS["Default"],
+          : VESU_V2_POOLS["Prime"],
       );
     }
   };

--- a/packages/nextjs/components/specific/vesu/VesuProtocolView.tsx
+++ b/packages/nextjs/components/specific/vesu/VesuProtocolView.tsx
@@ -40,7 +40,7 @@ export const VesuProtocolView: FC = () => {
   const { viewingAddress, status, isViewingOtherAddress } = useAccount();
   const userAddress = viewingAddress;
   const [selectedV1PoolId, setSelectedV1PoolId] = useState<bigint>(VESU_V1_POOLS["Genesis"]);
-  const [selectedV2PoolAddress, setSelectedV2PoolAddress] = useState<string>(VESU_V2_POOLS["Default"]);
+  const [selectedV2PoolAddress, setSelectedV2PoolAddress] = useState<string>(VESU_V2_POOLS["Prime"]);
   const normalizedPoolAddress = normalizeStarknetAddress(selectedV2PoolAddress);
 
   const v1Data = useVesuLendingPositions(userAddress, selectedV1PoolId);
@@ -116,7 +116,7 @@ export const VesuProtocolView: FC = () => {
 
   // Fetch positions for all V2 pools (for the positions list below)
   const v2All = {
-    Default: useVesuV2LendingPositions(userAddress, normalizeStarknetAddress(VESU_V2_POOLS.Default)),
+    Prime: useVesuV2LendingPositions(userAddress, normalizeStarknetAddress(VESU_V2_POOLS.Prime)),
     Re7xBTC: useVesuV2LendingPositions(userAddress, normalizeStarknetAddress(VESU_V2_POOLS.Re7xBTC)),
     Re7USDCCore: useVesuV2LendingPositions(userAddress, normalizeStarknetAddress(VESU_V2_POOLS.Re7USDCCore)),
     Re7USDCPrime: useVesuV2LendingPositions(userAddress, normalizeStarknetAddress(VESU_V2_POOLS.Re7USDCPrime)),
@@ -139,7 +139,7 @@ export const VesuProtocolView: FC = () => {
   ]);
   const { netBalanceUsd: netBalanceUsdV2, netYield30d: netYield30dV2, netApyPercent: netApyPercentV2 } = useMemo(() => {
     const allRows = [
-      ...v2All.Default.rows,
+      ...v2All.Prime.rows,
       ...v2All.Re7xBTC.rows,
       ...v2All.Re7USDCCore.rows,
       ...v2All.Re7USDCPrime.rows,
@@ -147,7 +147,7 @@ export const VesuProtocolView: FC = () => {
     ];
     return computeMetrics(allRows);
   }, [
-    v2All.Default.rows,
+    v2All.Prime.rows,
     v2All.Re7xBTC.rows,
     v2All.Re7USDCCore.rows,
     v2All.Re7USDCPrime.rows,
@@ -359,7 +359,7 @@ export const VesuProtocolView: FC = () => {
         {/* V2 Positions across all pools */}
         {(
           [
-            ["Default", v2All.Default] as const,
+            ["Prime", v2All.Prime] as const,
             ["Re7xBTC", v2All.Re7xBTC] as const,
             ["Re7USDCCore", v2All.Re7USDCCore] as const,
             ["Re7USDCPrime", v2All.Re7USDCPrime] as const,

--- a/packages/nextjs/components/specific/vesu/pools.ts
+++ b/packages/nextjs/components/specific/vesu/pools.ts
@@ -10,7 +10,7 @@ export const VESU_V1_POOLS = {
 export type VesuV1PoolName = keyof typeof VESU_V1_POOLS;
 
 export const VESU_V2_POOLS = {
-  Default: "0x0451fe483d5921a2919ddd81d0de6696669bccdacd859f72a4fba7656b97c3b5",
+  Prime: "0x0451fe483d5921a2919ddd81d0de6696669bccdacd859f72a4fba7656b97c3b5",
   Re7xBTC: "0x03a8416bf20d036df5b1cf3447630a2e1cb04685f6b0c3a70ed7fb1473548ecf",
   Re7USDCCore: "0x03976cac265a12609934089004df458ea29c776d77da423c96dc761d09d24124",
   Re7USDCPrime: "0x02eef0c13b10b487ea5916b54c0a7f98ec43fb3048f60fdeedaf5b08f6f88aaf",
@@ -39,7 +39,7 @@ const POOL_DISPLAY_NAMES_V1: Record<VesuV1PoolName, string> = {
 };
 
 const POOL_DISPLAY_NAMES_V2: Record<VesuV2PoolName, string> = {
-  Default: "Default",
+  Prime: "Prime",
   Re7xBTC: "Re7 xBTC",
   Re7USDCCore: "Re7 USDC Core",
   Re7USDCPrime: "Re7 USDC Prime",

--- a/packages/nextjs/hooks/useLendingAction.ts
+++ b/packages/nextjs/hooks/useLendingAction.ts
@@ -39,7 +39,7 @@ export const useLendingAction = (
 
   // For VesuV2, get the vault address and pool address from context
   const isVesuV2 = protocolName === "vesu_v2";
-  const poolAddress = vesuContext && 'poolAddress' in vesuContext ? vesuContext.poolAddress : "0x451fe483d5921a2919ddd81d0de6696669bccdacd859f72a4fba7656b97c3b5"; // V2 default pool
+  const poolAddress = vesuContext && 'poolAddress' in vesuContext ? vesuContext.poolAddress : "0x451fe483d5921a2919ddd81d0de6696669bccdacd859f72a4fba7656b97c3b5"; // V2 Prime pool
   
   // Check if this is a vToken position (from context metadata or counterpart is zero address)
   const isVTokenPositionCheck = (isVesuV2 && vesuContext && 'isVtoken' in vesuContext && vesuContext.isVtoken) ||


### PR DESCRIPTION
## Summary
- rename the Vesu V2 default pool constants to use the Prime name and display label
- update all Vesu V2 UI components and hooks to reference the Prime pool identifier

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690c8b648d4c83209d45b338de326e12