### PR TITLE
markets+positions: pharos.watch stablecoin safety grade badges

### DIFF
--- a/packages/nextjs/.env.example
+++ b/packages/nextjs/.env.example
@@ -13,6 +13,10 @@ NEXT_PUBLIC_ALCHEMY_API_KEY=
 NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=
 NEXT_PUBLIC_ONE_INCH_API_KEY=
 
+# Pharos stablecoin safety grades (server-side only, used by app/api/pharos/grades).
+# Self-serve key from https://pharos.watch/api/ — 30 req/min, expires after 60 days (renew there).
+PHAROS_API_KEY=
+
 # Supabase / Database (server-side only)
 # Use the "Transaction" pooler connection string from Supabase Dashboard > Settings > Database
 # Format: postgresql://postgres.[project-ref]:[password]@aws-0-[region].pooler.supabase.com:6543/postgres

--- a/packages/nextjs/app/api/pharos/grades/route.ts
+++ b/packages/nextjs/app/api/pharos/grades/route.ts
@@ -1,0 +1,235 @@
+import { NextResponse } from "next/server";
+
+/**
+ * Pharos stablecoin safety grades proxy.
+ *
+ * Joins https://api.pharos.watch/api/report-cards (letter grades) with
+ * /api/stablecoins (per-chain contract deployments) into a slim lookup payload
+ * consumed by components/common/PharosGradeBadge.tsx via utils/pharos/gradesApi.ts.
+ *
+ * Requires PHAROS_API_KEY (server-side env, self-serve key from
+ * https://pharos.watch/api/ — 30 req/min, expires after 60 days). Pharos CORS
+ * only allows their own origin, so this must stay a server-side proxy and the
+ * key must never ship to the client.
+ *
+ * Rate-limit compliance: Pharos asks for >=300s polling on these endpoints and
+ * caps self-serve keys at 30 req/min. We batch — the two endpoints return ALL
+ * coins in one call each (no per-asset requests) — and cache the joined result
+ * in module memory for an hour, serving stale data on upstream failure. A
+ * single warm server instance therefore makes at most ~2 upstream calls/hour;
+ * the Cache-Control header below additionally lets the CDN absorb client
+ * traffic for an hour. Client-side, react-query holds one cache entry per
+ * browser session (see usePharosGrades).
+ */
+
+export const dynamic = "force-dynamic";
+
+const PHAROS_API = "https://api.pharos.watch";
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+// Chains Kapan renders markets/positions on, in Pharos chain-identifier form.
+const SUPPORTED_CHAINS = new Set(["ethereum", "arbitrum", "base", "optimism", "linea", "starknet"]);
+
+/**
+ * Tickers shared by several active Pharos coins where the chain filter below
+ * cannot disambiguate, resolved manually to the asset our protocols actually
+ * list. Each entry was verified by matching Pendle's underlyingAsset.address
+ * (api-v2.pendle.finance markets, chains 1/42161/8453/10/59144) against
+ * Pharos /api/stablecoins contracts — see scripts note in the PR. Re-verify
+ * when adding entries; a wrong grade is worse than none.
+ */
+const AMBIGUOUS_SYMBOL_OVERRIDES: Record<string, string> = {
+  USD3: "usd3-3jane", // Pendle PT-USD3 wraps 3Jane, not Reserve's Web3 Dollar
+  REUSD: "reusd-re-protocol", // Pendle reUSD = Re Protocol, not Resupply
+  NUSD: "nusd-neutrl", // Pendle nUSD = Neutrl
+  USDF: "usdf-falcon", // Falcon (Astherus USDF is BSC-only)
+};
+
+interface PharosReportCard {
+  id: string;
+  symbol: string;
+  overallGrade: string; // "A+".."F" | "NR"
+  overallScore: number | null;
+  isDefunct?: boolean;
+}
+
+interface PharosContractDeployment {
+  chain: string;
+  address: string;
+  decimals: number;
+}
+
+interface PharosStablecoin {
+  id: string;
+  contracts?: PharosContractDeployment[];
+}
+
+export interface PharosGradeEntry {
+  /** Canonical Pharos stablecoin ID — links to https://pharos.watch/stablecoin/{id}/ */
+  id: string;
+  /** Letter grade "A+" through "F" (NR coins are omitted) */
+  grade: string;
+  /** Weighted safety score 0-100 */
+  score: number | null;
+}
+
+export interface PharosGradesPayload {
+  /** Unix seconds of the upstream report-card snapshot, null when unavailable */
+  updatedAt: number | null;
+  /** Uppercase ticker -> grade entry (unambiguous or manually resolved tickers) */
+  grades: Record<string, PharosGradeEntry>;
+  /** Lowercase token contract address (on SUPPORTED_CHAINS) -> grade entry. Exact — prefer over `grades`. */
+  byAddress: Record<string, PharosGradeEntry>;
+}
+
+const EMPTY: PharosGradesPayload = { updatedAt: null, grades: {}, byAddress: {} };
+
+/**
+ * Canonical address key: lowercase, leading zeros stripped. Starknet felts are
+ * zero-padded differently across sources (Pharos publishes unpadded, our hooks
+ * pad to 64 hex chars). Keep in sync with the same helper in
+ * utils/pharos/gradesApi.ts (not imported to keep server/client bundles apart).
+ */
+const addressKey = (address: string) => `0x${address.toLowerCase().replace(/^0x0*/, "")}`;
+
+/** Thrown on 429 so the cache layer can honor Retry-After. */
+class PharosRateLimitError extends Error {
+  retryAfterMs: number;
+  constructor(path: string, retryAfterMs: number) {
+    super(`Pharos ${path} returned 429`);
+    this.retryAfterMs = retryAfterMs;
+  }
+}
+
+async function fetchPharos<T>(path: string, apiKey: string): Promise<T> {
+  const response = await fetch(`${PHAROS_API}${path}`, {
+    headers: { "X-API-Key": apiKey, Accept: "application/json" },
+    cache: "no-store", // report-cards is ~4MB (over Next's 2MB fetch-cache limit); we cache the joined result ourselves
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (response.status === 429) {
+    const retryAfter = Number(response.headers.get("Retry-After"));
+    throw new PharosRateLimitError(path, Number.isFinite(retryAfter) && retryAfter > 0 ? retryAfter * 1000 : 60_000);
+  }
+  if (!response.ok) {
+    throw new Error(`Pharos ${path} returned ${response.status}`);
+  }
+  return (await response.json()) as T;
+}
+
+/**
+ * Pick the single card a ticker should resolve to. Duplicate tickers use the
+ * manual override first, then keep the coin actually deployed on our chains;
+ * still-ambiguous ones resolve to nothing — address lookup remains available.
+ */
+function resolveTickerCard(
+  symbol: string,
+  cards: PharosReportCard[],
+  onSupportedChains: Set<string>,
+): PharosReportCard | null {
+  if (cards.length === 1) return cards[0];
+  const overrideId = AMBIGUOUS_SYMBOL_OVERRIDES[symbol];
+  if (overrideId) return cards.find(c => c.id === overrideId) ?? null;
+  const local = cards.filter(c => onSupportedChains.has(c.id));
+  return local.length === 1 ? local[0] : null;
+}
+
+async function buildPayload(apiKey: string): Promise<PharosGradesPayload> {
+  const [reportCards, stablecoins] = await Promise.all([
+    fetchPharos<{ cards: PharosReportCard[]; updatedAt: number }>("/api/report-cards", apiKey),
+    fetchPharos<{ peggedAssets: PharosStablecoin[] }>("/api/stablecoins", apiKey),
+  ]);
+
+  const contractsById = new Map<string, PharosContractDeployment[]>();
+  const onSupportedChains = new Set<string>();
+  for (const coin of stablecoins.peggedAssets ?? []) {
+    const local = (coin.contracts ?? []).filter(c => SUPPORTED_CHAINS.has(c.chain));
+    if (local.length > 0) {
+      contractsById.set(coin.id, local);
+      onSupportedChains.add(coin.id);
+    }
+  }
+
+  const cardsBySymbol = new Map<string, PharosReportCard[]>();
+  const entryById = new Map<string, PharosGradeEntry>();
+  for (const card of reportCards.cards ?? []) {
+    if (card.isDefunct || !card.overallGrade || card.overallGrade === "NR") continue;
+    const symbol = card.symbol?.toUpperCase();
+    if (!symbol) continue;
+    const list = cardsBySymbol.get(symbol) ?? [];
+    list.push(card);
+    cardsBySymbol.set(symbol, list);
+    entryById.set(card.id, { id: card.id, grade: card.overallGrade, score: card.overallScore });
+  }
+
+  const grades: Record<string, PharosGradeEntry> = {};
+  for (const [symbol, cards] of cardsBySymbol) {
+    const card = resolveTickerCard(symbol, cards, onSupportedChains);
+    if (!card) continue;
+    grades[symbol] = entryById.get(card.id)!;
+  }
+
+  const byAddress: Record<string, PharosGradeEntry> = {};
+  for (const [id, contracts] of contractsById) {
+    const entry = entryById.get(id);
+    if (!entry) continue;
+    for (const contract of contracts) {
+      byAddress[addressKey(contract.address)] = entry;
+    }
+  }
+
+  return { updatedAt: reportCards.updatedAt ?? null, grades, byAddress };
+}
+
+// Module-level cache: one upstream refresh per TTL per server instance, with
+// single-flight de-dup, stale-serve on upstream failure, and a backoff window
+// after failures (Retry-After-derived on 429) so a burst of requests during a
+// Pharos incident can't hammer their API.
+let cached: { payload: PharosGradesPayload; fetchedAt: number } | null = null;
+let inflight: Promise<PharosGradesPayload> | null = null;
+let backoffUntil = 0;
+
+async function getPayload(apiKey: string): Promise<PharosGradesPayload> {
+  if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
+    return cached.payload;
+  }
+  if (Date.now() < backoffUntil) {
+    if (cached) return cached.payload;
+    throw new Error("Pharos upstream in backoff window");
+  }
+  if (!inflight) {
+    inflight = buildPayload(apiKey)
+      .then(payload => {
+        cached = { payload, fetchedAt: Date.now() };
+        return payload;
+      })
+      .finally(() => {
+        inflight = null;
+      });
+  }
+  try {
+    return await inflight;
+  } catch (error) {
+    backoffUntil = Date.now() + (error instanceof PharosRateLimitError ? error.retryAfterMs : 60_000);
+    console.error("[pharos/grades] upstream refresh failed:", error);
+    if (cached) return cached.payload; // serve stale rather than blanking badges
+    throw error;
+  }
+}
+
+export async function GET() {
+  const apiKey = process.env.PHAROS_API_KEY;
+  if (!apiKey) {
+    console.warn("[pharos/grades] PHAROS_API_KEY not set — serving empty grade map");
+    return NextResponse.json(EMPTY);
+  }
+
+  try {
+    const payload = await getPayload(apiKey);
+    return NextResponse.json(payload, {
+      headers: { "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400" },
+    });
+  } catch {
+    return NextResponse.json(EMPTY);
+  }
+}

--- a/packages/nextjs/components/common/BasePosition.tsx
+++ b/packages/nextjs/components/common/BasePosition.tsx
@@ -12,6 +12,7 @@ import { useWalletConnection } from "~~/hooks/useWalletConnection";
 import formatPercentage from "~~/utils/formatPercentage";
 import { formatCurrencyCompact } from "~~/utils/formatNumber";
 import { isPTToken } from "~~/hooks/usePendlePTYields";
+import { PharosGradeBadge } from "./PharosGradeBadge";
 import { TokenSymbolDisplay } from "./TokenSymbolDisplay";
 
 // Static handler for stopPropagation - extracted to module level to avoid recreation
@@ -199,6 +200,8 @@ function formatPriceForSubtitle(priceUsd: number): string | null {
 /** Token name display - handles renderName, PT tokens, and fallback. Shared by mobile/desktop. */
 const TokenNameContent: FC<{
   name: string;
+  /** Contract address — lets the Pharos grade badge match exactly (duplicate tickers) */
+  tokenAddress?: string;
   renderName?: (name: string) => ReactNode;
   subtitle?: ReactNode;
   /** USD price (already converted from raw 1e8). When set and no `subtitle` is provided,
@@ -206,14 +209,24 @@ const TokenNameContent: FC<{
    *  row. PT tokens skip this — their second row is the maturity date. */
   priceUsd?: number;
   variant: "mobile" | "desktop";
-}> = ({ name, renderName: renderNameFn, subtitle, priceUsd, variant }) => {
+}> = ({ name, tokenAddress, renderName: renderNameFn, subtitle, priceUsd, variant }) => {
   if (renderNameFn) {
     return variant === "desktop" ? <>{renderNameFn(name)}</> : <>{renderNameFn(name)}</>;
   }
   if (isPTToken(name)) {
-    return variant === "desktop"
-      ? <TokenSymbolDisplay symbol={name} size="sm" variant="stacked" />
-      : <TokenSymbolDisplay symbol={name} size="xs" />;
+    // Desktop uses the stacked (two-line) PT display — pin the badge to the
+    // symbol line instead of centering it across both lines.
+    return variant === "desktop" ? (
+      <span className="inline-flex items-start gap-1.5">
+        <TokenSymbolDisplay symbol={name} size="sm" variant="stacked" />
+        <PharosGradeBadge symbol={name} className="mt-[3px]" />
+      </span>
+    ) : (
+      <span className="inline-flex items-center gap-1.5">
+        <TokenSymbolDisplay symbol={name} size="xs" />
+        <PharosGradeBadge symbol={name} />
+      </span>
+    );
   }
   // Price subtitle takes priority over an explicit subtitle prop only when one isn't passed.
   // Callers that already pass a subtitle (rare today) still win — we don't clobber them.
@@ -221,7 +234,10 @@ const TokenNameContent: FC<{
   if (variant === "desktop") {
     return (
       <>
-        <span className="truncate text-base font-bold leading-tight tracking-tight" title={name}>{name}</span>
+        <span className="flex min-w-0 items-center gap-1.5">
+          <span className="truncate text-base font-bold leading-tight tracking-tight" title={name}>{name}</span>
+          <PharosGradeBadge symbol={name} address={tokenAddress} />
+        </span>
         {subtitle ? (
           <span className="text-base-content/70 truncate text-[10px] uppercase leading-tight tracking-wider">{subtitle}</span>
         ) : priceLabel ? (
@@ -233,10 +249,18 @@ const TokenNameContent: FC<{
   // Mobile: stacked name + tiny price. Skip when no price (preserves the existing behavior).
   return priceLabel ? (
     <span className="flex flex-col leading-tight">
-      <span className="truncate">{name}</span>
+      <span className="flex min-w-0 items-center gap-1">
+        <span className="truncate">{name}</span>
+        <PharosGradeBadge symbol={name} address={tokenAddress} />
+      </span>
       <span className="text-base-content/50 font-mono text-[9px] tabular-nums">{priceLabel}</span>
     </span>
-  ) : <>{name}</>;
+  ) : (
+    <span className="inline-flex items-center gap-1">
+      {name}
+      <PharosGradeBadge symbol={name} address={tokenAddress} />
+    </span>
+  );
 };
 
 
@@ -492,7 +516,7 @@ export const BasePosition: FC<BasePositionProps> = ({
               <Image src={icon} alt={`${name} icon`} fill className="rounded object-contain" />
             </div>
             <span className="max-w-[100px] truncate text-sm font-bold leading-none tracking-tight" title={name}>
-              <TokenNameContent name={name} renderName={renderName} priceUsd={tokenPriceUsd} variant="mobile" />
+              <TokenNameContent name={name} tokenAddress={tokenAddress} renderName={renderName} priceUsd={tokenPriceUsd} variant="mobile" />
             </span>
             {infoButtonNode && (
               <div className="hidden flex-shrink-0 sm:block" onClick={stopPropagation}>
@@ -556,7 +580,7 @@ export const BasePosition: FC<BasePositionProps> = ({
             </div>
             <div className="ml-3 flex min-w-0 items-center gap-1.5">
               <div className="flex min-w-0 flex-col">
-                <TokenNameContent name={name} renderName={renderName} subtitle={subtitle} priceUsd={tokenPriceUsd} variant="desktop" />
+                <TokenNameContent name={name} tokenAddress={tokenAddress} renderName={renderName} subtitle={subtitle} priceUsd={tokenPriceUsd} variant="desktop" />
               </div>
             </div>
             {infoButtonNode && (

--- a/packages/nextjs/components/common/PharosGradeBadge.tsx
+++ b/packages/nextjs/components/common/PharosGradeBadge.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import * as React from "react";
+import { Tooltip } from "@radix-ui/themes";
+import { resolvePharosGrade, pharosStablecoinUrl, usePharosGrades } from "~~/utils/pharos/gradesApi";
+
+/**
+ * Colored stablecoin safety grade sourced from pharos.watch, rendered as a
+ * small clickable pill next to token names in markets/positions rows. Renders
+ * nothing for tokens Pharos doesn't grade (non-stables, unknown long-tail).
+ *
+ * PT tokens show the grade of their underlying stablecoin — see
+ * utils/pharos/gradesApi.ts.
+ */
+
+const SIZE_CLASSES = {
+  xs: "text-[9px] px-1 py-0.5",
+  sm: "text-[10px] px-1.5 py-0.5",
+};
+
+// Bands follow the existing badge language: PositionHealthBadge greens/reds,
+// PTBadge's info blue. A=solid, B=stable-but-watch, C=caution, D/F=risk.
+function gradeColorClasses(grade: string): string {
+  switch (grade[0]) {
+    case "A":
+      return "bg-success/15 text-success";
+    case "B":
+      return "bg-info/15 text-info";
+    case "C":
+      return "bg-warning/15 text-warning";
+    default:
+      return "bg-error/15 text-error"; // D, F
+  }
+}
+
+interface PharosGradeBadgeProps {
+  /** Token symbol as displayed in the row (PT symbols resolve to their underlying) */
+  symbol: string;
+  /** Token contract address when the caller has it — exact match for duplicate tickers */
+  address?: string;
+  size?: keyof typeof SIZE_CLASSES;
+  className?: string;
+}
+
+export function PharosGradeBadge({ symbol, address, size = "xs", className = "" }: PharosGradeBadgeProps) {
+  const { data } = usePharosGrades();
+  const resolved = React.useMemo(() => resolvePharosGrade(data, symbol, address), [data, symbol, address]);
+
+  if (!resolved) return null;
+
+  const scoreLabel = resolved.score != null ? ` · ${resolved.score}/100` : "";
+  const tooltip = (
+    <span className="block space-y-1">
+      <span className="block font-medium">
+        Pharos safety grade: {resolved.grade}
+        {scoreLabel}
+      </span>
+      {resolved.viaPtUnderlying && (
+        <span className="text-base-content/70 block text-xs">Based on underlying {resolved.resolvedSymbol}</span>
+      )}
+      <span className="text-base-content/70 block text-xs">View report on pharos.watch</span>
+    </span>
+  );
+
+  return (
+    <Tooltip content={tooltip} className="pharos-tooltip">
+      <a
+        href={pharosStablecoinUrl(resolved.id)}
+        target="_blank"
+        // noopener only — we deliberately keep the Referer so Pharos can
+        // attribute traffic from kapan.finance (plus the UTM params on the URL).
+        rel="noopener"
+        // Badges live inside clickable rows/summaries — don't toggle/select the row.
+        onClick={e => e.stopPropagation()}
+        aria-label={`Pharos safety grade ${resolved.grade} for ${resolved.resolvedSymbol} — view on pharos.watch`}
+        className={`${gradeColorClasses(resolved.grade)} ${SIZE_CLASSES[size]} inline-flex shrink-0 items-center rounded font-semibold leading-none transition-opacity hover:opacity-75 ${className}`}
+      >
+        {resolved.grade}
+      </a>
+    </Tooltip>
+  );
+}

--- a/packages/nextjs/components/markets/MarketCard.tsx
+++ b/packages/nextjs/components/markets/MarketCard.tsx
@@ -4,6 +4,7 @@ import { DepositModalStark } from "~~/components/modals/stark/DepositModalStark"
 import { InterestPillRow } from "./InterestPillRow";
 import { MarketProps } from "./types";
 import { useMarketDeposit } from "./useMarketDeposit";
+import { PharosGradeBadge } from "~~/components/common/PharosGradeBadge";
 import { TokenSymbolDisplay } from "~~/components/common/TokenSymbolDisplay";
 import { isPTToken } from "~~/hooks/usePendlePTYields";
 
@@ -35,11 +36,14 @@ export const MarketCard: FC<MarketProps> = ({
           <div className="flex items-center gap-3">
             <Image src={icon} alt={name} width={32} height={32} className="rounded-full" />
             <div className="flex flex-1 flex-col">
-              {isPTToken(name) ? (
-                <TokenSymbolDisplay symbol={name} size="base" variant="inline" />
-              ) : (
-                <h3 className="text-lg font-semibold">{name}</h3>
-              )}
+              <div className="flex items-center gap-1.5">
+                {isPTToken(name) ? (
+                  <TokenSymbolDisplay symbol={name} size="base" variant="inline" />
+                ) : (
+                  <h3 className="text-lg font-semibold">{name}</h3>
+                )}
+                <PharosGradeBadge symbol={name} address={address} size="sm" />
+              </div>
               <span className="text-base-content/70 text-sm">${price}</span>
             </div>
             {showDepositButton && (

--- a/packages/nextjs/components/markets/MarketRow.tsx
+++ b/packages/nextjs/components/markets/MarketRow.tsx
@@ -4,6 +4,7 @@ import { DepositModalStark } from "~~/components/modals/stark/DepositModalStark"
 import { InterestPillRow } from "./InterestPillRow";
 import { MarketProps } from "./types";
 import { useMarketDeposit } from "./useMarketDeposit";
+import { PharosGradeBadge } from "~~/components/common/PharosGradeBadge";
 import { TokenSymbolDisplay } from "~~/components/common/TokenSymbolDisplay";
 import { isPTToken } from "~~/hooks/usePendlePTYields";
 
@@ -36,6 +37,7 @@ export const MarketRow: FC<MarketProps> = ({
           <div className="flex w-1/5 items-center gap-3">
             <Image src={icon} alt={name} width={24} height={24} className="rounded-full" />
             {isPTToken(name) ? <TokenSymbolDisplay symbol={name} size="sm" variant="inline" /> : <span className="font-medium">{name}</span>}
+            <PharosGradeBadge symbol={name} address={address} />
           </div>
           <div className="flex flex-1 items-center">
             <div className="flex w-1/5 flex-col items-center">
@@ -70,6 +72,7 @@ export const MarketRow: FC<MarketProps> = ({
             <div className="flex items-center gap-2">
               <Image src={icon} alt={name} width={24} height={24} className="rounded-full" />
               {isPTToken(name) ? <TokenSymbolDisplay symbol={name} size="sm" variant="inline" /> : <span className="font-medium">{name}</span>}
+            <PharosGradeBadge symbol={name} address={address} />
             </div>
             {showDepositButton && (
               <button className="btn btn-sm btn-primary" onClick={openModal}>
@@ -104,6 +107,7 @@ export const MarketRow: FC<MarketProps> = ({
             <div className="flex items-center gap-2">
               <Image src={icon} alt={name} width={24} height={24} className="rounded-full" />
               {isPTToken(name) ? <TokenSymbolDisplay symbol={name} size="sm" variant="inline" /> : <span className="font-medium">{name}</span>}
+            <PharosGradeBadge symbol={name} address={address} />
             </div>
             {showDepositButton && (
               <button className="btn btn-xs btn-primary" onClick={openModal}>

--- a/packages/nextjs/components/markets/MarketsGrouped.tsx
+++ b/packages/nextjs/components/markets/MarketsGrouped.tsx
@@ -27,6 +27,7 @@ import formatPercentage from "~~/utils/formatPercentage";
 import { useExternalYields } from "~~/hooks/useExternalYields";
 import { aaveRateToAPY, venusRateToAPY, CHAIN_ID_TO_NETWORK } from "~~/utils/protocolRates";
 import { canonicalizeTokenName } from "~~/utils/tokenSymbols";
+import { PharosGradeBadge } from "~~/components/common/PharosGradeBadge";
 import { TokenSymbolDisplay } from "~~/components/common/TokenSymbolDisplay";
 import { isPTToken } from "~~/hooks/usePendlePTYields";
 import { type TokenCategory, matchesCategory } from "~~/utils/tokenCategories";
@@ -988,6 +989,7 @@ export const MarketsGrouped: FC<{ search: string; network?: string; category?: T
                   ) : (
                     <span className="text-base font-semibold tracking-tight">{group.name}</span>
                   )}
+                  <PharosGradeBadge symbol={group.name} size="sm" />
                 </div>
 
                 {/* Rates */}

--- a/packages/nextjs/components/specific/common/CrossTopologyMarketsSection.tsx
+++ b/packages/nextjs/components/specific/common/CrossTopologyMarketsSection.tsx
@@ -18,6 +18,7 @@ import {
 } from "@tanstack/react-table";
 import { ChevronDown, ChevronUp } from "lucide-react";
 import { TokenIcon } from "~~/components/common/TokenDisplay";
+import { PharosGradeBadge } from "~~/components/common/PharosGradeBadge";
 import { TokenSymbolDisplay } from "~~/components/common/TokenSymbolDisplay";
 import { isPTToken } from "~~/hooks/usePendlePTYields";
 import { formatPercent } from "../utils";
@@ -83,6 +84,7 @@ const baseColumns = [
           ) : (
             <span className="font-medium">{symbol}</span>
           )}
+          <PharosGradeBadge symbol={symbol} address={info.row.original.tokenAddress} />
         </div>
       );
     },
@@ -316,11 +318,14 @@ export const CrossTopologyMarketsSection: FC<CrossTopologyMarketsSectionProps> =
             <div className="flex items-center gap-2">
               <TokenIcon symbol={row.symbol} customSize={24} />
               <div className="min-w-0 flex-1">
-                {isPTToken(row.symbol) ? (
-                  <TokenSymbolDisplay symbol={row.symbol} size="sm" variant="inline" />
-                ) : (
-                  <span className="font-medium">{row.symbol}</span>
-                )}
+                <span className="flex items-center gap-1.5">
+                  {isPTToken(row.symbol) ? (
+                    <TokenSymbolDisplay symbol={row.symbol} size="sm" variant="inline" />
+                  ) : (
+                    <span className="font-medium">{row.symbol}</span>
+                  )}
+                  <PharosGradeBadge symbol={row.symbol} address={row.tokenAddress} />
+                </span>
               </div>
               <div className="flex items-center gap-3 text-[11px]">
                 <span className={`font-mono tabular-nums ${row.supplyApy > 0 ? "text-success" : "text-base-content/60"}`}>

--- a/packages/nextjs/components/specific/euler/EulerMarketsSection.tsx
+++ b/packages/nextjs/components/specific/euler/EulerMarketsSection.tsx
@@ -33,6 +33,7 @@ import {
 import type { EulerVault, EulerCollateralInfo } from "~~/hooks/useEulerLendingPositions";
 import { tokenNameToLogo } from "~~/contracts/externalContracts";
 import { usePendlePTYields, isPTToken } from "~~/hooks/usePendlePTYields";
+import { PharosGradeBadge } from "~~/components/common/PharosGradeBadge";
 import { TokenSymbolDisplay } from "~~/components/common/TokenSymbolDisplay";
 import { useModal } from "~~/hooks/useModal";
 import { DepositModal } from "~~/components/modals/DepositModal";
@@ -529,6 +530,7 @@ function MobileVaultRow({ row, usd, chainId, onSupply, onBorrow }: MobileVaultRo
             >
               <TokenSymbolDisplay symbol={row.assetSymbol} size="sm" variant="inline" />
             </a>
+            <PharosGradeBadge symbol={row.assetSymbol} address={row.assetAddress} />
             <a
               href={eulerUrl}
               target="_blank"
@@ -709,15 +711,18 @@ export const EulerMarketsSection: FC<EulerMarketsSectionProps> = ({
           <div className="flex items-center gap-2">
             <TokenIcon symbol={row.assetSymbol} size={24} />
             <div className="flex flex-col">
-              <a
-                href={eulerUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="hover:text-primary group/link flex items-center gap-1 transition-colors"
-              >
-                <TokenSymbolDisplay symbol={row.assetSymbol} size="sm" variant="inline" />
-                <ExternalLink className="size-3 opacity-0 transition-opacity group-hover/link:opacity-60" />
-              </a>
+              <span className="flex items-center gap-1">
+                <a
+                  href={eulerUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="hover:text-primary group/link flex items-center gap-1 transition-colors"
+                >
+                  <TokenSymbolDisplay symbol={row.assetSymbol} size="sm" variant="inline" />
+                  <ExternalLink className="size-3 opacity-0 transition-opacity group-hover/link:opacity-60" />
+                </a>
+                <PharosGradeBadge symbol={row.assetSymbol} address={row.assetAddress} />
+              </span>
               <span className="text-base-content/50 max-w-[180px] truncate text-[10px]" title={row.vault.name}>
                 {row.vault.symbol}
               </span>

--- a/packages/nextjs/components/specific/morpho/MorphoMarketsSection.tsx
+++ b/packages/nextjs/components/specific/morpho/MorphoMarketsSection.tsx
@@ -42,6 +42,7 @@ import { useAccount } from "wagmi";
 import { notification } from "~~/utils/scaffold-eth/notification";
 import { parseUnits } from "viem";
 import { useExternalYields, hasExternalYield } from "~~/hooks/useExternalYields";
+import { PharosGradeBadge } from "~~/components/common/PharosGradeBadge";
 import { TokenSymbolDisplay } from "~~/components/common/TokenSymbolDisplay";
 import { createTextChangeHandler } from "~~/utils/handlers";
 import {
@@ -116,6 +117,7 @@ interface MarketRow {
   impliedApy: number | null; // PT implied yield for collateral (as percentage, e.g., 15.5)
   maxLoopApy: number | null; // Max leveraged APY at ~99% of LLTV (as percentage)
   collateralAddress: string;
+  loanAddress: string;
 }
 
 const columnHelper = createColumnHelper<MarketRow>();
@@ -570,8 +572,10 @@ function MobileMarketRow({ row, usd, chainId, onSupply, onLoop }: MobileMarketRo
         <div className="min-w-0 flex-1 overflow-hidden">
           <div className="flex min-w-0 items-center gap-1">
             <TokenSymbolDisplay symbol={row.collateralSymbol} size="xs" variant="inline" />
+            <PharosGradeBadge symbol={row.collateralSymbol} address={row.market.collateralAsset?.address} />
             <span className="text-base-content/50 text-xs">/</span>
             <span className="text-xs font-medium">{row.loanSymbol}</span>
+            <PharosGradeBadge symbol={row.loanSymbol} address={row.market.loanAsset?.address} />
             {morphoUrl && (
               <a
                 href={morphoUrl}
@@ -726,6 +730,7 @@ export const MorphoMarketsSection: FC<MorphoMarketsSectionProps> = ({
           collateralSymbol,
           loanSymbol: m.loanAsset?.symbol ?? "",
           collateralAddress,
+          loanAddress: (m.loanAsset?.address ?? "").toLowerCase(),
           liquidityUsd,
           supplyUsd,
           borrowUsd,
@@ -770,25 +775,25 @@ export const MorphoMarketsSection: FC<MorphoMarketsSectionProps> = ({
           <div className="flex items-center gap-2">
             <TokenPairAvatars collateralSymbol={row.collateralSymbol} loanSymbol={row.loanSymbol} />
             <div className="flex flex-col">
-              {morphoUrl ? (
-                <a
-                  href={morphoUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="hover:text-primary group/link flex items-center gap-1 transition-colors"
-                >
-                  <TokenSymbolDisplay symbol={row.collateralSymbol} size="sm" variant="inline" />
-                  <span className="text-base-content/50">/</span>
-                  <span className="font-medium">{row.loanSymbol}</span>
-                  <ExternalLink className="size-3 opacity-0 transition-opacity group-hover/link:opacity-60" />
-                </a>
-              ) : (
-                <span className="flex items-center gap-1">
-                  <TokenSymbolDisplay symbol={row.collateralSymbol} size="sm" variant="inline" />
-                  <span className="text-base-content/50">/</span>
-                  <span className="font-medium">{row.loanSymbol}</span>
-                </span>
-              )}
+              {/* Grade badges are anchors themselves, so the Morpho link is icon-only here
+                  (same idiom as the compact row) instead of wrapping the pair text. */}
+              <span className="flex items-center gap-1">
+                <TokenSymbolDisplay symbol={row.collateralSymbol} size="sm" variant="inline" />
+                <PharosGradeBadge symbol={row.collateralSymbol} address={row.collateralAddress} />
+                <span className="text-base-content/50">/</span>
+                <span className="font-medium">{row.loanSymbol}</span>
+                <PharosGradeBadge symbol={row.loanSymbol} address={row.loanAddress} />
+                {morphoUrl && (
+                  <a
+                    href={morphoUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="opacity-40 transition-opacity hover:opacity-80"
+                  >
+                    <ExternalLink className="size-3" />
+                  </a>
+                )}
+              </span>
               <span className="text-base-content/50 text-[10px]">LLTV {formatPercent(row.lltv01, 0)}</span>
             </div>
           </div>

--- a/packages/nextjs/lib/queryKeys.ts
+++ b/packages/nextjs/lib/queryKeys.ts
@@ -51,6 +51,11 @@ export const qk = {
     debtSwapMarkets: (chainId: number) => ["morpho", chainId, "debt-swap-markets"] as const,
   },
 
+  // Pharos stablecoin safety grades (chain-agnostic, one global map)
+  pharos: {
+    grades: () => ["pharos", "grades"] as const,
+  },
+
   // Bridges
   bridges: {
     history: (wallet?: string) => ["bridges", "history", wallet?.toLowerCase() ?? ""] as const,

--- a/packages/nextjs/styles/globals.css
+++ b/packages/nextjs/styles/globals.css
@@ -335,3 +335,14 @@ img[src$="/logos/ethereum.svg"] {
 .landing-canvas-wrapper * {
   pointer-events: none !important;
 }
+
+/* Pharos grade badge tooltip (components/common/PharosGradeBadge.tsx).
+   Radix Themes tooltips use an inverted (light-on-dark-theme) bubble by
+   default, which clashes with our dark UI — repaint content + arrow with
+   surface tokens. */
+.pharos-tooltip.rt-TooltipContent {
+  @apply bg-base-200 text-base-content border border-base-content/10 shadow-lg shadow-black/40;
+}
+.pharos-tooltip .rt-TooltipArrow {
+  fill: theme("colors.base-200");
+}

--- a/packages/nextjs/utils/pharos/gradesApi.ts
+++ b/packages/nextjs/utils/pharos/gradesApi.ts
@@ -1,0 +1,106 @@
+/**
+ * Pharos stablecoin safety grades — client fetch + symbol resolution.
+ *
+ * Data flows from app/api/pharos/grades/route.ts (server-side proxy that holds
+ * the PHAROS_API_KEY) into a single react-query cache entry shared by every
+ * PharosGradeBadge on the page. PT (Pendle) tokens resolve to their underlying
+ * stablecoin's grade — a PT carries the credit risk of what it redeems into.
+ */
+import { useQuery } from "@tanstack/react-query";
+import type { PharosGradeEntry, PharosGradesPayload } from "~~/app/api/pharos/grades/route";
+import { parsePTToken } from "~~/hooks/usePendlePTYields";
+import { qk } from "~~/lib/queryKeys";
+
+export type { PharosGradeEntry, PharosGradesPayload };
+
+/**
+ * Where a grade badge links out to — the coin's Pharos report page.
+ * UTM-tagged (and the badge link keeps its Referer) so Pharos can attribute
+ * the traffic we send them.
+ */
+export const pharosStablecoinUrl = (id: string) =>
+  `https://pharos.watch/stablecoin/${id}/?utm_source=kapan.finance&utm_medium=grade-badge`;
+
+/**
+ * Wrapped/bridged variants that inherit the canonical coin's grade.
+ * Deliberately short — only aliases where the peg/issuer risk is identical.
+ */
+const SYMBOL_ALIASES: Record<string, string> = {
+  "USDC.E": "USDC", // bridged USDC
+  USDT0: "USDT", // LayerZero OFT USDT
+  "USD₮0": "USDT",
+  "USD₮": "USDT",
+};
+
+/**
+ * Canonical address key: lowercase, leading zeros stripped (Starknet felts are
+ * zero-padded differently across sources). Mirror of the helper in
+ * app/api/pharos/grades/route.ts — keep in sync.
+ */
+const addressKey = (address: string) => `0x${address.toLowerCase().replace(/^0x0*/, "")}`;
+
+export interface ResolvedPharosGrade extends PharosGradeEntry {
+  /** The symbol the grade was found under (for PT tokens: the underlying) */
+  resolvedSymbol: string;
+  /** True when this came from a PT token's underlying asset */
+  viaPtUnderlying: boolean;
+}
+
+/**
+ * Resolve a display symbol (as rendered in markets/positions rows) to a Pharos
+ * grade entry. The token's contract address, when the caller has one, is the
+ * exact match (disambiguates duplicate tickers like reUSD/USD3); otherwise we
+ * fall back to the symbol map, handling PT tokens ("PT-sUSDE-25SEP2025" ->
+ * "SUSDE") and the alias map above. Returns null for anything Pharos doesn't
+ * grade — callers render nothing in that case.
+ */
+export function resolvePharosGrade(
+  data: PharosGradesPayload | undefined,
+  symbol: string,
+  address?: string,
+): ResolvedPharosGrade | null {
+  if (!data || !symbol) return null;
+
+  const parsed = parsePTToken(symbol);
+  const viaPtUnderlying = parsed.isPT;
+  const base = parsed.isPT ? parsed.baseToken : symbol;
+
+  const upper = base.replace("₮", "T").trim().toUpperCase();
+  const resolvedSymbol = SYMBOL_ALIASES[upper] ?? upper;
+
+  // PT addresses are the PT contract itself (not tracked by Pharos), so the
+  // address path only applies to regular tokens.
+  if (!parsed.isPT && address) {
+    const byAddress = data.byAddress?.[addressKey(address)];
+    if (byAddress) return { ...byAddress, resolvedSymbol, viaPtUnderlying: false };
+  }
+
+  const entry = data.grades[resolvedSymbol];
+  return entry ? { ...entry, resolvedSymbol, viaPtUnderlying } : null;
+}
+
+async function fetchPharosGrades(): Promise<PharosGradesPayload> {
+  const response = await fetch("/api/pharos/grades");
+  if (!response.ok) {
+    console.error(`[pharos/gradesApi] grades API error: ${response.status}`);
+    return { updatedAt: null, grades: {}, byAddress: {} };
+  }
+  return response.json();
+}
+
+/** One hour — the server route itself only refreshes upstream hourly. */
+const GRADES_STALE_TIME = 60 * 60 * 1000;
+
+/**
+ * Global Pharos grade map. Mounted by every badge; react-query dedupes to a
+ * single request per page load.
+ */
+export function usePharosGrades() {
+  return useQuery({
+    queryKey: qk.pharos.grades(),
+    queryFn: fetchPharosGrades,
+    staleTime: GRADES_STALE_TIME,
+    gcTime: GRADES_STALE_TIME,
+    refetchOnWindowFocus: false,
+  });
+}


### PR DESCRIPTION
Clickable colored grade pills (A+..F) next to stablecoins across markets and positions, linking to the coin's Pharos report card. PT tokens show their underlying's grade (a PT carries the credit risk of what it redeems into).

Matching is address-first: /api/pharos/grades joins report-cards with per-chain contract deployments into a byAddress map (Starknet felt zero-padding normalized), and rows that know their token address pass it in. Symbol-only spots (PT underlyings, aggregated markets headline) fall back to a ticker map where duplicate tickers (USD3, reUSD, nUSD, USDF each name 2+ distinct Pharos coins) are resolved via overrides, each verified by matching Pendle underlyingAsset.address to Pharos contracts. Unverifiable ambiguity renders no badge - a wrong grade is worse than none.

Rate-limit compliance (self-serve key: 30 req/min, >=300s polling guidance): grades for all coins come from 2 batched calls, cached in-module for 1h with single-flight dedup, CDN-cached via s-maxage=3600
+ SWR, one react-query entry per browser session. 429s honor Retry-After with a backoff window; failures serve stale data or an empty map so badges degrade silently. Requires PHAROS_API_KEY (server-side only; Pharos CORS blocks browser use by design). Badge links keep Referer + UTM params so Pharos can attribute our traffic.