### PR TITLE
Ensure Compound collateral-only positions display zero debt

### DIFF
--- a/packages/nextjs/components/ProtocolView.tsx
+++ b/packages/nextjs/components/ProtocolView.tsx
@@ -182,7 +182,7 @@ export const ProtocolView: FC<ProtocolViewProps> = ({
   // - If showing all, show everything in the borrowedPositions array
   const filteredBorrowedPositions = (effectiveShowAll
     ? borrowedPositions
-    : borrowedPositions.filter(p => p.balance < 0)).map(p =>
+    : borrowedPositions.filter(p => p.balance < 0 || (p.collateralValue ?? 0) > 0)).map(p =>
     readOnly
       ? {
           ...p,


### PR DESCRIPTION
## Summary
- include Compound borrowed positions with positive collateral even when no debt is present so the zero balance is visible

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69164fd7c8708320a83b6b3bdbab6406)